### PR TITLE
Add Claude Code CLI as alternative LLM provider

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     llmwhisperer_api_url: str = "https://llmwhisperer-api.eu-west.unstract.com/api/v2"
     llmwhisperer_api_key: str = ""
 
+    # LLM provider: "ollama" (local) or "claude" (Claude Code CLI subscription)
+    llm_provider: str = "ollama"
+    claude_model: str = "claude-opus-4-6"
+
     # Ollama (local LLM)
     ollama_base_url: str = "http://localhost:11434"
     ollama_model: str = "llama3.2:3b"
@@ -37,7 +41,7 @@ class Settings(BaseSettings):
     frontend_url: str = "http://localhost:5173"
     backend_url: str = "http://localhost:8000"
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    model_config = {"env_file": ["../.env", ".env"], "env_file_encoding": "utf-8"}
 
 
 settings = Settings()

--- a/backend/app/cv/claude_classifier.py
+++ b/backend/app/cv/claude_classifier.py
@@ -1,0 +1,53 @@
+"""Classify CV entries using Claude Code CLI (subscription-based, no API key needed)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def call_claude(
+    system_prompt: str,
+    user_message: str,
+    model: str | None = None,
+) -> str:
+    """Call Claude Code CLI in print mode and return the response text.
+
+    Uses the ``claude -p`` non-interactive mode which leverages the user's
+    Claude subscription (no API key required).
+    """
+    cmd = ["claude", "-p", "--output-format", "json"]
+
+    if model:
+        cmd.extend(["--model", model])
+
+    cmd.extend(["--system-prompt", system_prompt])
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate(input=user_message.encode("utf-8"))
+
+    if process.returncode != 0:
+        error_msg = stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"Claude CLI exited with code {process.returncode}: {error_msg}"
+        )
+
+    output = stdout.decode("utf-8").strip()
+
+    # --output-format json wraps the result in a JSON envelope
+    # with fields like: result, cost_usd, duration_ms, etc.
+    try:
+        envelope = json.loads(output)
+        return envelope.get("result", "")
+    except json.JSONDecodeError:
+        # If not a JSON envelope, return raw output
+        return output

--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -104,20 +104,39 @@ async def classify_entries(
 
 Parse every entry in this CV into structured nodes. Return JSON with "nodes" and "unmatched" arrays."""
 
+    provider = settings.llm_provider
+
     for attempt in range(MAX_RETRIES):
         try:
-            result = await _call_ollama(user_message)
+            if provider == "claude":
+                from app.cv.claude_classifier import call_claude
+
+                result = await call_claude(
+                    system_prompt=SYSTEM_PROMPT,
+                    user_message=user_message,
+                    model=settings.claude_model or None,
+                )
+            else:
+                result = await _call_ollama(user_message)
+
             nodes, unmatched = _parse_result(result)
             if nodes or unmatched:
                 return nodes, unmatched
-            logger.warning("Ollama returned empty result, attempt %d", attempt + 1)
+            logger.warning(
+                "%s returned empty result, attempt %d", provider, attempt + 1
+            )
         except Exception as e:
             logger.warning(
-                "Ollama classification attempt %d failed: %s", attempt + 1, e
+                "%s classification attempt %d failed: %s",
+                provider,
+                attempt + 1,
+                e,
             )
 
     # Final fallback: return everything as unmatched
-    logger.error("All Ollama classification attempts failed — returning as unmatched")
+    logger.error(
+        "All %s classification attempts failed — returning as unmatched", provider
+    )
     fallback_lines = [
         line.strip()
         for line in raw_text.split("\n")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -861,9 +861,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -881,9 +878,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,9 +895,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -921,9 +912,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,9 +929,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -961,9 +946,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,9 +1189,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1231,9 +1210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1255,9 +1231,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1279,9 +1252,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1454,9 +1424,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1474,9 +1441,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1494,9 +1458,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,9 +1475,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3751,9 +3709,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3775,9 +3730,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3799,9 +3751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3823,9 +3772,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION

- Add `claude_classifier.py` that spawns `claude -p` (print mode) as a subprocess, passing the system prompt via `--system-prompt` and CV text via stdin
- Extend `classify_entries()` in `ollama_classifier.py` to dispatch to either Ollama or Claude based on `settings.llm_provider`
- Add `LLM_PROVIDER` and `CLAUDE_MODEL` settings to `config.py`

## How it works

The Claude CLI is invoked in non-interactive print mode with `--output-format json`. The JSON envelope returned by the CLI contains a `result` field with the model's response, which is then parsed by the same `_parse_result()` used for Ollama.

**Prerequisites:** `claude` CLI installed and logged in with an active subscription.

## Test plan

- [x] Verified `classify_entries()` works with `LLM_PROVIDER=claude` using a sample CV
- [x] Verified `classify_entries()` works with a real PDF CV (34 nodes extracted correctly)

Resolves #44
