### PR TITLE
Add search bar to shared orb page with privacy-aware filtering

### DIFF
--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from app.dependencies import get_current_user, get_db
 from app.graph.embeddings import build_embedding_text, generate_embedding
+from app.orbs.filter_token import decode_filter_token, node_matches_filters
 
 router = APIRouter(prefix="/search", tags=["search"])
 
@@ -166,6 +167,90 @@ async def text_search(
                         if uid in seen_uids:
                             continue
                         # Check fuzzy match against all searchable fields
+                        matched = False
+                        for f in fields:
+                            val = node.get(f)
+                            if val and _fuzzy_match(str(val), terms):
+                                matched = True
+                                break
+                        if matched:
+                            node.pop("embedding", None)
+                            node["_labels"] = record["node_labels"]
+                            seen_uids.add(uid)
+                            results.append(node)
+                except Exception:
+                    continue
+
+    return results
+
+
+class PublicTextSearchRequest(BaseModel):
+    query: str
+    orb_id: str
+    filter_token: str | None = None
+
+
+@router.post("/text/public")
+async def public_text_search(
+    data: PublicTextSearchRequest,
+    db: AsyncDriver = Depends(get_db),
+):
+    """Fuzzy text search across a public orb's nodes (no auth required)."""
+    # Decode filter token to get privacy keywords (if any)
+    filter_keywords: list[str] = []
+    if data.filter_token:
+        decoded = decode_filter_token(data.filter_token)
+        if decoded and decoded["orb_id"] == data.orb_id:
+            filter_keywords = decoded["filters"]
+
+    raw_term = data.query.strip().lower()
+    terms = [t for t in raw_term.split() if len(t) >= 2]
+    if not terms:
+        terms = [raw_term]
+
+    results = []
+    seen_uids: set[str] = set()
+
+    async with db.session() as session:
+        for label, fields in _SEARCH_FIELDS.items():
+            where_clauses = " OR ".join(
+                f"toLower(toString(n.{f})) CONTAINS $term" for f in fields
+            )
+            cypher = (
+                f"MATCH (p:Person {{orb_id: $orb_id}})-[r]->(n:{label}) "
+                f"WHERE {where_clauses} "
+                f"RETURN n, labels(n) AS node_labels"
+            )
+            try:
+                result = await session.run(cypher, orb_id=data.orb_id, term=raw_term)
+                async for record in result:
+                    node = dict(record["n"])
+                    node.pop("embedding", None)
+                    node["_labels"] = record["node_labels"]
+                    if node.get("uid") not in seen_uids:
+                        if filter_keywords and node_matches_filters(node, filter_keywords):
+                            continue
+                        seen_uids.add(node.get("uid", ""))
+                        results.append(node)
+            except Exception:
+                continue
+
+    if len(results) < 3:
+        async with db.session() as session:
+            for label, fields in _SEARCH_FIELDS.items():
+                cypher = (
+                    f"MATCH (p:Person {{orb_id: $orb_id}})-[r]->(n:{label}) "
+                    f"RETURN n, labels(n) AS node_labels"
+                )
+                try:
+                    result = await session.run(cypher, orb_id=data.orb_id)
+                    async for record in result:
+                        node = dict(record["n"])
+                        uid = node.get("uid", "")
+                        if uid in seen_uids:
+                            continue
+                        if filter_keywords and node_matches_filters(node, filter_keywords):
+                            continue
                         matched = False
                         for f in fields:
                             val = node.get(f)

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -61,6 +61,11 @@ export async function textSearch(query: string): Promise<OrbNode[]> {
   return data;
 }
 
+export async function publicTextSearch(query: string, orbId: string, filterToken?: string): Promise<OrbNode[]> {
+  const { data } = await client.post('/search/text/public', { query, orb_id: orbId, filter_token: filterToken });
+  return data;
+}
+
 export async function linkSkill(nodeUid: string, skillUid: string): Promise<void> {
   await client.post('/orbs/me/link-skill', { node_uid: nodeUid, skill_uid: skillUid });
 }

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -16,6 +16,8 @@ interface ChatBoxProps {
   onAdd?: () => void;
   onShare?: () => void;
   highlightAdd?: boolean;
+  placeholder?: string;
+  searchFn?: (query: string) => Promise<OrbNode[]>;
 }
 
 export type { ChatMessage };
@@ -58,7 +60,7 @@ function getNodeSubtitle(node: OrbNode): string {
   return '';
 }
 
-export default function ChatBox({ onHighlight, messages, onMessagesChange, onAdd, onShare, highlightAdd }: ChatBoxProps) {
+export default function ChatBox({ onHighlight, messages, onMessagesChange, onAdd, onShare, highlightAdd, placeholder = 'Query your orb...', searchFn = textSearch }: ChatBoxProps) {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -86,7 +88,7 @@ export default function ChatBox({ onHighlight, messages, onMessagesChange, onAdd
     setLoading(true);
 
     try {
-      const results = await textSearch(query);
+      const results = await searchFn(query);
 
       if (results.length === 0) {
         setMessages((prev) => [
@@ -233,7 +235,7 @@ export default function ChatBox({ onHighlight, messages, onMessagesChange, onAdd
               ref={inputRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder="Query your orb..."
+              placeholder={placeholder}
               className="flex-1 bg-transparent text-white text-sm placeholder:text-white/30 focus:outline-none"
             />
             {input.trim() && (

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useOrbStore } from '../stores/orbStore';
+import { publicTextSearch } from '../api/orbs';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
+import ChatBox from '../components/chat/ChatBox';
+import type { ChatMessage } from '../components/chat/ChatBox';
 
 export default function SharedOrbPage() {
   const { orbId } = useParams<{ orbId: string }>();
@@ -9,6 +12,14 @@ export default function SharedOrbPage() {
   const filterToken = searchParams.get('filter_token') || undefined;
   const { data, loading, error, fetchPublicOrb } = useOrbStore();
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
+  const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set());
+
+  // Public search bound to this orb — respects filter_token privacy
+  const searchFn = useCallback(
+    (query: string) => publicTextSearch(query, orbId || '', filterToken),
+    [orbId, filterToken]
+  );
 
   useEffect(() => {
     if (orbId) fetchPublicOrb(orbId, filterToken);
@@ -43,26 +54,51 @@ export default function SharedOrbPage() {
 
   return (
     <div className="min-h-screen bg-black relative">
-      <div className="absolute top-0 left-0 right-0 z-30 flex items-center justify-between px-6 py-4">
-        <div className="text-white">
-          <span className="text-lg font-semibold">{personName}</span>
-          <span className="text-gray-500 text-sm ml-3">{data.nodes.length} nodes</span>
-          {filterToken && (
-            <span className="text-amber-400/60 text-xs ml-3">Filtered view</span>
-          )}
+      {/* ── Header ── */}
+      <div className="absolute top-0 left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 sm:gap-3">
+            <div className="w-8 h-8 rounded-full bg-purple-600/30 border border-purple-500/40 flex items-center justify-center">
+              <span className="text-purple-300 text-xs font-bold">
+                {personName.charAt(0).toUpperCase()}
+              </span>
+            </div>
+            <div>
+              <span className="text-white text-xs sm:text-sm font-semibold">{personName}</span>
+              <span className="text-white/20 text-xs ml-2 hidden sm:inline">{data.nodes.length} nodes</span>
+            </div>
+          </div>
+
+          <a
+            href="/"
+            className="text-purple-400 hover:text-purple-300 text-sm font-medium transition-colors"
+          >
+            Create your own Orb
+          </a>
         </div>
-        <a
-          href="/"
-          className="text-purple-400 hover:text-purple-300 text-sm font-medium transition-colors"
-        >
-          Create your own Orb
-        </a>
       </div>
 
+      {/* ── 3D Graph ── */}
       <OrbGraph3D
         data={data}
+        onBackgroundClick={() => {
+          if (chatMessages.length > 0) {
+            setChatMessages([]);
+            setHighlightedNodeIds(new Set());
+          }
+        }}
+        highlightedNodeIds={highlightedNodeIds}
         width={dimensions.width}
         height={dimensions.height}
+      />
+
+      {/* ── Chat Box (no Add / Share buttons) ── */}
+      <ChatBox
+        onHighlight={setHighlightedNodeIds}
+        messages={chatMessages}
+        onMessagesChange={setChatMessages}
+        placeholder={`Query ${personName}'s orb...`}
+        searchFn={searchFn}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add ChatBox (search bar) to SharedOrbPage so viewers can query the shared orb — without Add/Share buttons
- Add public text search endpoint (`POST /search/text/public`) that requires no authentication and respects `filter_token` privacy by excluding filtered nodes from results
- Remove all filter UI, indicators, and "Filtered view" labels from the shared orb page so external users cannot infer what the owner has hidden

Closes #40

## Test plan
- [ ] Open a shared orb link (e.g. `/alessandro-berti`) — search bar appears at the bottom, no filter button or indicator visible
- [ ] Search for a term — matching nodes are highlighted in the graph
- [ ] Open a filtered shared link (`?filter_token=...`) — filtered nodes are absent from the graph and not discoverable via the search bar
- [ ] Verify no UI element reveals that data has been filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)