### PR TITLE
Add CV template export with editable preview [D5]

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-    <title>Orbis</title>
+    <title>OpenOrbis</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
         "@react-three/postprocessing": "^3.0.4",
         "axios": "^1.13.6",
         "framer-motion": "^12.38.0",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.2.1",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -1616,6 +1618,19 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1665,6 +1680,13 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~1.0.1"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
@@ -2138,6 +2160,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2306,6 +2337,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2382,6 +2433,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -2412,6 +2475,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2643,6 +2715,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/draco3d": {
@@ -2958,6 +3040,17 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3317,6 +3410,19 @@
       "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
       "license": "Apache-2.0"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3388,6 +3494,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3519,6 +3631,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/kapsule": {
@@ -4118,6 +4247,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4149,6 +4284,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4292,6 +4434,16 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -4421,6 +4573,13 @@
         }
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4438,6 +4597,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -4534,6 +4703,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stats-gl": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
@@ -4595,6 +4774,16 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -4614,6 +4803,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/three": {
@@ -4921,6 +5119,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,8 @@
     "@react-three/postprocessing": "^3.0.4",
     "axios": "^1.13.6",
     "framer-motion": "^12.38.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/public/template_cv.html
+++ b/frontend/public/template_cv.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FIRST LAST - Complete Google Style Resume</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        /* Material Design 3 (Material You) Violet Baseline Palette */
+        :root {
+            --md-primary: #6750A4;
+            --md-on-primary: #FFFFFF;
+            --md-primary-container: #EADDFF;
+            --md-on-primary-container: #21005D;
+            --md-surface: #FEF7FF;
+            --md-on-surface: #1D1B20;
+            --md-surface-variant: #E7E0EC;
+            --md-on-surface-variant: #49454F;
+            --md-bg: #F3EDF7;
+            --md-outline-variant: #CAC4D0;
+        }
+
+        body {
+            font-family: 'Roboto', sans-serif;
+            background-color: var(--md-bg);
+            color: var(--md-on-surface);
+            line-height: 1.5;
+            margin: 0;
+            padding: 32px 20px; /* Reduced outer padding */
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        /* Google M3 Elevated Card */
+        .resume-container {
+            background-color: var(--md-surface);
+            max-width: 850px;
+            width: 100%;
+            padding: 48px; /* Reduced from 56px */
+            border-radius: 28px;
+            box-shadow: 0 4px 8px 3px rgba(0, 0, 0, 0.05), 0 1px 3px rgba(0, 0, 0, 0.1);
+            box-sizing: border-box;
+        }
+
+        /* Header / Identity Area */
+        header {
+            background-color: var(--md-primary-container);
+            color: var(--md-on-primary-container);
+            padding: 24px; /* Reduced from 32px */
+            border-radius: 20px;
+            margin-bottom: 24px; /* Reduced from 40px */
+        }
+
+        h1 {
+            font-size: 2.5rem; /* Slightly smaller */
+            margin: 0 0 4px 0;
+            font-weight: 700;
+            letter-spacing: -0.25px;
+        }
+
+        h2.title {
+            font-size: 1.15rem;
+            margin: 0 0 12px 0; /* Reduced from 16px */
+            font-weight: 500;
+            opacity: 0.9;
+        }
+
+        .contact-info {
+            font-size: 0.95rem;
+            font-weight: 500;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .contact-info span {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .contact-info a {
+            color: var(--md-on-primary-container);
+            text-decoration: none;
+            padding: 4px 8px; /* Tighter padding */
+            margin-left: -4px;
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        /* Typography & Spacing */
+        section {
+            margin-bottom: 24px; /* Reduced from 40px */
+        }
+
+        h3.section-title {
+            color: var(--md-primary);
+            font-size: 1.15rem;
+            font-weight: 500;
+            margin: 0 0 16px 0; /* Reduced from 24px */
+            padding-bottom: 8px; /* Reduced from 12px */
+            border-bottom: 1px solid var(--md-outline-variant);
+            display: flex;
+            align-items: center;
+        }
+
+        .item {
+            margin-bottom: 16px; /* Reduced from 28px */
+        }
+
+        .item:last-child {
+            margin-bottom: 0;
+        }
+
+        .item-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 2px; /* Tighter gap */
+        }
+
+        .item-title {
+            font-size: 1.05rem;
+            font-weight: 700;
+            color: var(--md-primary); 
+            margin: 0;
+        }
+
+        .item-subtitle {
+            color: var(--md-on-surface);
+            font-weight: 600;
+            font-size: 0.95rem;
+            margin: 0 0 6px 0; /* Reduced from 12px */
+            font-style: italic;
+        }
+
+        .item-date {
+            color: var(--md-on-surface-variant);
+            font-size: 0.85rem;
+            font-weight: 500;
+            white-space: nowrap;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 20px;
+            color: var(--md-on-surface-variant);
+        }
+
+        li {
+            margin-bottom: 4px; /* Reduced from 8px */
+            font-size: 0.95rem;
+        }
+
+        .link-button {
+            color: var(--md-primary);
+            text-decoration: none;
+            font-weight: 500;
+            margin-left: 8px;
+            font-size: 0.85rem;
+        }
+
+        /* Google M3 Filter Chips */
+        .skills-category {
+            margin-bottom: 12px; /* Reduced from 20px */
+        }
+
+        .skills-category:last-child {
+            margin-bottom: 0;
+        }
+
+        .skills-category strong {
+            display: block;
+            margin-bottom: 8px; /* Reduced from 12px */
+            color: var(--md-on-surface-variant);
+            font-weight: 500;
+            font-size: 0.95rem;
+        }
+
+        .chip-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px; /* Tighter gap */
+        }
+
+        .chip {
+            background-color: var(--md-surface-variant);
+            color: var(--md-on-surface-variant);
+            padding: 4px 12px; /* Tighter padding */
+            border-radius: 6px;
+            font-size: 0.85rem;
+            font-weight: 500;
+            border: 1px solid rgba(0,0,0,0);
+        }
+
+        /* Footer */
+        footer {
+            width: 100%;
+            max-width: 850px;
+            margin-top: 16px;
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            align-items: center;
+            color: #9E9E9E;
+            font-size: 0.85rem;
+            font-weight: 500;
+        }
+
+        .footer-center {
+            grid-column: 2;
+            text-align: center;
+        }
+
+        .footer-right {
+            grid-column: 3;
+            text-align: right;
+        }
+
+        /* Responsive Design */
+        @media (max-width: 600px) {
+            .resume-container {
+                padding: 24px 16px;
+                border-radius: 16px;
+            }
+            header {
+                padding: 20px;
+            }
+            h1 {
+                font-size: 2rem;
+            }
+            .item-header {
+                flex-direction: column;
+            }
+            .item-date {
+                margin-top: 2px;
+                margin-bottom: 6px;
+            }
+            footer {
+                grid-template-columns: 1fr;
+                gap: 8px;
+                text-align: center;
+            }
+            .footer-center, .footer-right {
+                grid-column: 1;
+                text-align: center;
+            }
+        }
+
+        /* --- PRINT STYLES FOR PDF EXPORT --- */
+        @media print {
+            * {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+            body {
+                background-color: #FFFFFF;
+                padding: 0;
+                display: block;
+            }
+            .resume-container {
+                box-shadow: none;
+                padding: 0;
+                margin: 0;
+                max-width: 100%;
+            }
+            header {
+                background-color: transparent;
+                color: var(--md-on-surface);
+                padding: 0 0 16px 0;
+                border-bottom: 2px solid var(--md-primary);
+                border-radius: 0;
+            }
+            .contact-info a, .contact-info span {
+                color: var(--md-on-surface);
+                padding: 0;
+                margin: 0;
+            }
+            .item, section {
+                page-break-inside: avoid;
+            }
+            footer {
+                display: flex;
+                justify-content: space-between;
+                margin-top: 24px;
+            }
+            .footer-center {
+                flex-grow: 1;
+            }
+        }
+    </style>
+</head>
+<body>
+
+<div class="resume-container">
+    <header>
+        <h1>FIRST LAST</h1>
+        <h2 class="title">Software Engineer</h2>
+        <div class="contact-info">
+            <span><i class="fas fa-envelope"></i> first.last@email.com</span>
+            <span>|</span>
+            <a href="https://www.example.com"><i class="fas fa-globe"></i> Portfolio</a>
+            <a href="https://github.com/github-username"><i class="fab fa-github"></i> github-username</a>
+            <a href="https://linkedin.com/in/linkedin-username"><i class="fab fa-linkedin"></i> linkedin-username</a>
+        </div>
+    </header>
+
+    <section>
+        <h3 class="section-title">Experience</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Job Title</h4>
+                <span class="item-date">Mon YYYY - Present</span>
+            </div>
+            <p class="item-subtitle">Company Name — City, Country</p>
+            <ul>
+                <li>Accomplished [X] by implementing [Y], which led to [Z measurable impact].</li>
+                <li>Built [system/feature] serving [N] users using [technologies], reducing [metric] by [N]%.</li>
+                <li>Led [N]-person team to deliver [project] on time, increasing [KPI] by [N]%.</li>
+            </ul>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Education</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Degree in Field of Study</h4>
+                <span class="item-date">YYYY</span>
+            </div>
+            <p class="item-subtitle">Institution Name — City, Country</p>
+            <ul>
+                <li>Relevant Coursework: Course A, Course B, Course C.</li>
+            </ul>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Projects</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Project Name 
+                    <a href="#" class="link-button"><i class="fab fa-github"></i> [code]</a> 
+                    <a href="#" class="link-button"><i class="fas fa-external-link-alt"></i> [demo]</a>
+                </h4>
+            </div>
+            <p class="item-subtitle">Role/Context</p>
+            <ul>
+                <li>Brief description of what the project does and the problem it solves.</li>
+                <li>Built with [Language A], [Framework B], [Tool C]. Deployed on [Platform].</li>
+            </ul>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Publications</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Title of the Research Paper or Article</h4>
+                <span class="item-date">Month YYYY</span>
+            </div>
+            <p class="item-subtitle">Journal / Conference Name</p>
+            <ul>
+                <li>Briefly detail your contribution or the core findings of the paper.</li>
+            </ul>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Patents</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Title of the Patent</h4>
+                <span class="item-date">Issued: YYYY</span>
+            </div>
+            <p class="item-subtitle">Patent Number: US-XXXXXXX-X</p>
+            <ul>
+                <li>Summary of the patented technology and its primary application.</li>
+            </ul>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Certifications</h3>
+        <div class="item">
+            <div class="item-header">
+                <h4 class="item-title">Name of Certification</h4>
+                <span class="item-date">YYYY</span>
+            </div>
+            <p class="item-subtitle">Issuing Organization</p>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Achievements</h3>
+        <ul>
+            <li><strong>Award Name (YYYY):</strong> Brief description of the criteria and why you received this recognition.</li>
+            <li><strong>Hackathon Winner (YYYY):</strong> Placed 1st out of 50 teams at [Event Name] for building [App Name].</li>
+        </ul>
+    </section>
+
+    <section>
+        <h3 class="section-title">Skills</h3>
+        <div class="skills-category">
+            <strong>Languages</strong>
+            <div class="chip-container">
+                <span class="chip">Python</span>
+                <span class="chip">Java</span>
+                <span class="chip">TypeScript</span>
+                <span class="chip">C++</span>
+            </div>
+        </div>
+        <div class="skills-category">
+            <strong>Frameworks & Tools</strong>
+            <div class="chip-container">
+                <span class="chip">React</span>
+                <span class="chip">AWS</span>
+                <span class="chip">Docker</span>
+                <span class="chip">Git</span>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h3 class="section-title">Languages</h3>
+        <div class="chip-container">
+            <span class="chip">English (Native)</span>
+            <span class="chip">Spanish (Professional Working)</span>
+            <span class="chip">Italian (Conversational)</span>
+        </div>
+    </section>
+</div>
+
+<footer>
+    <div></div>
+    <div class="footer-center">Made with love by OpenOrbis ❤️</div>
+    <div class="footer-right">April 1, 2026</div>
+</footer>
+
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import CreateOrbPage from './pages/CreateOrbPage';
 import AboutPage from './pages/AboutPage';
 import OrbViewPage from './pages/OrbViewPage';
 import SharedOrbPage from './pages/SharedOrbPage';
+import CvExportPage from './pages/CvExportPage';
 import ToastContainer from './components/ToastContainer';
 
 const pageVariants = {
@@ -46,6 +47,7 @@ function AnimatedRoutes() {
         <Route path="/create" element={<PageWrapper><CreateOrbPage /></PageWrapper>} />
         {/* <Route path="/review" element={<PageWrapper><ReviewPage /></PageWrapper>} /> */}
         <Route path="/orb" element={<PageWrapper><OrbViewPage /></PageWrapper>} />
+        <Route path="/cv-export" element={<CvExportPage />} />
         <Route path="/:orbId" element={<PageWrapper><SharedOrbPage /></PageWrapper>} />
       </Routes>
     </AnimatePresence>

--- a/frontend/src/components/graph/NodeLegend.tsx
+++ b/frontend/src/components/graph/NodeLegend.tsx
@@ -30,7 +30,7 @@ export default function NodeLegend() {
   }, [open]);
 
   return (
-    <div ref={ref} className="absolute bottom-20 left-3 z-30 select-none">
+    <div ref={ref} className="absolute bottom-20 right-3 z-30 select-none">
       {open ? (
         <div className="bg-gray-900/90 backdrop-blur-sm border border-white/10 rounded-xl shadow-2xl p-3 w-48 animate-in fade-in slide-in-from-bottom-2 duration-200">
           <div className="flex items-center justify-between mb-2">

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -63,11 +63,15 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
   const filteredRef = useRef<Set<string>>(new Set());
   filteredRef.current = filteredNodeIds ?? new Set();
 
-  // Clear cache when data changes
+  // Clear cache when data changes & zoom to fit
   useEffect(() => {
     nodeObjectCacheRef.current.clear();
     orbitRing1Ref.current = null;
     orbitRing2Ref.current = null;
+    // Start camera closer to the graph
+    if (fgRef.current) {
+      fgRef.current.cameraPosition({ x: 0, y: 0, z: 400 });
+    }
   }, [data]);
 
   const graphData = useMemo(() => {

--- a/frontend/src/components/inbox/Inbox.tsx
+++ b/frontend/src/components/inbox/Inbox.tsx
@@ -20,7 +20,7 @@ const DEMO_MESSAGES: Message[] = [
     sender_name: 'Sarah Chen',
     sender_email: 'sarah.chen@talentscout.ai',
     subject: 'Impressed by your graph — Senior Engineer role at Nexus',
-    body: "Hi there,\n\nI came across your Orbis profile through our AI sourcing pipeline. Your knowledge graph is really impressive — the way your skills connect to your projects tells a much richer story than a traditional CV.\n\nWe have a Senior Engineer position at Nexus that aligns well with your background, particularly your experience with graph databases and distributed systems.\n\nWould you be open to a quick chat this week?\n\nBest,\nSarah Chen\nTalent Partner @ Nexus",
+    body: "Hi there,\n\nI came across your OpenOrbis profile through our AI sourcing pipeline. Your knowledge graph is really impressive — the way your skills connect to your projects tells a much richer story than a traditional CV.\n\nWe have a Senior Engineer position at Nexus that aligns well with your background, particularly your experience with graph databases and distributed systems.\n\nWould you be open to a quick chat this week?\n\nBest,\nSarah Chen\nTalent Partner @ Nexus",
     created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
     read: false,
     replies: [],

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -20,7 +20,7 @@ const FEATURES = [
   },
   {
     title: 'Connected network',
-    description: 'When collaborators join Orbis, your orbs link together — forming a professional knowledge graph that recruiters can explore.',
+    description: 'When collaborators join OpenOrbis, your orbs link together — forming a professional knowledge graph that recruiters can explore.',
   },
 ];
 

--- a/frontend/src/pages/CvExportPage.tsx
+++ b/frontend/src/pages/CvExportPage.tsx
@@ -1,0 +1,1306 @@
+import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { getMyOrb } from '../api/orbs';
+import type { OrbData, OrbNode } from '../api/orbs';
+import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
+
+/* ── Helpers ── */
+
+function parseDateSort(v: unknown): number {
+  if (!v || typeof v !== 'string') return 0;
+  if (v.toLowerCase() === 'present') return Date.now();
+  const parts = v.split('/');
+  if (parts.length === 2) return new Date(Number(parts[1]), Number(parts[0]) - 1).getTime();
+  return 0;
+}
+
+function sortDesc(nodes: OrbNode[], field: string): OrbNode[] {
+  return [...nodes].sort((a, b) => parseDateSort(b[field]) - parseDateSort(a[field]));
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+/* ── PDF pagination constants ── */
+const A4_W = 210;
+const A4_H = 297;
+const M_X = 8;
+const M_TOP = 8;
+const FOOTER_H = 8;
+const USABLE_W = A4_W - 2 * M_X;   // 194mm
+const USABLE_H = A4_H - M_TOP - FOOTER_H; // 281mm
+
+/** Collect atomic blocks from the container — items that should not be split across pages. */
+function collectBlocks(container: HTMLElement): { top: number; height: number }[] {
+  const blocks: { top: number; height: number }[] = [];
+  const cTop = container.getBoundingClientRect().top;
+
+  const add = (el: Element) => {
+    const r = el.getBoundingClientRect();
+    blocks.push({ top: r.top - cTop, height: r.height });
+  };
+
+  // Header as one block
+  const header = container.querySelector('header');
+  if (header) add(header);
+
+  for (const section of container.querySelectorAll('section')) {
+    const h3 = section.querySelector(':scope > h3');
+    const items = section.querySelectorAll(':scope > .item');
+    const cats = section.querySelectorAll(':scope > .skills-category');
+    const directChips = section.querySelector(':scope > .chip-container');
+
+    if (items.length > 0) {
+      // Keep section title glued to first item
+      if (h3 && items[0]) {
+        const h3r = h3.getBoundingClientRect();
+        const ir = items[0].getBoundingClientRect();
+        blocks.push({ top: h3r.top - cTop, height: ir.bottom - h3r.top });
+      }
+      for (let i = 1; i < items.length; i++) add(items[i]);
+    } else if (cats.length > 0) {
+      if (h3 && cats[0]) {
+        const h3r = h3.getBoundingClientRect();
+        const cr = cats[0].getBoundingClientRect();
+        blocks.push({ top: h3r.top - cTop, height: cr.bottom - h3r.top });
+      }
+      for (let i = 1; i < cats.length; i++) add(cats[i]);
+    } else if (directChips || h3) {
+      add(section);
+    }
+  }
+  return blocks.sort((a, b) => a.top - b.top);
+}
+
+/** Given sorted blocks and a page height, return Y positions where new pages begin. */
+function computePageBreaks(
+  blocks: { top: number; height: number }[],
+  pageH: number,
+  startY: number,
+): number[] {
+  const breaks: number[] = [];
+  let pageBottom = startY + pageH;
+
+  for (const block of blocks) {
+    const blockBottom = block.top + block.height;
+    if (blockBottom > pageBottom) {
+      if (block.top > startY && block.top > (breaks[breaks.length - 1] ?? startY)) {
+        breaks.push(block.top);
+        pageBottom = block.top + pageH;
+      }
+      while (blockBottom > pageBottom) pageBottom += pageH;
+    }
+  }
+  return breaks;
+}
+
+function hexToHsl(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+  }
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+}
+
+/* ── Section types ── */
+
+type SectionKey = 'experience' | 'education' | 'projects' | 'publications' | 'patents' | 'certifications' | 'skills' | 'languages';
+
+const DEFAULT_ORDER: SectionKey[] = [
+  'experience', 'education', 'projects', 'publications',
+  'patents', 'certifications', 'skills', 'languages',
+];
+
+const SECTION_LABELS: Record<SectionKey, string> = {
+  experience: 'Experience',
+  education: 'Education',
+  projects: 'Projects',
+  publications: 'Publications',
+  patents: 'Patents',
+  certifications: 'Certifications',
+  skills: 'Skills',
+  languages: 'Languages',
+};
+
+/* ── Component ── */
+
+export default function CvExportPage() {
+  const [data, setData] = useState<OrbData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { activeKeywords } = useFilterStore();
+  const cvRef = useRef<HTMLDivElement>(null);
+
+  /* Section order + drag state */
+  const [sectionOrder, setSectionOrder] = useState<SectionKey[]>(DEFAULT_ORDER);
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [overIdx, setOverIdx] = useState<number | null>(null);
+
+  /* Hidden entries + undo stack */
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set());
+  const [undoStack, setUndoStack] = useState<string[]>([]);
+
+  /* Entry links */
+  const [entryLinks, setEntryLinks] = useState<Record<string, string>>({});
+  const addLink = (uid: string) => {
+    const current = entryLinks[uid] || '';
+    const url = prompt('Enter URL for this entry:', current);
+    if (url === null) return; // cancelled
+    setEntryLinks((prev) => {
+      const next = { ...prev };
+      if (url) next[uid] = url; else delete next[uid];
+      return next;
+    });
+  };
+
+  const removeEntry = (key: string) => {
+    setHiddenKeys((prev) => new Set(prev).add(key));
+    setUndoStack((prev) => [...prev, key]);
+  };
+
+  const undo = useCallback(() => {
+    setUndoStack((prev) => {
+      if (prev.length === 0) return prev;
+      const key = prev[prev.length - 1];
+      setHiddenKeys((hk) => {
+        const next = new Set(hk);
+        next.delete(key);
+        return next;
+      });
+      return prev.slice(0, -1);
+    });
+  }, []);
+
+  /* ── Visual page-break indicators ── */
+  const [pageBreaks, setPageBreaks] = useState<number[]>([]);
+
+  useEffect(() => {
+    const el = cvRef.current;
+    if (!el || !data) return;
+
+    const update = () => {
+      const containerW = el.clientWidth;
+      const pxPerMm = containerW / USABLE_W;
+      const pageH = USABLE_H * pxPerMm;
+
+      const blocks = collectBlocks(el);
+      if (blocks.length === 0) { setPageBreaks([]); return; }
+      const contentStart = blocks[0].top;
+      const breaks = computePageBreaks(blocks, pageH, contentStart);
+      setPageBreaks(breaks);
+    };
+
+    const t = setTimeout(update, 120);
+    window.addEventListener('resize', update);
+    return () => { clearTimeout(t); window.removeEventListener('resize', update); };
+  }, [data, hiddenKeys, sectionOrder]);
+
+  /* ── PDF export (native print → selectable text + clickable links) ── */
+  const handleDownloadPdf = useCallback(() => {
+    const personName = (data?.person?.name as string) || 'CV';
+    const prev = document.title;
+    document.title = `${personName} CV by OpenOrbis`;
+    window.print();
+    document.title = prev;
+  }, [data]);
+
+  /* Accent color */
+  const [accentColor, setAccentColor] = useState('#6750A4');
+
+  useEffect(() => {
+    const [h, s] = hexToHsl(accentColor);
+    const root = document.documentElement;
+    root.style.setProperty('--md-primary', accentColor);
+    root.style.setProperty('--md-primary-container', `hsl(${h}, ${Math.min(s, 40)}%, 90%)`);
+    root.style.setProperty('--md-on-primary-container', `hsl(${h}, ${s}%, 15%)`);
+    return () => {
+      root.style.removeProperty('--md-primary');
+      root.style.removeProperty('--md-primary-container');
+      root.style.removeProperty('--md-on-primary-container');
+    };
+  }, [accentColor]);
+
+  /* Global Ctrl+Z for undo deletions (when not editing text) */
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+        const active = document.activeElement;
+        if (active && (active as HTMLElement).isContentEditable) return; // let browser handle text undo
+        e.preventDefault();
+        undo();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo]);
+
+  /* Fetch orb data */
+  useEffect(() => {
+    getMyOrb()
+      .then((d) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  /* Inject Google Fonts & Font Awesome */
+  useEffect(() => {
+    const links: HTMLLinkElement[] = [];
+    const add = (href: string) => {
+      const el = document.createElement('link');
+      el.rel = 'stylesheet';
+      el.href = href;
+      document.head.appendChild(el);
+      links.push(el);
+    };
+    add('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+    add('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css');
+    return () => links.forEach((l) => document.head.removeChild(l));
+  }, []);
+
+  /* Override body class while this page is mounted */
+  useEffect(() => {
+    document.body.classList.add('cv-export-active');
+    return () => document.body.classList.remove('cv-export-active');
+  }, []);
+
+  /* Page title → becomes default PDF filename */
+  useEffect(() => {
+    if (data?.person?.name) document.title = `${str(data.person.name)} — CV`;
+  }, [data]);
+
+  /* ── Filtering ── */
+  const filteredIds = useMemo(() => {
+    if (!data) return new Set<string>();
+    return computeFilteredNodeIds(data.nodes, activeKeywords);
+  }, [data, activeKeywords]);
+
+  const visible = useCallback((label: string) =>
+    data?.nodes.filter((n) => n._labels.includes(label) && !filteredIds.has(n.uid) && !hiddenKeys.has(n.uid)) ?? [],
+  [data, filteredIds, hiddenKeys]);
+
+  /* ── Loading / error states ── */
+  if (loading)
+    return (
+      <>
+        <style>{CV_CSS}</style>
+        <div className="cv-loading">Loading CV…</div>
+      </>
+    );
+  if (!data)
+    return (
+      <>
+        <style>{CV_CSS}</style>
+        <div className="cv-loading">Failed to load orb data.</div>
+      </>
+    );
+
+  /* ── Prepare data ── */
+  const p = data.person;
+  const experience = sortDesc(visible('WorkExperience'), 'start_date');
+  const education = sortDesc(visible('Education'), 'start_date');
+  const projects = visible('Project');
+  const publications = visible('Publication');
+  const patents = visible('Patent');
+  const certifications = sortDesc(visible('Certification'), 'date');
+  const skills = visible('Skill');
+  const languages = visible('Language');
+
+  /* Which sections have data */
+  const hasData: Record<SectionKey, boolean> = {
+    experience: experience.length > 0,
+    education: education.length > 0,
+    projects: projects.length > 0,
+    publications: publications.length > 0,
+    patents: patents.length > 0,
+    certifications: certifications.length > 0,
+    skills: skills.length > 0,
+    languages: languages.length > 0,
+  };
+
+  const visibleSections = sectionOrder.filter((k) => hasData[k]);
+
+  /* ── Drag handlers ── */
+  const handleDragStart = (visIdx: number) => setDragIdx(visIdx);
+
+  const handleDragOver = (e: React.DragEvent, visIdx: number) => {
+    e.preventDefault();
+    setOverIdx(visIdx);
+  };
+
+  const handleDrop = () => {
+    if (dragIdx !== null && overIdx !== null && dragIdx !== overIdx) {
+      const fromKey = visibleSections[dragIdx];
+      const toKey = visibleSections[overIdx];
+      setSectionOrder((prev) => {
+        const next = [...prev];
+        const fromFull = next.indexOf(fromKey);
+        const toFull = next.indexOf(toKey);
+        next.splice(fromFull, 1);
+        next.splice(toFull, 0, fromKey);
+        return next;
+      });
+    }
+    setDragIdx(null);
+    setOverIdx(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragIdx(null);
+    setOverIdx(null);
+  };
+
+  /* Group skills by category (fallback: single group) */
+  const skillGroups: Record<string, OrbNode[]> = {};
+  for (const sk of skills) {
+    const cat = str(sk.category) || 'Skills';
+    (skillGroups[cat] ??= []).push(sk);
+  }
+
+  /* Contact links */
+  const contacts = [
+    p.email && { icon: 'fas fa-envelope', text: str(p.email) },
+    p.website_url && { icon: 'fas fa-globe', href: str(p.website_url), text: 'Website' },
+    p.scholar_url && { icon: 'fas fa-graduation-cap', href: str(p.scholar_url), text: 'Scholar' },
+    p.github_url && { icon: 'fab fa-github', href: str(p.github_url), text: 'GitHub' },
+    p.linkedin_url && { icon: 'fab fa-linkedin', href: str(p.linkedin_url), text: 'LinkedIn' },
+    p.twitter_url && { icon: 'fab fa-twitter', href: str(p.twitter_url), text: 'Twitter' },
+  ].filter(Boolean) as { icon: string; href?: string; text: string }[];
+
+  const visibleContacts = contacts.filter((_, i) => !hiddenKeys.has(`contact-${i}`));
+
+  const today = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+
+  /* ── Delete button for block items (positioned on right gutter) ── */
+  const DeleteBtn = ({ id }: { id: string }) => (
+    <button className="item-delete no-print" onClick={() => removeEntry(id)} title="Remove from CV">
+      <i className="fas fa-times" />
+    </button>
+  );
+
+  const LinkBtn = ({ id }: { id: string }) => (
+    <button className="item-add-link no-print" onClick={() => addLink(id)} title="Add link">
+      <i className="fas fa-link" />
+    </button>
+  );
+
+  const EntryLink = ({ id }: { id: string }) =>
+    entryLinks[id] ? (
+      <a href={entryLinks[id]} target="_blank" rel="noreferrer" className="item-link">
+        <i className="fas fa-external-link-alt" />
+      </a>
+    ) : null;
+
+  /* ── Section renderer ── */
+  const renderSection = (key: SectionKey): JSX.Element | null => {
+    switch (key) {
+      case 'experience':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Experience</h3>
+            {experience.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.title)}</h4>
+                  <EntryLink id={n.uid} />
+                  <span className="item-date" contentEditable suppressContentEditableWarning>
+                    {str(n.start_date)} — {str(n.end_date)}
+                  </span>
+                </div>
+                <p className="item-subtitle" contentEditable suppressContentEditableWarning>
+                  {str(n.company)}{n.location ? ` — ${str(n.location)}` : ''}
+                </p>
+                {n.description && (
+                  <ul contentEditable suppressContentEditableWarning>
+                    <li>{str(n.description)}</li>
+                  </ul>
+                )}
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'education':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Education</h3>
+            {education.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.degree)}</h4>
+                  <EntryLink id={n.uid} />
+                  <span className="item-date" contentEditable suppressContentEditableWarning>
+                    {str(n.start_date)} — {str(n.end_date)}
+                  </span>
+                </div>
+                <p className="item-subtitle" contentEditable suppressContentEditableWarning>
+                  {str(n.institution)}{n.location ? ` — ${str(n.location)}` : ''}
+                </p>
+                {n.description && (
+                  <ul contentEditable suppressContentEditableWarning>
+                    <li>{str(n.description)}</li>
+                  </ul>
+                )}
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'projects':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Projects</h3>
+            {projects.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.name)}</h4>
+                  <EntryLink id={n.uid} />
+                </div>
+                {n.role && (
+                  <p className="item-subtitle" contentEditable suppressContentEditableWarning>{str(n.role)}</p>
+                )}
+                {n.description && (
+                  <ul contentEditable suppressContentEditableWarning>
+                    <li>{str(n.description)}</li>
+                  </ul>
+                )}
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'publications':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Publications</h3>
+            {publications.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.title)}</h4>
+                  <EntryLink id={n.uid} />
+                </div>
+                <p className="item-subtitle" contentEditable suppressContentEditableWarning>{str(n.venue)}</p>
+                {n.description && (
+                  <ul contentEditable suppressContentEditableWarning>
+                    <li>{str(n.description)}</li>
+                  </ul>
+                )}
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'patents':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Patents</h3>
+            {patents.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.name)}</h4>
+                  <EntryLink id={n.uid} />
+                </div>
+                {n.patent_number && (
+                  <p className="item-subtitle" contentEditable suppressContentEditableWarning>
+                    Patent Number: {str(n.patent_number)}
+                  </p>
+                )}
+                {n.description && (
+                  <ul contentEditable suppressContentEditableWarning>
+                    <li>{str(n.description)}</li>
+                  </ul>
+                )}
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'certifications':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Certifications</h3>
+            {certifications.map((n) => (
+              <div key={n.uid} className="item">
+                <DeleteBtn id={n.uid} />
+                <LinkBtn id={n.uid} />
+                <div className="item-header">
+                  <h4 className="item-title" contentEditable suppressContentEditableWarning>{str(n.name)}</h4>
+                  <EntryLink id={n.uid} />
+                  <span className="item-date" contentEditable suppressContentEditableWarning>{str(n.date)}</span>
+                </div>
+                <p className="item-subtitle" contentEditable suppressContentEditableWarning>{str(n.issuing_organization)}</p>
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'skills':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Skills</h3>
+            {Object.entries(skillGroups).map(([cat, group]) => (
+              <div key={cat} className="skills-category">
+                <strong contentEditable suppressContentEditableWarning>{cat}</strong>
+                <div className="chip-container">
+                  {group.map((sk) => (
+                    <span key={sk.uid} className="chip">
+                      <span contentEditable suppressContentEditableWarning>{str(sk.name)}</span>
+                      <button className="chip-delete no-print" onClick={() => removeEntry(sk.uid)}>×</button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </section>
+        );
+
+      case 'languages':
+        return (
+          <section key={key}>
+            <h3 className="section-title">Languages</h3>
+            <div className="chip-container">
+              {languages.map((n) => (
+                <span key={n.uid} className="chip">
+                  <span contentEditable suppressContentEditableWarning>
+                    {str(n.name)}{n.proficiency ? ` (${str(n.proficiency)})` : ''}
+                  </span>
+                  <button className="chip-delete no-print" onClick={() => removeEntry(n.uid)}>×</button>
+                </span>
+              ))}
+            </div>
+          </section>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      <style>{CV_CSS}</style>
+
+      {/* ── Toolbar (hidden when printing) ── */}
+      <div className="cv-toolbar no-print">
+        <span className="cv-toolbar-hint">Click any text to edit · Drag sections to reorder · Save as PDF &amp; uncheck &quot;Headers and footers&quot;</span>
+
+        {/* Accent color picker */}
+        <label className="cv-color-picker">
+          <span className="cv-color-label">Accent</span>
+          <input
+            type="color"
+            value={accentColor}
+            onChange={(e) => setAccentColor(e.target.value)}
+          />
+          <span className="cv-color-swatch" style={{ background: accentColor }} />
+        </label>
+
+        {/* Undo button */}
+        <button
+          onClick={undo}
+          disabled={undoStack.length === 0}
+          className="cv-toolbar-btn cv-toolbar-undo"
+          title="Undo last deletion (Ctrl+Z)"
+        >
+          <i className="fas fa-undo" /> Undo
+        </button>
+
+        <button onClick={handleDownloadPdf} className="cv-toolbar-btn cv-toolbar-download">
+          <i className="fas fa-file-pdf" /> Download PDF
+        </button>
+      </div>
+
+      {/* ── Sidebar — section order (hidden when printing) ── */}
+      <div className="cv-sidebar no-print">
+        <div className="cv-sidebar-title">Section Order</div>
+        {visibleSections.map((key, idx) => (
+          <div
+            key={key}
+            className={
+              'cv-sidebar-item' +
+              (dragIdx === idx ? ' dragging' : '') +
+              (overIdx === idx && dragIdx !== idx ? ' drag-over' : '')
+            }
+            draggable
+            onDragStart={() => handleDragStart(idx)}
+            onDragOver={(e) => handleDragOver(e, idx)}
+            onDrop={handleDrop}
+            onDragEnd={handleDragEnd}
+          >
+            <i className="fas fa-grip-vertical cv-sidebar-grip" />
+            {SECTION_LABELS[key]}
+          </div>
+        ))}
+      </div>
+
+      {/* ── Print-only footer (repeats on every page via position:fixed) ── */}
+      <div className="cv-print-footer">
+        <span>Made with love by <img src="/favicon.svg" className="cv-footer-logo" alt="" />OpenOrbis</span>
+        <span>{today}</span>
+      </div>
+
+      {/* ── CV Body ── */}
+      <div className="cv-page-body">
+        <div ref={cvRef} className="resume-container">
+
+          {/* Header */}
+          <header>
+            <h1 contentEditable suppressContentEditableWarning>{str(p.name)}</h1>
+            <h2 className="title" contentEditable suppressContentEditableWarning>{str(p.headline)}</h2>
+            <div className="contact-info">
+              {visibleContacts.map((c, i) => {
+                const origIdx = contacts.indexOf(c);
+                return (
+                  <span key={origIdx} className="contact-entry">
+                    {i > 0 && <span className="contact-sep">|</span>}
+                    {c.href ? (
+                      <a href={c.href} target="_blank" rel="noreferrer">
+                        <i className={c.icon} />
+                        <span contentEditable suppressContentEditableWarning>{c.text}</span>
+                      </a>
+                    ) : (
+                      <span><i className={c.icon} /> <span contentEditable suppressContentEditableWarning>{c.text}</span></span>
+                    )}
+                    <button className="contact-delete no-print" onClick={() => removeEntry(`contact-${origIdx}`)}>×</button>
+                  </span>
+                );
+              })}
+            </div>
+          </header>
+
+          {/* Sections — rendered in user-defined order */}
+          {visibleSections.map((key) => renderSection(key))}
+
+          {/* Page break indicators */}
+          {pageBreaks.map((y, i) => (
+            <div key={i} className="page-break-line no-print" style={{ top: `${y}px` }}>
+              <span className="page-break-label">Page {i + 2}</span>
+            </div>
+          ))}
+
+        </div>
+
+        {/* On-screen footer */}
+        <footer className="no-print">
+          <div />
+          <div className="footer-center">Made with love by <img src="/favicon.svg" className="cv-footer-logo" alt="" />OpenOrbis</div>
+          <div className="footer-right" contentEditable suppressContentEditableWarning>{today}</div>
+        </footer>
+      </div>
+    </>
+  );
+}
+
+/* ══════════════════════════════════════════════════
+   CSS
+   ══════════════════════════════════════════════════ */
+
+const CV_CSS = `
+  /* Material Design 3 palette */
+  :root {
+    --md-primary: #6750A4;
+    --md-on-primary: #FFFFFF;
+    --md-primary-container: #EADDFF;
+    --md-on-primary-container: #21005D;
+    --md-surface: #FFFFFF;
+    --md-on-surface: #1D1B20;
+    --md-surface-variant: #E7E0EC;
+    --md-on-surface-variant: #49454F;
+    --md-bg: #F3EDF7;
+    --md-outline-variant: #CAC4D0;
+  }
+
+  body.cv-export-active {
+    background-color: var(--md-bg) !important;
+    color: var(--md-on-surface) !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  .cv-loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    font-family: 'Roboto', sans-serif;
+    font-size: 1.1rem;
+    color: var(--md-on-surface-variant);
+  }
+
+  /* ── Toolbar ── */
+  .cv-toolbar {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 24px;
+    background: var(--md-surface);
+    border-bottom: 1px solid var(--md-outline-variant);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    font-family: 'Roboto', sans-serif;
+  }
+  .cv-toolbar-hint {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.85rem;
+    color: var(--md-on-surface-variant);
+    font-style: italic;
+  }
+  .cv-toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    border: none;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: 'Roboto', sans-serif;
+    transition: background 0.15s, opacity 0.15s;
+  }
+  .cv-toolbar-download {
+    background: var(--md-primary);
+    color: var(--md-on-primary);
+  }
+  .cv-toolbar-download:hover { background: #7c6bbf; }
+  .cv-toolbar-undo {
+    background: var(--md-surface-variant);
+    color: var(--md-on-surface);
+  }
+  .cv-toolbar-undo:hover { background: var(--md-outline-variant); }
+  .cv-toolbar-undo:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+
+  /* ── Color picker ── */
+  .cv-color-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    position: relative;
+  }
+  .cv-color-label {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--md-on-surface-variant);
+  }
+  .cv-color-picker input[type="color"] {
+    position: absolute;
+    width: 0; height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .cv-color-swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid var(--md-outline-variant);
+    transition: box-shadow 0.15s;
+    cursor: pointer;
+  }
+  .cv-color-picker:hover .cv-color-swatch {
+    box-shadow: 0 0 0 3px rgba(103,80,164,0.25);
+  }
+
+  /* ── Sidebar ── */
+  .cv-sidebar {
+    position: fixed;
+    right: 24px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 190px;
+    background: var(--md-surface);
+    border-radius: 16px;
+    padding: 16px 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    font-family: 'Roboto', sans-serif;
+    z-index: 90;
+  }
+  .cv-sidebar-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--md-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 10px;
+    padding-left: 4px;
+  }
+  .cv-sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: var(--md-on-surface);
+    cursor: grab;
+    transition: background 0.15s;
+    user-select: none;
+    border: 2px solid transparent;
+  }
+  .cv-sidebar-item:active { cursor: grabbing; }
+  .cv-sidebar-item:hover { background: var(--md-surface-variant); }
+  .cv-sidebar-item.dragging { opacity: 0.35; }
+  .cv-sidebar-item.drag-over {
+    border-top-color: var(--md-primary);
+    background: var(--md-primary-container);
+  }
+  .cv-sidebar-grip {
+    color: var(--md-outline-variant);
+    font-size: 0.75rem;
+  }
+
+  /* ── Page body ── */
+  .cv-page-body {
+    font-family: 'Roboto', sans-serif;
+    background-color: var(--md-bg);
+    color: var(--md-on-surface);
+    line-height: 1.5;
+    padding: 80px 20px 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ── Resume card ── */
+  .resume-container {
+    background-color: var(--md-surface);
+    max-width: 850px;
+    width: 100%;
+    padding: 48px;
+    border-radius: 28px;
+    box-shadow: 0 4px 8px 3px rgba(0,0,0,0.05), 0 1px 3px rgba(0,0,0,0.1);
+    box-sizing: border-box;
+    position: relative;
+  }
+
+  /* ── Header ── */
+  .cv-page-body header {
+    background-color: var(--md-primary-container);
+    color: var(--md-on-primary-container);
+    padding: 24px;
+    border-radius: 20px;
+    margin-bottom: 24px;
+  }
+  .cv-page-body h1 {
+    font-size: 2.5rem;
+    margin: 0 0 4px 0;
+    font-weight: 700;
+    letter-spacing: -0.25px;
+    line-height: 1.1;
+  }
+  .cv-page-body h2.title {
+    font-size: 1.15rem;
+    margin: 0 0 12px 0;
+    font-weight: 500;
+    opacity: 0.9;
+  }
+  .contact-info {
+    font-size: 0.95rem;
+    font-weight: 500;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+  }
+  .contact-entry {
+    display: flex !important;
+    align-items: center;
+    gap: 6px;
+  }
+  .contact-info a {
+    color: var(--md-on-primary-container);
+    text-decoration: none;
+    padding: 4px 8px;
+    margin-left: -4px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .contact-delete {
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(0,0,0,0.15);
+    color: var(--md-on-primary-container);
+    font-size: 0.65rem;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+    margin-left: 2px;
+    flex-shrink: 0;
+  }
+  .contact-entry:hover .contact-delete { display: flex; }
+
+  /* ── Sections ── */
+  .cv-page-body section { margin-bottom: 24px; }
+  .cv-page-body h3.section-title {
+    color: var(--md-on-primary-container);
+    font-size: 1.3rem;
+    font-weight: 700;
+    font-variant: small-caps;
+    letter-spacing: 0.5px;
+    margin: 0 0 16px 0;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--md-outline-variant);
+    display: flex;
+    align-items: center;
+  }
+
+  /* ── Items ── */
+  .item {
+    position: relative;
+    margin-bottom: 16px;
+  }
+  .item:last-child { margin-bottom: 0; }
+  .item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 2px;
+  }
+  .item-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--md-primary);
+    margin: 0;
+  }
+  .item-subtitle {
+    color: var(--md-on-surface);
+    font-weight: 600;
+    font-size: 0.95rem;
+    margin: 0 0 6px 0;
+    font-style: italic;
+  }
+  .item-date {
+    color: var(--md-on-surface-variant);
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .cv-page-body ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--md-on-surface-variant);
+  }
+  .cv-page-body li {
+    margin-bottom: 4px;
+    font-size: 0.95rem;
+  }
+
+  /* ── Item delete — right gutter ── */
+  .item-delete {
+    position: absolute;
+    top: 50%;
+    right: -56px;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid var(--md-outline-variant);
+    background: var(--md-surface);
+    color: var(--md-on-surface-variant);
+    font-size: 0.6rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, color 0.15s;
+    z-index: 5;
+    padding: 0;
+  }
+  .item:hover .item-delete {
+    opacity: 1;
+  }
+  .item-delete:hover {
+    background: #ef4444;
+    color: white;
+    border-color: #ef4444;
+  }
+
+  /* ── Item add-link button (right gutter, below delete) ── */
+  .item-add-link {
+    position: absolute;
+    top: 50%;
+    right: -56px;
+    transform: translateY(calc(-50% + 28px));
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid var(--md-outline-variant);
+    background: var(--md-surface);
+    color: var(--md-on-surface-variant);
+    font-size: 0.55rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s, color 0.15s;
+    z-index: 5;
+    padding: 0;
+  }
+  .item:hover .item-add-link { opacity: 1; }
+  .item-add-link:hover {
+    background: var(--md-primary);
+    color: white;
+    border-color: var(--md-primary);
+  }
+
+  /* ── Entry link icon (visible in CV + export) ── */
+  .item-link {
+    color: var(--md-primary);
+    font-size: 0.8rem;
+    margin-left: 6px;
+    flex-shrink: 0;
+    text-decoration: none;
+    opacity: 0.7;
+    transition: opacity 0.15s;
+  }
+  .item-link:hover { opacity: 1; }
+
+  /* ── Chips ── */
+  .skills-category { margin-bottom: 12px; }
+  .skills-category:last-child { margin-bottom: 0; }
+  .skills-category strong {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--md-on-surface-variant);
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+  .chip-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    background-color: var(--md-primary-container);
+    color: var(--md-on-primary-container);
+    padding: 6px 14px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    line-height: 1.3;
+    border: 1px solid rgba(0,0,0,0);
+  }
+  .chip-delete {
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--md-on-surface-variant);
+    font-size: 0.75rem;
+    font-weight: 700;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .chip:hover .chip-delete {
+    display: flex;
+    background: rgba(0,0,0,0.08);
+  }
+
+  /* ── On-screen footer ── */
+  .cv-page-body footer {
+    width: 100%;
+    max-width: 850px;
+    margin-top: 16px;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    color: #9E9E9E;
+    font-size: 0.85rem;
+    font-weight: 500;
+  }
+  .footer-center { grid-column: 2; text-align: center; }
+  .cv-footer-logo {
+    width: 14px;
+    height: 14px;
+    vertical-align: -2px;
+    margin: 0 3px;
+    display: inline;
+  }
+  .footer-right  { grid-column: 3; text-align: right; }
+
+  /* ── Print-only footer (hidden on screen) ── */
+  /* ── Editable cues ── */
+  [contenteditable]:hover {
+    outline: 1px dashed var(--md-primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+  [contenteditable]:focus {
+    outline: 2px solid var(--md-primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* ── Page break indicators ── */
+  .page-break-line {
+    position: absolute;
+    left: -40px;
+    right: -40px;
+    height: 0;
+    border-top: 2px dashed rgba(239, 68, 68, 0.45);
+    z-index: 10;
+    pointer-events: none;
+  }
+  .page-break-label {
+    position: absolute;
+    right: calc(100% + 24px);
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
+    font-size: 1.36rem;
+    font-weight: 600;
+    color: rgba(239, 68, 68, 0.6);
+    background: var(--md-surface);
+    padding: 2px 8px;
+    border-radius: 4px;
+    letter-spacing: 0.3px;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    .cv-sidebar { display: none; }
+    .item-delete { right: -28px; width: 20px; height: 20px; font-size: 0.55rem; }
+  }
+  @media (max-width: 600px) {
+    .resume-container { padding: 24px 16px; border-radius: 16px; }
+    .cv-page-body header { padding: 20px; }
+    .cv-page-body h1 { font-size: 2rem; }
+    .item-header { flex-direction: column; }
+    .item-date { margin-top: 2px; margin-bottom: 6px; }
+    .item-delete { right: -22px; }
+    .cv-page-body footer {
+      grid-template-columns: 1fr; gap: 8px; text-align: center;
+    }
+    .footer-center, .footer-right { grid-column: 1; text-align: center; }
+  }
+
+  /* ── Print-only footer (hidden on screen) ── */
+  .cv-print-footer { display: none; }
+
+  /* ── Print ── */
+  @page {
+    size: A4;
+    margin: 10mm 10mm 18mm 10mm;
+  }
+
+  @media print {
+    .no-print { display: none !important; }
+
+    * {
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+    }
+
+    /* Kill black background everywhere */
+    html, body, body.cv-export-active, #root, #root > * {
+      background: white !important;
+      background-color: white !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      min-height: 0 !important;
+    }
+
+    .cv-page-body {
+      padding: 0;
+      display: block;
+      background: white !important;
+    }
+
+    /* Hide anything outside the CV */
+    .cv-page-body > footer { display: none !important; }
+
+    /* Keep the card styling but drop shadow */
+    .resume-container {
+      box-shadow: none;
+      border-radius: 0;
+      max-width: 100%;
+      padding: 8px 16px;
+      background: white !important;
+    }
+
+    /* Keep header look — background, rounded corners, padding */
+    .cv-page-body header {
+      border-radius: 16px;
+      margin-bottom: 16px;
+    }
+
+    /* Smart page breaks — never split an item */
+    .item {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+    /* Allow sections to break across pages */
+    .cv-page-body section {
+      break-inside: auto;
+    }
+    /* Keep section title with at least one item */
+    .cv-page-body h3.section-title {
+      break-after: avoid;
+      page-break-after: avoid;
+    }
+
+    /* Hide edit cues */
+    [contenteditable]:hover,
+    [contenteditable]:focus {
+      outline: none !important;
+    }
+
+    /* Repeating footer on every page */
+    .cv-print-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 6px 0;
+      font-size: 0.7rem;
+      color: #9E9E9E;
+      font-family: 'Roboto', sans-serif;
+      font-weight: 500;
+      border-top: 1px solid #E0E0E0;
+    }
+  }
+`;

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -76,7 +76,7 @@ export default function LandingPage() {
             <div className="w-7 h-7 rounded-full bg-purple-600/30 border border-purple-500/40 flex items-center justify-center">
               <div className="w-3 h-3 rounded-full bg-purple-400" />
             </div>
-            <span className="text-white font-bold text-lg tracking-tight">Orbis</span>
+            <span className="text-white font-bold text-lg tracking-tight">OpenOrbis</span>
           </div>
           {user && !signingIn ? (
             <button
@@ -210,11 +210,11 @@ export default function LandingPage() {
         </motion.div>
       </section>
 
-      {/* ── What makes Orbis different ── */}
+      {/* ── What makes OpenOrbis different ── */}
       <section id="orbis-difference" className="py-16 sm:py-28 px-4 sm:px-6">
         <div className="max-w-5xl mx-auto">
           <FadeIn className="text-center mb-16">
-            <p className="text-purple-400/60 text-xs font-bold uppercase tracking-widest mb-3">The Orbis difference</p>
+            <p className="text-purple-400/60 text-xs font-bold uppercase tracking-widest mb-3">The OpenOrbis difference</p>
             <h2 className="text-3xl sm:text-4xl font-bold text-white">Your career, one single source of truth</h2>
           </FadeIn>
 
@@ -334,9 +334,9 @@ export default function LandingPage() {
       <section className="py-16 sm:py-28 px-4 sm:px-6">
         <div className="max-w-5xl mx-auto">
           <FadeIn className="text-center mb-16">
-            <p className="text-purple-400/60 text-xs font-bold uppercase tracking-widest mb-3">Why Orbis</p>
+            <p className="text-purple-400/60 text-xs font-bold uppercase tracking-widest mb-3">Why OpenOrbis</p>
             <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">Built for everyone in the loop</h2>
-            <p className="text-white/30 text-base max-w-lg mx-auto">Whether you're a professional, a recruiter, or an AI agent — Orbis speaks your language.</p>
+            <p className="text-white/30 text-base max-w-lg mx-auto">Whether you're a professional, a recruiter, or an AI agent — OpenOrbis speaks your language.</p>
           </FadeIn>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -417,7 +417,7 @@ export default function LandingPage() {
             <div className="w-5 h-5 rounded-full bg-purple-600/30 border border-purple-500/30 flex items-center justify-center">
               <div className="w-2 h-2 rounded-full bg-purple-400" />
             </div>
-            <span className="text-white/30 text-sm font-medium">Orbis</span>
+            <span className="text-white/30 text-sm font-medium">OpenOrbis</span>
           </div>
           <p className="text-white/15 text-xs">Your career as a knowledge graph.</p>
         </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -118,7 +118,7 @@ function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) 
 
         <div className="mb-5">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orb ID</label>
-          <p className="text-[11px] text-gray-500 mt-0.5 mb-1">Use this ID with the Orbis MCP server to let AI agents query your graph.</p>
+          <p className="text-[11px] text-gray-500 mt-0.5 mb-1">Use this ID with the OpenOrbis MCP server to let AI agents query your graph.</p>
           <div className="flex items-center gap-2">
             <input readOnly value={mcpUri} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
             <button onClick={() => copy(mcpUri)} className="bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap">Copy</button>
@@ -676,13 +676,7 @@ export default function OrbViewPage() {
               )}
             </HeaderBtn>
             <button
-              onClick={() => {
-                if (orbId) {
-                  const params = new URLSearchParams({ format: 'pdf' });
-                  if (activeKeywords.length > 0) params.set('filter_keyword', activeKeywords.join(','));
-                  window.open(`${import.meta.env.VITE_API_URL || 'http://localhost:8000'}/export/${orbId}?${params}`, '_blank');
-                }
-              }}
+              onClick={() => window.open('/cv-export', '_blank')}
               className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all"
             >
               <IconDownload />

--- a/ontology.md
+++ b/ontology.md
@@ -1,0 +1,109 @@
+# Orb Knowledge Graph Ontology
+
+## Node Labels & Properties
+
+### Person (Root Node)
+- `user_id` (string) — unique user identifier
+- `orb_id` (string) — public profile identifier
+- `name` (string)
+- `email` (string)
+- `headline` (string)
+- `location` (string)
+- `linkedin_url` (string)
+- `github_url` (string)
+- `twitter_url` (string)
+- `instagram_url` (string)
+- `scholar_url` (string)
+- `website_url` (string)
+- `open_to_work` (boolean)
+- `created_at` (datetime)
+- `updated_at` (datetime)
+
+### Education
+- `uid` (string)
+- `institution` (string)
+- `degree` (string)
+- `field_of_study` (string)
+- `location` (string)
+- `description` (string)
+- `start_date` (string)
+- `end_date` (string)
+
+### WorkExperience
+- `uid` (string)
+- `company` (string)
+- `title` (string)
+- `location` (string)
+- `description` (string)
+- `start_date` (string)
+- `end_date` (string)
+
+### Skill
+- `uid` (string)
+- `name` (string)
+- `category` (string)
+- `proficiency` (string)
+- `embedding` (vector)
+
+### Certification
+- `uid` (string)
+- `name` (string)
+- `issuing_organization` (string)
+- `date` (string)
+
+### Language
+- `uid` (string)
+- `name` (string)
+- `proficiency` (string)
+
+### Publication
+- `uid` (string)
+- `title` (string)
+- `venue` (string)
+- `abstract` (string)
+- `description` (string)
+- `embedding` (vector)
+
+### Project
+- `uid` (string)
+- `name` (string)
+- `role` (string)
+- `description` (string)
+- `embedding` (vector)
+
+### Patent
+- `uid` (string)
+- `name` (string)
+- `patent_number` (string)
+- `description` (string)
+- `inventors` (string)
+- `filing_date` (string)
+- `grant_date` (string)
+
+### Collaborator
+- `uid` (string)
+- `name` (string)
+- `email` (string)
+- `description` (string)
+- `affiliation` (string)
+
+## Relationships
+
+### Person → Node
+| Relationship        | Target Node    |
+|---------------------|----------------|
+| HAS_EDUCATION       | Education      |
+| HAS_WORK_EXPERIENCE | WorkExperience |
+| HAS_SKILL           | Skill          |
+| HAS_CERTIFICATION   | Certification  |
+| SPEAKS              | Language       |
+| HAS_PUBLICATION     | Publication    |
+| HAS_PROJECT         | Project        |
+| HAS_PATENT          | Patent         |
+| COLLABORATED_WITH   | Collaborator   |
+
+### Cross-node
+| Relationship | Source                                                      | Target |
+|--------------|-------------------------------------------------------------|--------|
+| USED_SKILL   | Education, WorkExperience, Publication, Project, Patent     | Skill  |
+


### PR DESCRIPTION
## Summary
- New `/cv-export` page: opens a full CV preview populated from orb data, excluding filtered nodes
- Inline editing: all text fields are contentEditable, with undo support (Ctrl/Cmd+Z)
- Accent color picker to dynamically theme the entire CV
- Draggable section ordering sidebar
- Delete entries (x button), add links to items
- Visual A4 page break indicators (block-aware, never splits items)
- PDF export via native print: selectable text, clickable links, smart page breaks, repeating footer with OpenOrbis branding
- Renamed app from "Orbis" to "OpenOrbis" across the frontend
- Graph opens at closer zoom (z=400), Legend moved to bottom-right

Closes #38

## Test plan
- [ ] Log in via dev-login, click "Export CV" from the orb view
- [ ] Verify CV loads with all orb data, filtered nodes excluded
- [ ] Edit text inline, reorder sections, delete entries, add links
- [ ] Change accent color and verify theme updates
- [ ] Click "Download PDF", save as PDF, verify selectable text and clickable links
- [ ] Verify page breaks don't split items mid-text
- [ ] Check "OpenOrbis" branding on landing page, about page, and PDF footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)