### PR TITLE
Implement fine-grained access control with visibility filters [A4]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 | A2 | **Fix graph visualization consistency** | The 3D graph rendered on screen (react-force-graph-3d) does not match the actual GraphRAG structure in Neo4j. Audit the mapping between Neo4j nodes/relationships and the frontend graph data. Ensure all node types, edges (HAS_EDUCATION, USED_SKILL, etc.), and hierarchies are accurately represented in the visualization. | High |
 | A3 | **Graph-level similarity for HR queries** | Individual nodes have vector embeddings, but there's no way to compute similarity between an HR query and the *entire* graph. Research approaches: (1) aggregate node embeddings into a single graph-level embedding (mean/weighted pooling), (2) subgraph matching with ranked node hits, (3) GNN-based graph embeddings, (4) query decomposition — break HR query into sub-queries, match each to relevant nodes, aggregate scores. This is critical for the recruiter tier. | High |
 | A4 | **Implement fine-grained access control** | Allow users to control visibility per node, per field, per consumer. Example: "show everything to Lovable, hide my address from HR agents, hide salary from public view." Design a permission token system: each token specifies allowed node types, fields, and operations. Enforce at the API/MCP layer before data leaves the backend. | High |
+| A5 | **Introduce similarity distance evaluation metrics** | Currently there is no formal way to assess how well the embedding-based similarity performs. Introduce metrics such as Inner Product Error (IPE), cosine distance distribution, and rank correlation against human-labelled relevance judgments. Build a benchmark dataset of query–graph pairs with known relevance scores, compute metrics across different aggregation strategies (mean pooling, weighted pooling, GNN), and report precision@k / nDCG. This directly supports tuning and validating the graph-level similarity work in A3. | Medium |
 
 ---
 
@@ -21,6 +22,7 @@
 |---|------|---------|----------|
 | B1 | **Test voice & LinkedIn onboarding with Claude models** | Run systematic tests of the voice onboarding and LinkedIn import flows using Haiku, Sonnet, and Opus. For each model: (1) measure classification accuracy, (2) evaluate structured CV output quality, (3) compare cost per CV, (4) measure latency. Build a comparison matrix and decide which model to use for each pipeline stage. | High |
 | B2 | **Email scraping → friend invite with rewards** | When emails are detected in a CV (collaborators, references), prompt the user: "Want to invite them to join Orbis?" Design a reward system: what incentive does the inviter/invitee get? Options: premium feature unlock, extended storage, badge/visibility boost, early access to recruiter features. Implement the invite email flow with tracking. | Medium |
+| B3 | **Evaluate NVIDIA NeMo for speech-to-text** | Assess [NVIDIA NeMo](https://github.com/NVIDIA-NeMo/NeMo) as an alternative or complement to the current speech-to-text pipeline used during voice onboarding. Benchmark NeMo's ASR models (Conformer, FastConformer) against the current solution on: (1) word error rate across English + multilingual CVs, (2) latency per utterance, (3) GPU/CPU resource cost, (4) ease of self-hosting vs. API dependency. If NeMo outperforms, design a migration plan; if comparable, evaluate whether self-hosting reduces long-term costs. Ties into multilanguage support (C7). | Medium |
 
 ---
 
@@ -32,6 +34,9 @@
 | C2 | **A2UI (AI-to-UI) testing** | Test AI-to-UI interaction patterns — where AI actions directly manipulate the interface. Validate that AI-generated graph updates render correctly, that real-time node additions animate properly, and that AI suggestions integrate smoothly into the editing flow. | Low |
 | C3 | **Interface walkthrough / guided tour** | Implement an interactive walkthrough for first-time users: highlight key features (add node, edit, share link, MCP orb ID, export). Use a library like Shepherd.js or Intro.js. Cover: graph navigation (rotate, zoom, click), node editing, sharing, and the "paste your orb link into an LLM" demo flow. | Medium |
 | C4 | **Print orb + QR code** | Generate a printable version of the orb (static graph snapshot or styled summary) with a QR code that links to the live 3D interactive graph. Use case: hand out at conferences, attach to physical resumes. Implement as an export option (PDF with embedded QR). The QR links to the public orb URL (`orbis.io/{orb_id}`). | Low |
+| C5 | **Edge insertion UI via node selection** | Allow users to manually add edges between nodes directly in the 3D graph. Interaction flow: (1) user clicks a source node (highlighted), (2) clicks a destination node, (3) a pop-up menu appears listing the valid relationship labels from the ontology (e.g., HAS_SKILL, WORKED_AT, HAS_EDUCATION) filtered to only those semantically valid for the selected node types. User picks one and the edge is created in Neo4j + rendered in real time. Include an undo action and validation to prevent duplicate edges. | Medium |
+| C6 | **Node color legend and colorblind accessibility** | Add a visible legend panel to the graph view that maps each node color to its type (e.g., blue = Skill, green = Education, orange = Experience). Audit the current palette for colorblind accessibility — test against Deuteranopia, Protanopia, and Tritanopia using a simulator (e.g., Coblis or Sim Daltonism). If the palette fails, switch to a colorblind-safe scheme (e.g., IBM Design, Wong palette) and add secondary cues (shape, icon, or pattern) so color is never the sole differentiator. | Medium |
+| C7 | **Multilanguage website and pipeline** | Internationalize the entire platform: (1) wrap all UI strings with an i18n framework (react-i18next or similar), (2) support locale-aware speech-to-text in the voice onboarding (ties into B3/NeMo evaluation), (3) ensure the CV extraction pipeline handles non-English CVs (accented characters, right-to-left scripts, CJK text), (4) add a language selector in the UI. Start with English, Italian, and Spanish as pilot locales; design the system so adding new languages requires only a translation file, no code changes. | Low |
 
 ---
 
@@ -43,6 +48,7 @@
 | D2 | **Cross-platform MCP client** | Build an installable MCP client/plugin for ChatGPT, Gemini, and Claude so users can access any orb from within those platforms. Package as: (1) ChatGPT custom GPT/action, (2) Gemini extension, (3) Claude MCP server config. The client connects to Orbis's MCP endpoint and exposes the 5 orb query tools. | High |
 | D3 | **MCP query monetization** | Design a billing model for MCP queries. Options: (1) per-query pricing ($0.01–0.05/query), (2) monthly API token bundles, (3) freemium with rate limits (100 free queries/month, then paid). Integrate with Stripe. Track query origin (which agent/platform), query type, and data volume. This is the core B2B revenue stream. | High |
 | D4 | **Orb as identity/login provider** | Explore using an orb as a universal login identity — replacing email-based auth. Why should an email define your online identity? Research: (1) OAuth provider implementation (Orbis as an identity provider), (2) DID (Decentralized Identifier) standards, (3) Verifiable Credentials. Long-term vision but architecturally significant — start with a design doc. | Low |
+| D5 | **CV template export from visible orb data** | Let users upload a CV/résumé template (DOCX, LaTeX, or structured HTML) and auto-populate it with the information currently visible in their orb (respecting active filters and access control settings — filtered-out nodes are excluded). Return the document in an editable format (DOCX or HTML). Two delivery options: (1) download the pre-filled document for offline editing, (2) integrate a lightweight in-app editor (e.g., TipTap, CKEditor, or OnlyOffice) so users can review and tweak content before exporting. Support section mapping: map orb node types → template sections (Experience, Education, Skills, etc.). | Medium |
 
 ---
 
@@ -73,10 +79,18 @@
 
 ---
 
+## H. Account & Settings
+
+| # | Task | Details | Priority |
+|---|------|---------|----------|
+| H1 | **Change sign-in email and account deletion** | Allow users to update the email address associated with their account (with re-verification of the new address) and to permanently delete their account and all associated data. Account deletion must: (1) remove all Neo4j graph data, embeddings, and uploaded files, (2) revoke all active MCP tokens and permission grants, (3) send a confirmation email before executing, (4) comply with GDPR right-to-erasure requirements (full data wipe within 30 days). Expose both actions in a dedicated "Account Settings" page with clear warnings and confirmation dialogs. | Medium |
+
+---
+
 ## Priority Summary
 
 | Priority | Count | Tasks |
 |----------|-------|-------|
 | **High** | 8 | A1, A2, A3, A4, B1, D2, D3, E2, F1 |
-| **Medium** | 6 | B2, C1, C3, D1, E1, F2 |
-| **Low** | 5 | C2, C4, D4, G1, G2 |
+| **Medium** | 12 | A5, B2, B3, C1, C3, C5, C6, D1, D5, E1, F2, H1 |
+| **Low** | 7 | C2, C4, C7, D4, G1, G2 |

--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -10,6 +10,7 @@ from neo4j import AsyncDriver
 from app.dependencies import get_db
 from app.graph.encryption import decrypt_properties
 from app.graph.queries import GET_FULL_ORB_PUBLIC
+from app.orbs.filter_token import decode_filter_token, node_matches_filters
 
 router = APIRouter(prefix="/export", tags=["export"])
 
@@ -167,6 +168,8 @@ def _generate_pdf(person: dict, nodes: list[dict], orb_id: str) -> bytes:
 async def export_orb(
     orb_id: str,
     format: str = Query("json", pattern="^(json|jsonld|pdf)$"),
+    filter_token: str | None = Query(None),
+    filter_keyword: str | None = Query(None),
     db: AsyncDriver = Depends(get_db),
 ):
     async with db.session() as session:
@@ -176,6 +179,18 @@ async def export_orb(
             raise HTTPException(status_code=404, detail="Orb not found")
 
     person, nodes = _gather_orb(record)
+
+    # Apply filter: either via signed token or direct keywords (for owner exports)
+    active_filters: list[str] = []
+    if filter_token:
+        decoded = decode_filter_token(filter_token)
+        if decoded and decoded["orb_id"] == orb_id:
+            active_filters = decoded["filters"]
+    elif filter_keyword:
+        active_filters = [kw.strip().lower() for kw in filter_keyword.split(",") if kw.strip()]
+
+    if active_filters:
+        nodes = [n for n in nodes if not node_matches_filters(n, active_filters)]
 
     if format == "pdf":
         pdf_bytes = _generate_pdf(person, nodes, orb_id)

--- a/backend/app/orbs/filter_token.py
+++ b/backend/app/orbs/filter_token.py
@@ -1,0 +1,56 @@
+"""Filter-token utilities for fine-grained access control.
+
+A filter token is a JWT that encodes an orb_id and one or more filter keywords.
+When a shared link includes this token, the public API excludes any node
+whose string fields contain any of the keywords.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from jose import JWTError, jwt
+
+from app.config import settings
+
+
+def create_filter_token(orb_id: str, keywords: list[str]) -> str:
+    """Create a JWT encoding the orb_id and filter keywords (no expiry)."""
+    payload = {
+        "orb_id": orb_id,
+        "filters": [kw.strip().lower() for kw in keywords if kw.strip()],
+        "iat": datetime.now(timezone.utc),
+        "type": "filter",
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def decode_filter_token(token: str) -> dict | None:
+    """Decode a filter token. Returns {"orb_id": ..., "filters": [...]} or None."""
+    try:
+        payload = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=[settings.jwt_algorithm],
+            options={"verify_exp": False},
+        )
+        if payload.get("type") != "filter":
+            return None
+        orb_id = payload.get("orb_id")
+        filters = payload.get("filters", [])
+        if not orb_id or not filters:
+            return None
+        return {"orb_id": orb_id, "filters": filters}
+    except JWTError:
+        return None
+
+
+def node_matches_filters(node: dict, keywords: list[str]) -> bool:
+    """Check if any string property of a node contains any of the keywords (case-insensitive)."""
+    for value in node.values():
+        if isinstance(value, str):
+            lower_val = value.lower()
+            for kw in keywords:
+                if kw.lower() in lower_val:
+                    return True
+    return False

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from neo4j import AsyncDriver
 from neo4j.time import DateTime as Neo4jDateTime, Date as Neo4jDate, Time as Neo4jTime
 
@@ -24,11 +24,20 @@ from app.graph.queries import (
     UPDATE_PERSON,
 )
 from app.orbs.models import NodeCreate, NodeUpdate, OrbIdUpdate, PersonUpdate
+from app.orbs.filter_token import (
+    create_filter_token,
+    decode_filter_token,
+    node_matches_filters,
+)
 
 
 class SkillLinkRequest(BaseModel):
     node_uid: str
     skill_uid: str
+
+
+class FilterTokenRequest(BaseModel):
+    keywords: list[str]
 
 router = APIRouter(prefix="/orbs", tags=["orbs"])
 
@@ -256,9 +265,31 @@ async def unlink_skill(
         return {"status": "unlinked"}
 
 
+@router.post("/me/filter-token")
+async def generate_filter_token(
+    data: FilterTokenRequest,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Generate a shareable token that encodes a visibility filter for this user's orb."""
+    async with db.session() as session:
+        result = await session.run(GET_FULL_ORB, user_id=current_user["user_id"])
+        record = await result.single()
+        if record is None:
+            raise HTTPException(status_code=404, detail="Orb not found")
+        person = dict(record["p"])
+        orb_id = person.get("orb_id", "")
+        if not orb_id:
+            raise HTTPException(status_code=400, detail="Set an orb ID first")
+
+    token = create_filter_token(orb_id, data.keywords)
+    return {"token": token, "keywords": [kw.strip().lower() for kw in data.keywords]}
+
+
 @router.get("/{orb_id}")
 async def get_public_orb(
     orb_id: str,
+    filter_token: str | None = Query(None),
     db: AsyncDriver = Depends(get_db),
 ):
     async with db.session() as session:
@@ -266,4 +297,28 @@ async def get_public_orb(
         record = await result.single()
         if record is None:
             raise HTTPException(status_code=404, detail="Orb not found")
-        return _serialize_orb(record)
+
+    orb_data = _serialize_orb(record)
+
+    # Apply filter if a valid filter token is provided
+    if filter_token:
+        decoded = decode_filter_token(filter_token)
+        if decoded and decoded["orb_id"] == orb_id:
+            keywords = decoded["filters"]
+            # Remove nodes that match any filter keyword
+            filtered_nodes = []
+            filtered_uids = set()
+            for node in orb_data["nodes"]:
+                if node_matches_filters(node, keywords):
+                    filtered_uids.add(node.get("uid"))
+                else:
+                    filtered_nodes.append(node)
+            # Remove links connected to filtered nodes
+            filtered_links = [
+                link for link in orb_data["links"]
+                if link["target"] not in filtered_uids and link["source"] not in filtered_uids
+            ]
+            orb_data["nodes"] = filtered_nodes
+            orb_data["links"] = filtered_links
+
+    return orb_data

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -23,8 +23,14 @@ export async function getMyOrb(): Promise<OrbData> {
   return data;
 }
 
-export async function getPublicOrb(orbId: string): Promise<OrbData> {
-  const { data } = await client.get(`/orbs/${orbId}`);
+export async function getPublicOrb(orbId: string, filterToken?: string): Promise<OrbData> {
+  const params = filterToken ? { filter_token: filterToken } : {};
+  const { data } = await client.get(`/orbs/${orbId}`, { params });
+  return data;
+}
+
+export async function createFilterToken(keywords: string[]): Promise<{ token: string; keywords: string[] }> {
+  const { data } = await client.post('/orbs/me/filter-token', { keywords });
   return data;
 }
 

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -10,6 +10,8 @@ interface OrbGraph3DProps {
   onNodeClick?: (node: Record<string, unknown>) => void;
   onBackgroundClick?: () => void;
   highlightedNodeIds?: Set<string>;
+  /** Node IDs that match the active visibility filter — rendered as transparent */
+  filteredNodeIds?: Set<string>;
   width?: number;
   height?: number;
 }
@@ -40,7 +42,7 @@ const SHARED_GEO = {
   highlightRing: new THREE.RingGeometry(5.1, 6.0, 24),
 };
 
-export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, width, height }: OrbGraph3DProps) {
+export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, filteredNodeIds, width, height }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
@@ -56,6 +58,10 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
   highlightRef.current = highlightedNodeIds ?? new Set();
   const hasHighlightsRef = useRef(false);
   hasHighlightsRef.current = (highlightedNodeIds?.size ?? 0) > 0;
+
+  // Use ref for filtered nodes (visibility filter)
+  const filteredRef = useRef<Set<string>>(new Set());
+  filteredRef.current = filteredNodeIds ?? new Set();
 
   // Clear cache when data changes
   useEffect(() => {
@@ -201,6 +207,18 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     }
   }, [highlightedNodeIds]);
 
+  // When filtered nodes change, invalidate cache and refresh
+  const prevFilterKeyRef = useRef<string>('');
+  useEffect(() => {
+    const newKey = filteredNodeIds ? Array.from(filteredNodeIds).sort().join(',') : '';
+    if (newKey !== prevFilterKeyRef.current) {
+      prevFilterKeyRef.current = newKey;
+      nodeObjectCacheRef.current.clear();
+      const fg = fgRef.current;
+      if (fg) fg.refresh();
+    }
+  }, [filteredNodeIds]);
+
   const handleNodeHover = useCallback((node: any) => {
     setHoveredNode(node || null);
     const el = document.querySelector('canvas');
@@ -235,6 +253,10 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     const hasHighlights = hasHighlightsRef.current;
     const isHighlighted = hasHighlights && highlightRef.current.has(nodeId);
     const isDimmed = hasHighlights && !isHighlighted;
+    const isFiltered = filteredRef.current.has(nodeId);
+
+    const fo = isFiltered ? 0.15 : 1; // filter opacity multiplier
+    const nodeCol = isFiltered ? new THREE.Color('#ffffff') : new THREE.Color(color);
 
     const group = new THREE.Group();
     const col = new THREE.Color(color);
@@ -242,9 +264,9 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     if (isPerson) {
       // ── Person node: emissive core + orbital rings (no PointLight) ──
       const coreMat = new THREE.MeshBasicMaterial({
-        color: col,
+        color: nodeCol,
         transparent: true,
-        opacity: isDimmed ? 0.2 : 0.9,
+        opacity: (isDimmed ? 0.2 : 0.9) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.personCore, coreMat));
 
@@ -252,15 +274,15 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
       const innerGlowMat = new THREE.MeshBasicMaterial({
         color: '#ffffff',
         transparent: true,
-        opacity: isDimmed ? 0.05 : 0.55,
+        opacity: (isDimmed ? 0.05 : 0.55) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.personInnerGlow, innerGlowMat));
 
       // Orbital ring 1
       const ring1Mat = new THREE.MeshBasicMaterial({
-        color: col,
+        color: nodeCol,
         transparent: true,
-        opacity: isDimmed ? 0.05 : 0.5,
+        opacity: (isDimmed ? 0.05 : 0.5) * fo,
       });
       const ring1 = new THREE.Mesh(SHARED_GEO.personRing1, ring1Mat);
       ring1.rotation.x = Math.PI / 2;
@@ -269,9 +291,9 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
 
       // Orbital ring 2
       const ring2Mat = new THREE.MeshBasicMaterial({
-        color: new THREE.Color('#a78bfa'),
+        color: isFiltered ? new THREE.Color('#ffffff') : new THREE.Color('#a78bfa'),
         transparent: true,
-        opacity: isDimmed ? 0.03 : 0.3,
+        opacity: (isDimmed ? 0.03 : 0.3) * fo,
       });
       const ring2 = new THREE.Mesh(SHARED_GEO.personRing2, ring2Mat);
       ring2.rotation.x = Math.PI / 3;
@@ -281,11 +303,25 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
 
       // Mid glow
       const midMat = new THREE.MeshBasicMaterial({
-        color: col,
+        color: nodeCol,
         transparent: true,
-        opacity: isDimmed ? 0.01 : 0.06,
+        opacity: (isDimmed ? 0.01 : 0.06) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.personMidGlow, midMat));
+
+      // White wireframe sphere border for filtered person node
+      if (isFiltered) {
+        const borderGeo = new THREE.SphereGeometry(6 * 1.5, 16, 12);
+        const borderMat = new THREE.MeshBasicMaterial({
+          color: new THREE.Color('#ffffff'),
+          transparent: true,
+          opacity: 0.5,
+          wireframe: true,
+        });
+        const border = new THREE.Mesh(borderGeo, borderMat);
+        border.name = '__filter_border';
+        group.add(border);
+      }
 
     } else {
       // ── Regular nodes: 2 meshes (core + main), no PointLight ──
@@ -294,28 +330,42 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
       const coreMat = new THREE.MeshBasicMaterial({
         color: 0xffffff,
         transparent: true,
-        opacity: isDimmed ? 0.05 : isHighlighted ? 0.95 : 0.7,
+        opacity: (isDimmed ? 0.05 : isHighlighted ? 0.95 : 0.7) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.nodeCore, coreMat));
 
       // Main sphere — emissive color via MeshBasicMaterial (no light needed)
       const mainMat = new THREE.MeshBasicMaterial({
-        color: col,
+        color: nodeCol,
         transparent: true,
-        opacity: isDimmed ? 0.2 : 0.85,
+        opacity: (isDimmed ? 0.2 : 0.85) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.nodeMain, mainMat));
 
-      // Single glow layer (removed outer glow)
+      // Single glow layer
       const glowMat = new THREE.MeshBasicMaterial({
-        color: col,
+        color: nodeCol,
         transparent: true,
-        opacity: isDimmed ? 0.01 : isHighlighted ? 0.15 : 0.05,
+        opacity: (isDimmed ? 0.01 : isHighlighted ? 0.15 : 0.05) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.nodeGlow, glowMat));
 
+      // White wireframe sphere border for filtered node
+      if (isFiltered) {
+        const borderGeo = new THREE.SphereGeometry(radius * 1.4, 16, 12);
+        const borderMat = new THREE.MeshBasicMaterial({
+          color: new THREE.Color('#ffffff'),
+          transparent: true,
+          opacity: 0.5,
+          wireframe: true,
+        });
+        const border = new THREE.Mesh(borderGeo, borderMat);
+        border.name = '__filter_border';
+        group.add(border);
+      }
+
       // Highlight ring
-      if (isHighlighted) {
+      if (isHighlighted && !isFiltered) {
         const ringMat = new THREE.MeshBasicMaterial({
           color: 0xffffff,
           transparent: true,
@@ -340,7 +390,8 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
 
       ctx.font = `600 ${isPerson ? 18 : 13}px Inter, -apple-system, sans-serif`;
       ctx.textAlign = 'center';
-      ctx.fillStyle = isDimmed ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.9)';
+      const textAlpha = isFiltered ? 0.06 : isDimmed ? 0.12 : 0.9;
+      ctx.fillStyle = `rgba(255,255,255,${textAlpha})`;
       const displayName = name.length > 28 ? name.slice(0, 26) + '\u2026' : name;
       ctx.fillText(displayName, 256, isPerson ? 24 : 20);
 
@@ -348,7 +399,7 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
         const typeLabel = getTypeLabel(node);
         if (typeLabel) {
           ctx.font = '500 10px Inter, -apple-system, sans-serif';
-          ctx.fillStyle = isDimmed ? 'rgba(255,255,255,0.06)' : color;
+          ctx.fillStyle = isFiltered ? 'rgba(255,255,255,0.03)' : isDimmed ? 'rgba(255,255,255,0.06)' : color;
           ctx.fillText(typeLabel, 256, 38);
         }
       }
@@ -373,6 +424,12 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
   // Link color
   const linkColorRef = useRef<(link: any) => string>(() => 'rgba(255,255,255,0.2)');
   linkColorRef.current = (link: any) => {
+    // Check if either end of the link is filtered
+    const sourceId = typeof link.source === 'object' ? (link.source.id || link.source.uid) : link.source;
+    const targetId = typeof link.target === 'object' ? (link.target.id || link.target.uid) : link.target;
+    const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
+    if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
+
     if (hasHighlightsRef.current) return 'rgba(255,255,255,0.04)';
     const source = link.source;
     if (source && source._labels) {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useOrbStore } from '../stores/orbStore';
 import { useAuthStore } from '../stores/authStore';
-import { claimOrbId, updateProfile } from '../api/orbs';
+import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
+import { claimOrbId, updateProfile, createFilterToken } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import FloatingInput from '../components/editor/FloatingInput';
@@ -18,13 +19,37 @@ import ProcessingCounter from '../components/cv/ProcessingCounter';
 
 function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) {
   const [copied, setCopied] = useState(false);
+  const [copiedFiltered, setCopiedFiltered] = useState(false);
+  const [filterToken, setFilterToken] = useState<string | null>(null);
+  const [generatingToken, setGeneratingToken] = useState(false);
+  const { activeKeywords } = useFilterStore();
+  const hasActiveFilters = activeKeywords.length > 0;
   const shareUrl = `${window.location.origin}/${orbId}`;
+  const filteredShareUrl = filterToken ? `${window.location.origin}/${orbId}?filter_token=${filterToken}` : '';
   const mcpUri = `orb://${orbId}`;
 
-  const copy = (text: string) => {
+  // Generate a filter token when the panel opens if filters are active
+  useEffect(() => {
+    if (hasActiveFilters && orbId) {
+      setGeneratingToken(true);
+      createFilterToken(activeKeywords)
+        .then(({ token }) => setFilterToken(token))
+        .catch(() => setFilterToken(null))
+        .finally(() => setGeneratingToken(false));
+    } else {
+      setFilterToken(null);
+    }
+  }, [activeKeywords, hasActiveFilters, orbId]);
+
+  const copy = (text: string, filtered = false) => {
     navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (filtered) {
+      setCopiedFiltered(true);
+      setTimeout(() => setCopiedFiltered(false), 2000);
+    } else {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   return (
@@ -42,7 +67,7 @@ function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) 
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.92, y: 24 }}
         transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl"
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-y-auto"
       >
         <h2 className="text-white text-lg font-semibold mb-1">Share Your Orb</h2>
         <p className="text-gray-400 text-sm mb-5">Share your orb link or use the MCP identifier to let AI agents access your professional graph.</p>
@@ -50,7 +75,7 @@ function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) 
         {/* QR Code */}
         <div className="flex justify-center mb-5">
           <div className="bg-white p-3 rounded-xl">
-            <QRCodeSVG value={shareUrl} size={140} level="M" />
+            <QRCodeSVG value={filteredShareUrl || shareUrl} size={140} level="M" />
           </div>
         </div>
 
@@ -63,6 +88,32 @@ function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) 
             </button>
           </div>
         </div>
+
+        {/* Filtered share link — only shown when filters are active */}
+        {hasActiveFilters && (
+          <div className="mb-4">
+            <label className="text-xs text-amber-400/80 uppercase tracking-wide font-medium">Filtered Link</label>
+            <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
+              This link hides nodes matching {activeKeywords.map((kw, i) => (
+                <span key={kw}>{i > 0 && ', '}"<span className="text-amber-400">{kw}</span>"</span>
+              ))} from the viewer.
+            </p>
+            <div className="flex items-center gap-2">
+              {generatingToken ? (
+                <div className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-gray-500 text-sm">Generating...</div>
+              ) : (
+                <input readOnly value={filteredShareUrl} className="flex-1 bg-gray-800 border border-amber-600/30 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+              )}
+              <button
+                onClick={() => copy(filteredShareUrl, true)}
+                disabled={!filterToken}
+                className="bg-amber-600 hover:bg-amber-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
+              >
+                {copiedFiltered ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+        )}
 
         <div className="mb-5">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orb ID</label>
@@ -84,6 +135,8 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+  const [newKeyword, setNewKeyword] = useState('');
+  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
 
   const handleSave = async () => {
     const trimmed = customId.trim().toLowerCase();
@@ -101,6 +154,13 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
     } finally { setSaving(false); }
   };
 
+  const handleAddKeyword = () => {
+    const trimmed = newKeyword.trim();
+    if (!trimmed) return;
+    addKeyword(trimmed);
+    setNewKeyword('');
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <motion.div
@@ -116,10 +176,12 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.92, y: 24 }}
         transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl"
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-y-auto"
       >
         <h2 className="text-white text-lg font-semibold mb-1">Settings</h2>
-        <p className="text-gray-400 text-sm mb-5">Customize your orb identity.</p>
+        <p className="text-gray-400 text-sm mb-5">Customize your orb identity and visibility.</p>
+
+        {/* Orb ID section */}
         <div className="mb-5">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orb ID</label>
           <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Choose a memorable ID for your orb. This will be your public URL and MCP identifier.</p>
@@ -130,6 +192,84 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
           {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
           {success && <p className="text-green-400 text-xs mt-2">Orb ID updated!</p>}
         </div>
+
+        {/* ── Visibility Filters section ── */}
+        <div className="mb-5 border-t border-gray-700 pt-4">
+          <label className="text-xs text-amber-400/80 uppercase tracking-wide font-medium">Visibility Filters</label>
+          <p className="text-[11px] text-gray-500 mt-0.5 mb-3">
+            Add keywords to filter nodes. When a filter is active, nodes containing that keyword become transparent. Filtered nodes are excluded from shared links and CV exports.
+          </p>
+
+          {/* Add new keyword */}
+          <div className="flex items-center gap-2 mb-3">
+            <input
+              value={newKeyword}
+              onChange={(e) => setNewKeyword(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddKeyword()}
+              placeholder="e.g. confidential, private, salary..."
+              className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+            />
+            <button
+              onClick={handleAddKeyword}
+              className="bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
+            >
+              Add
+            </button>
+          </div>
+
+          {/* Keyword list */}
+          {keywords.length === 0 ? (
+            <p className="text-gray-600 text-xs italic">No filter keywords configured yet.</p>
+          ) : (
+            <div className="space-y-1.5">
+              {keywords.map((kw) => {
+                const isActive = activeKeywords.includes(kw);
+                return (
+                  <div
+                    key={kw}
+                    className={`flex items-center justify-between gap-2 px-3 py-2 rounded-lg border transition-all ${
+                      isActive
+                        ? 'bg-amber-600/15 border-amber-500/40'
+                        : 'bg-gray-800/50 border-gray-700/50 hover:border-gray-600'
+                    }`}
+                  >
+                    <span className="text-white text-sm font-mono truncate">{kw}</span>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <button
+                        onClick={() => toggleKeyword(kw)}
+                        className={`text-[10px] font-medium px-2 py-1 rounded transition-colors ${
+                          isActive
+                            ? 'bg-amber-500 text-white'
+                            : 'bg-gray-700 text-gray-400 hover:text-white hover:bg-gray-600'
+                        }`}
+                      >
+                        {isActive ? 'Active' : 'Activate'}
+                      </button>
+                      <button
+                        onClick={() => removeKeyword(kw)}
+                        className="text-gray-500 hover:text-red-400 transition-colors"
+                        title="Remove"
+                      >
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {activeKeywords.length > 0 && (
+            <p className="text-amber-400/70 text-[11px] mt-2">
+              {activeKeywords.length === 1 ? 'Filter' : 'Filters'} {activeKeywords.map((kw, i) => (
+                <span key={kw}>{i > 0 && ', '}"<span className="font-semibold">{kw}</span>"</span>
+              ))} active. Matching nodes are transparent.
+            </p>
+          )}
+        </div>
+
         <div className="flex gap-3">
           <button onClick={handleSave} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm">{saving ? 'Saving…' : 'Save'}</button>
           <button onClick={onClose} className="flex-1 border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Cancel</button>
@@ -464,6 +604,13 @@ export default function OrbViewPage() {
   };
 
   const orbId = (data?.person?.orb_id as string) || '';
+  const { activeKeywords } = useFilterStore();
+
+  // Compute which nodes match any active visibility filter
+  const filteredNodeIds = useMemo(
+    () => computeFilteredNodeIds(data?.nodes ?? [], activeKeywords),
+    [data?.nodes, activeKeywords]
+  );
 
   if (loading || !data) {
     return (
@@ -495,6 +642,14 @@ export default function OrbViewPage() {
             <div>
               <span className="text-white text-xs sm:text-sm font-semibold">{user?.name || 'My Orb'}</span>
               <span className="text-white/20 text-xs ml-2 hidden sm:inline">{data.nodes.length} nodes</span>
+              {activeKeywords.length > 0 && (
+                <span className="text-amber-400/70 text-[10px] ml-2 hidden sm:inline-flex items-center gap-1">
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                  </svg>
+                  {activeKeywords.join(', ')}
+                </span>
+              )}
             </div>
           </div>
 
@@ -521,7 +676,11 @@ export default function OrbViewPage() {
             </HeaderBtn>
             <button
               onClick={() => {
-                if (orbId) window.open(`${import.meta.env.VITE_API_URL || 'http://localhost:8000'}/export/${orbId}?format=pdf`, '_blank');
+                if (orbId) {
+                  const params = new URLSearchParams({ format: 'pdf' });
+                  if (activeKeywords.length > 0) params.set('filter_keyword', activeKeywords.join(','));
+                  window.open(`${import.meta.env.VITE_API_URL || 'http://localhost:8000'}/export/${orbId}?${params}`, '_blank');
+                }
               }}
               className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all"
             >
@@ -572,6 +731,7 @@ export default function OrbViewPage() {
           }
         }}
         highlightedNodeIds={highlightedNodeIds}
+        filteredNodeIds={filteredNodeIds}
         width={dimensions.width}
         height={dimensions.height}
       />

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useOrbStore } from '../stores/orbStore';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 
 export default function SharedOrbPage() {
   const { orbId } = useParams<{ orbId: string }>();
+  const [searchParams] = useSearchParams();
+  const filterToken = searchParams.get('filter_token') || undefined;
   const { data, loading, error, fetchPublicOrb } = useOrbStore();
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
 
   useEffect(() => {
-    if (orbId) fetchPublicOrb(orbId);
-  }, [orbId, fetchPublicOrb]);
+    if (orbId) fetchPublicOrb(orbId, filterToken);
+  }, [orbId, filterToken, fetchPublicOrb]);
 
   useEffect(() => {
     const handleResize = () => setDimensions({ width: window.innerWidth, height: window.innerHeight });
@@ -45,6 +47,9 @@ export default function SharedOrbPage() {
         <div className="text-white">
           <span className="text-lg font-semibold">{personName}</span>
           <span className="text-gray-500 text-sm ml-3">{data.nodes.length} nodes</span>
+          {filterToken && (
+            <span className="text-amber-400/60 text-xs ml-3">Filtered view</span>
+          )}
         </div>
         <a
           href="/"

--- a/frontend/src/stores/filterStore.ts
+++ b/frontend/src/stores/filterStore.ts
@@ -1,0 +1,92 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface FilterState {
+  /** List of filter keywords configured by the user */
+  keywords: string[];
+  /** Set of currently active filter keywords */
+  activeKeywords: string[];
+
+  addKeyword: (keyword: string) => void;
+  removeKeyword: (keyword: string) => void;
+  toggleKeyword: (keyword: string) => void;
+  setActiveKeywords: (keywords: string[]) => void;
+}
+
+export const useFilterStore = create<FilterState>()(
+  persist(
+    (set, get) => ({
+      keywords: [],
+      activeKeywords: [],
+
+      addKeyword: (keyword: string) => {
+        const trimmed = keyword.trim().toLowerCase();
+        if (!trimmed) return;
+        const { keywords } = get();
+        if (keywords.includes(trimmed)) return;
+        set({ keywords: [...keywords, trimmed] });
+      },
+
+      removeKeyword: (keyword: string) => {
+        const { keywords, activeKeywords } = get();
+        set({
+          keywords: keywords.filter((k) => k !== keyword),
+          activeKeywords: activeKeywords.filter((k) => k !== keyword),
+        });
+      },
+
+      toggleKeyword: (keyword: string) => {
+        const { activeKeywords } = get();
+        if (activeKeywords.includes(keyword)) {
+          set({ activeKeywords: activeKeywords.filter((k) => k !== keyword) });
+        } else {
+          set({ activeKeywords: [...activeKeywords, keyword] });
+        }
+      },
+
+      setActiveKeywords: (keywords: string[]) => {
+        set({ activeKeywords: keywords });
+      },
+    }),
+    {
+      name: 'orbis_filters',
+    }
+  )
+);
+
+/**
+ * Check if a node matches a filter keyword.
+ * Returns true if any string field of the node contains the keyword (case-insensitive).
+ */
+export function nodeMatchesFilter(
+  node: Record<string, unknown>,
+  keyword: string
+): boolean {
+  const lowerKeyword = keyword.toLowerCase();
+  for (const value of Object.values(node)) {
+    if (typeof value === 'string' && value.toLowerCase().includes(lowerKeyword)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Compute the set of node UIDs that match any of the active filter keywords.
+ */
+export function computeFilteredNodeIds(
+  nodes: Array<Record<string, unknown>>,
+  activeKeywords: string[]
+): Set<string> {
+  if (activeKeywords.length === 0) return new Set();
+  const filtered = new Set<string>();
+  for (const node of nodes) {
+    for (const keyword of activeKeywords) {
+      if (nodeMatchesFilter(node, keyword)) {
+        filtered.add(node.uid as string);
+        break;
+      }
+    }
+  }
+  return filtered;
+}

--- a/frontend/src/stores/orbStore.ts
+++ b/frontend/src/stores/orbStore.ts
@@ -8,7 +8,7 @@ interface OrbState {
   loading: boolean;
   error: string | null;
   fetchOrb: () => Promise<void>;
-  fetchPublicOrb: (orbId: string) => Promise<void>;
+  fetchPublicOrb: (orbId: string, filterToken?: string) => Promise<void>;
   addNode: (nodeType: string, properties: Record<string, unknown>) => Promise<OrbNode>;
   updateNode: (uid: string, properties: Record<string, unknown>) => Promise<void>;
   deleteNode: (uid: string) => Promise<void>;
@@ -29,10 +29,10 @@ export const useOrbStore = create<OrbState>((set, get) => ({
     }
   },
 
-  fetchPublicOrb: async (orbId: string) => {
+  fetchPublicOrb: async (orbId: string, filterToken?: string) => {
     set({ loading: true, error: null });
     try {
-      const data = await orbsApi.getPublicOrb(orbId);
+      const data = await orbsApi.getPublicOrb(orbId, filterToken);
       set({ data, loading: false });
     } catch (e) {
       set({ error: (e as Error).message, loading: false });


### PR DESCRIPTION
Closes #6

## Summary
- **Visibility Filters in Settings**: Users can add multiple filter keywords from the Settings panel (top-left). Each keyword can be independently activated/deactivated. When active, any node whose string fields contain the keyword turns white and transparent in the 3D graph, along with its edges.
- **Filtered Share Links**: The Share panel generates a signed JWT token encoding all active filters. Recipients of a filtered link only see non-filtered nodes — filtered data never reaches their browser.
- **Filtered CV Export**: When filters are active, the Export CV button excludes matching nodes from the PDF output.

## Files Changed
| File | Change |
|------|--------|
| `frontend/src/stores/filterStore.ts` | **New** — Zustand store (persisted) for filter keywords and active state |
| `backend/app/orbs/filter_token.py` | **New** — JWT filter token creation/decoding + node matching logic |
| `frontend/src/pages/OrbViewPage.tsx` | Filter UI in SettingsPanel, filtered share link in SharePanel, header badge, export with filter |
| `frontend/src/components/graph/OrbGraph3D.tsx` | Filtered nodes render white + transparent with wireframe border; edges fade |
| `frontend/src/pages/SharedOrbPage.tsx` | Read `filter_token` from URL, pass to API for server-side filtering |
| `frontend/src/api/orbs.ts` | `createFilterToken()` API + `filterToken` param on `getPublicOrb()` |
| `frontend/src/stores/orbStore.ts` | `fetchPublicOrb` accepts optional `filterToken` |
| `backend/app/orbs/router.py` | `POST /orbs/me/filter-token` endpoint + `filter_token` query on `GET /orbs/{orb_id}` |
| `backend/app/export/router.py` | `filter_token` / `filter_keyword` query params to exclude nodes from export |

## Test plan
- [ ] **Add filter keywords**: Open Settings (top-left avatar) → scroll to "Visibility Filters" → add keywords (e.g. "confidential", "google") → verify they appear in the list
- [ ] **Activate multiple filters**: Click "Activate" on two or more keywords → verify header shows filter badge with all active keywords
- [ ] **Graph rendering**: Confirm filtered nodes turn **white and transparent** with a wireframe sphere border; their edges also become nearly invisible
- [ ] **Deactivate filter**: Toggle a filter off → node should return to its original color and full opacity
- [ ] **Remove keyword**: Click the X on a keyword → verify it's removed (and deactivated if it was active)
- [ ] **Persistence**: Refresh the page → verify keywords and active state persist (stored in localStorage)
- [ ] **Filtered share link**: With filter(s) active, open Share panel → verify "Filtered Link" section appears with a token URL
- [ ] **Open filtered link in incognito**: Copy the filtered link, open in a new incognito window → verify filtered nodes are **completely absent** (not just transparent)
- [ ] **Full share link still works**: The regular "Public Link" should still show all nodes
- [ ] **Export CV with filter**: With filter(s) active, click "Export CV" → verify the PDF does **not** contain entries matching the filter keywords
- [ ] **Export CV without filter**: Deactivate all filters → export → verify full CV is generated
- [ ] **No filters configured**: Verify the app behaves identically to before (no regressions) when no keywords exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)