### PR TITLE
Fix dev login to use seeded Alessandro graph

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -75,7 +75,7 @@ async def dev_login(
     db: AsyncDriver = Depends(get_db),
 ):
     """Dev-only login that creates a test user without Google OAuth."""
-    user_id = "dev-user-001"
+    user_id = "seed-alessandro-berti"
     email = "dev@orbis.local"
     name = "Alessandro Berti"
 
@@ -89,7 +89,7 @@ async def dev_login(
                 user_id=user_id,
                 email=encrypt_value(email),
                 name=name,
-                orb_id="alessandro-berti",
+                orb_id="alessandro",
             )
             await send_welcome_message(db, user_id)
 


### PR DESCRIPTION
## Summary
- Updated dev-login endpoint to use `seed-alessandro-berti` user_id and `alessandro` orb_id instead of the previous `dev-user-001` / `alessandro-berti`
- Dev environment now loads the rich seeded knowledge graph instead of an empty one

## Test plan
- [x] Log out and log back in via dev-login
- [x] Verify `/orb` page shows the full seeded graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)