### PR TITLE
fix: central graph node identity from CV import

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -79,9 +79,9 @@ async def dev_login(
     db: AsyncDriver = Depends(get_db),
 ):
     """Dev-only login that creates a test user without Google OAuth."""
-    user_id = "seed-alessandro-berti"
+    user_id = "dev-user"
     email = "dev@orbis.local"
-    name = "Alessandro Berti"
+    name = "Dev User"
 
     async with db.session() as session:
         result = await session.run(GET_PERSON_BY_USER_ID, user_id=user_id)
@@ -93,7 +93,7 @@ async def dev_login(
                 user_id=user_id,
                 email=encrypt_value(email),
                 name=name,
-                orb_id="alessandro",
+                orb_id="dev-user",
             )
             await send_welcome_message(db, user_id)
 

--- a/backend/app/cv/models.py
+++ b/backend/app/cv/models.py
@@ -25,8 +25,10 @@ class ExtractedData(BaseModel):
     skipped_nodes: list[SkippedNode] = []
     relationships: list[ExtractedRelationship] = []
     truncated: bool = False
+    cv_owner_name: str | None = None
 
 
 class ConfirmRequest(BaseModel):
     nodes: list[ExtractedNode]
     relationships: list[ExtractedRelationship] = []
+    cv_owner_name: str | None = None

--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -71,6 +71,7 @@ to the skill node (by its index in the nodes array). Use type "USED_SKILL".
 
 You MUST return valid JSON in exactly this format:
 {
+  "cv_owner_name": "Full Name of the person whose CV this is",
   "nodes": [
     {"node_type": "work_experience", "properties": {"company": "...", "title": "...", ...}},
     {"node_type": "skill", "properties": {"name": "Python", "category": "Programming"}},
@@ -163,6 +164,7 @@ class ClassificationResult:
     skipped: list[SkippedNode] = field(default_factory=list)
     relationships: list[ExtractedRelationship] = field(default_factory=list)
     truncated: bool = False
+    cv_owner_name: str | None = None
 
 
 MAX_RETRIES = 2
@@ -251,8 +253,10 @@ Parse every entry in this CV into structured nodes. Return JSON with "nodes", "r
                 nodes.append(ExtractedNode(node_type=node_type, properties=properties))
             if nodes:
                 logger.info("Rule-based fallback produced %d nodes", len(nodes))
+                fallback_name = extraction.get("contact", {}).get("name")
                 return ClassificationResult(
                     nodes=nodes, skipped=skipped, truncated=truncated,
+                    cv_owner_name=fallback_name,
                 )
     except Exception as e:
         logger.warning("Rule-based fallback also failed: %s", e)
@@ -327,6 +331,7 @@ def _parse_result(raw_response: str) -> ClassificationResult:
         logger.warning("Failed to parse Ollama response as JSON")
         return ClassificationResult()
 
+    cv_owner_name = parsed.get("cv_owner_name") or None
     raw_nodes = parsed.get("nodes", [])
     unmatched = parsed.get("unmatched", [])
     raw_rels = parsed.get("relationships", [])
@@ -404,4 +409,5 @@ def _parse_result(raw_response: str) -> ClassificationResult:
         unmatched=unmatched_str,
         skipped=skipped,
         relationships=relationships,
+        cv_owner_name=cv_owner_name,
     )

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -18,6 +18,7 @@ from app.graph.queries import (
     NODE_TYPE_LABELS,
     NODE_TYPE_MERGE_KEYS,
     NODE_TYPE_RELATIONSHIPS,
+    UPDATE_PERSON,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ async def upload_cv(
             skipped_nodes=result.skipped,
             relationships=result.relationships,
             truncated=result.truncated,
+            cv_owner_name=result.cv_owner_name,
         )
 
     except HTTPException:
@@ -103,6 +105,13 @@ async def confirm_cv(
     created: list[str | None] = []
 
     async with db.session() as session:
+        # Update Person node name from CV owner if provided
+        if data.cv_owner_name:
+            await session.run(
+                UPDATE_PERSON,
+                user_id=current_user["user_id"],
+                properties={"name": data.cv_owner_name},
+            )
         for node in data.nodes:
             if node.node_type not in NODE_TYPE_LABELS:
                 created.append(None)

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -20,6 +20,7 @@ export interface ExtractedData {
   skipped_nodes?: SkippedNode[];
   relationships?: ExtractedRelationship[];
   truncated?: boolean;
+  cv_owner_name?: string | null;
 }
 
 export async function uploadCV(file: File): Promise<ExtractedData> {
@@ -35,8 +36,9 @@ export async function uploadCV(file: File): Promise<ExtractedData> {
 export async function confirmCV(
   nodes: ExtractedData['nodes'],
   relationships?: ExtractedRelationship[],
+  cv_owner_name?: string | null,
 ): Promise<void> {
-  await client.post('/cv/confirm', { nodes, relationships: relationships || [] });
+  await client.post('/cv/confirm', { nodes, relationships: relationships || [], cv_owner_name: cv_owner_name || null });
 }
 
 export async function getProcessingCount(): Promise<number> {

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -17,6 +17,7 @@ export default function CVUploadOnboarding() {
   const [skippedCount, setSkippedCount] = useState(0);
   const [truncated, setTruncated] = useState(false);
   const [relationships, setRelationships] = useState<ExtractedRelationship[]>([]);
+  const [cvOwnerName, setCvOwnerName] = useState<string | null>(null);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
   const handleFile = useCallback(async (file: File) => {
@@ -47,6 +48,7 @@ export default function CVUploadOnboarding() {
       setSkippedCount(data.skipped_nodes?.length || 0);
       setTruncated(data.truncated || false);
       setRelationships(data.relationships || []);
+      setCvOwnerName(data.cv_owner_name || null);
 
       if (data.nodes.length === 0 && (!data.unmatched || data.unmatched.length === 0)) {
         setError('No entries could be extracted from this file. Try a different CV or use manual entry.');
@@ -92,7 +94,7 @@ export default function CVUploadOnboarding() {
     if (!extractedNodes || extractedNodes.length === 0) return;
     setConfirming(true);
     try {
-      await confirmCV(extractedNodes, relationships);
+      await confirmCV(extractedNodes, relationships, cvOwnerName);
       navigate('/orb');
     } catch {
       setError('Failed to save entries. Please try again.');

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -18,7 +18,7 @@ export default function ReviewPage() {
   const handleConfirm = async () => {
     setConfirming(true);
     try {
-      await confirmCV(nodes);
+      await confirmCV(nodes, undefined, extracted?.cv_owner_name);
       navigate('/orb');
     } catch {
       setConfirming(false);


### PR DESCRIPTION
- Separated dev-login user from seed script so dev users start with a clean graph instead of inheriting "Alessandro Berti"'s seeded data
- Added CV owner name extraction to the classification pipeline (both LLM and rule-based fallback)
- Propagated `cv_owner_name` through the full stack and update the Person node on CV confirm

Closes #50
