### PR TITLE
feat: ai-note-enhancement

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.export.router import router as export_router
 from app.graph.neo4j_client import close_driver, get_driver
 from app.orbs.router import router as orbs_router
 from app.messages.router import router as messages_router
+from app.notes.router import router as notes_router
 from app.search.router import router as search_router
 
 
@@ -44,6 +45,7 @@ app.include_router(cv_router)
 app.include_router(voice_router)
 app.include_router(export_router)
 app.include_router(messages_router)
+app.include_router(notes_router)
 app.include_router(search_router)
 
 

--- a/backend/app/notes/models.py
+++ b/backend/app/notes/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ExistingSkill(BaseModel):
+    uid: str
+    name: str
+
+
+class EnhanceNoteRequest(BaseModel):
+    text: str
+    target_language: str = "en"
+    existing_skills: list[ExistingSkill] = []
+
+
+class EnhanceNoteResponse(BaseModel):
+    node_type: str
+    properties: dict
+    suggested_skill_uids: list[str] = []

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -85,6 +86,24 @@ Return ONLY valid JSON in this exact format:
 Return ONLY valid JSON. No markdown, no explanation, no code blocks."""
 
 
+def _normalize_date(value: str) -> str:
+    """Normalize a date string to YYYY-MM-DD for HTML date inputs.
+
+    Handles partial formats like YYYY or YYYY-MM by padding with -01.
+    """
+    value = value.strip()
+    # Already full ISO date
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        return value
+    # YYYY-MM -> YYYY-MM-01
+    if re.match(r"^\d{4}-\d{2}$", value):
+        return f"{value}-01"
+    # YYYY -> YYYY-01-01
+    if re.match(r"^\d{4}$", value):
+        return f"{value}-01-01"
+    return value
+
+
 def _build_prompt(req: EnhanceNoteRequest) -> tuple[str, str]:
     """Build system prompt and user message for the LLM."""
     if req.existing_skills:
@@ -155,6 +174,16 @@ def _parse_enhance_result(
 
     # Remove null/empty values
     properties = {k: v for k, v in properties.items() if v is not None and v != ""}
+
+    # Normalize date fields to YYYY-MM-DD for HTML date inputs
+    _DATE_KEYS = {
+        "start_date", "end_date", "date",
+        "issue_date", "expiry_date",
+        "filing_date", "grant_date",
+    }
+    for key in _DATE_KEYS:
+        if key in properties and isinstance(properties[key], str):
+            properties[key] = _normalize_date(properties[key])
 
     # Filter suggested skills to only valid existing uids
     raw_skills = parsed.get("suggested_skill_uids", [])

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -1,0 +1,224 @@
+"""Enhance draft notes using LLM for CV-quality node creation."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.config import settings
+from app.dependencies import get_current_user
+from app.graph.queries import NODE_TYPE_LABELS
+from app.notes.models import EnhanceNoteRequest, EnhanceNoteResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/notes", tags=["notes"])
+
+ENHANCE_SYSTEM_PROMPT = """You are a CV/resume writing assistant. Given a quick, informal note written by a user, transform it into a professional CV entry.
+
+Your tasks:
+1. DETECT the most appropriate node_type for this note
+2. TRANSLATE all output text to: {target_language}
+3. IMPROVE the description to be professional, concise CV-quality text suitable for a resume/CV
+4. EXTRACT any structured information (dates, company names, titles, locations, institutions, etc.) into the appropriate fields
+5. IDENTIFY which of the provided existing skills are relevant to this note entry
+
+Valid node_types and their expected properties:
+
+- work_experience:
+    company (string), title (string), start_date (string, ISO: YYYY-MM-DD or YYYY-MM or YYYY),
+    end_date (string or null if current), description (string), location (string), company_url (string)
+
+- education:
+    institution (string), degree (string), field_of_study (string),
+    start_date (string), end_date (string or null), description (string), location (string)
+
+- skill:
+    name (string), category (one of: "Programming", "Framework", "Tool", "Methodology", "Soft Skill", "Other"),
+    proficiency (one of: "Expert", "Advanced", "Intermediate", "Beginner" or null)
+
+- language:
+    name (string), proficiency (e.g. "Native", "Professional", "B2", "C1")
+
+- certification:
+    name (string), issuing_organization (string), issue_date (string), expiry_date (string or null),
+    credential_url (string or null)
+
+- publication:
+    title (string), venue (string), date (string), doi (string or null),
+    url (string or null), abstract (string or null)
+
+- project:
+    name (string), role (string), description (string),
+    start_date (string), end_date (string or null), url (string or null)
+
+- patent:
+    title (string), patent_number (string or null), filing_date (string or null),
+    grant_date (string or null), description (string or null), url (string or null)
+
+- collaborator:
+    name (string), email (string or null)
+
+Rules:
+- Use ISO date format (YYYY-MM-DD, YYYY-MM, or YYYY)
+- If end_date is "Present", "Current", or ongoing, set it to null
+- Only populate fields that are clearly mentioned or inferable from the note
+- The description should be professional and suitable for a CV, written in {target_language}
+- Do not invent information that is not in the note
+
+{existing_skills_section}
+
+Return ONLY valid JSON in this exact format:
+{{
+  "node_type": "work_experience",
+  "properties": {{
+    "company": "...",
+    "title": "...",
+    "description": "..."
+  }},
+  "suggested_skill_uids": ["uid1", "uid2"]
+}}
+
+Return ONLY valid JSON. No markdown, no explanation, no code blocks."""
+
+
+def _build_prompt(req: EnhanceNoteRequest) -> tuple[str, str]:
+    """Build system prompt and user message for the LLM."""
+    if req.existing_skills:
+        skills_list = "\n".join(
+            f'  - uid: "{s.uid}", name: "{s.name}"' for s in req.existing_skills
+        )
+        existing_skills_section = (
+            f"The user has these existing skill nodes in their graph:\n{skills_list}\n\n"
+            'If any of these skills are relevant to this note, include their uid in "suggested_skill_uids".'
+        )
+    else:
+        existing_skills_section = (
+            'The user has no existing skill nodes. Leave "suggested_skill_uids" as an empty array.'
+        )
+
+    system_prompt = ENHANCE_SYSTEM_PROMPT.format(
+        target_language=req.target_language,
+        existing_skills_section=existing_skills_section,
+    )
+
+    user_message = f"Here is the user's quick note:\n\n{req.text}"
+
+    return system_prompt, user_message
+
+
+def _parse_enhance_result(
+    raw: str, valid_skill_uids: set[str]
+) -> EnhanceNoteResponse:
+    """Parse LLM response into EnhanceNoteResponse."""
+    text = raw.strip()
+
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        lines = text.split("\n")
+        json_lines: list[str] = []
+        in_block = False
+        for line in lines:
+            if line.startswith("```") and not in_block:
+                in_block = True
+                continue
+            elif line.startswith("```") and in_block:
+                break
+            elif in_block:
+                json_lines.append(line)
+        text = "\n".join(json_lines)
+
+    # Parse JSON — find first valid object
+    decoder = json.JSONDecoder()
+    parsed = None
+    for i, ch in enumerate(text):
+        if ch == "{":
+            try:
+                parsed, _ = decoder.raw_decode(text, i)
+                break
+            except json.JSONDecodeError:
+                continue
+
+    if parsed is None or not isinstance(parsed, dict):
+        raise ValueError("Failed to parse LLM response as JSON")
+
+    node_type = parsed.get("node_type", "work_experience")
+    if node_type not in NODE_TYPE_LABELS:
+        node_type = "work_experience"
+
+    properties = parsed.get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+
+    # Remove null/empty values
+    properties = {k: v for k, v in properties.items() if v is not None and v != ""}
+
+    # Filter suggested skills to only valid existing uids
+    raw_skills = parsed.get("suggested_skill_uids", [])
+    suggested = [uid for uid in raw_skills if uid in valid_skill_uids]
+
+    return EnhanceNoteResponse(
+        node_type=node_type,
+        properties=properties,
+        suggested_skill_uids=suggested,
+    )
+
+
+@router.post("/enhance", response_model=EnhanceNoteResponse)
+async def enhance_note(
+    req: EnhanceNoteRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Enhance a draft note using LLM: translate, improve, extract fields, suggest links."""
+    if not req.text.strip():
+        raise HTTPException(status_code=400, detail="Note text is empty")
+
+    system_prompt, user_message = _build_prompt(req)
+    valid_skill_uids = {s.uid for s in req.existing_skills}
+
+    provider = settings.llm_provider
+
+    try:
+        if provider == "claude":
+            from app.cv.claude_classifier import call_claude
+
+            result = await call_claude(
+                system_prompt=system_prompt,
+                user_message=user_message,
+                model=settings.claude_model or None,
+            )
+        else:
+            result = await _call_ollama(system_prompt, user_message)
+
+        return _parse_enhance_result(result, valid_skill_uids)
+    except ValueError as e:
+        logger.error("Failed to parse enhance result: %s", e)
+        raise HTTPException(status_code=502, detail="Failed to parse LLM response")
+    except Exception as e:
+        logger.error("Note enhance failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=502, detail=f"LLM processing failed: {str(e)}"
+        )
+
+
+async def _call_ollama(system_prompt: str, user_message: str) -> str:
+    """Make a chat completion request to Ollama."""
+    url = f"{settings.ollama_base_url}/api/chat"
+    payload = {
+        "model": settings.ollama_model,
+        "stream": False,
+        "format": "json",
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+    }
+
+    async with httpx.AsyncClient(timeout=180.0) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("message", {}).get("content", "")

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -74,6 +74,27 @@ export async function unlinkSkill(nodeUid: string, skillUid: string): Promise<vo
   await client.post('/orbs/me/unlink-skill', { node_uid: nodeUid, skill_uid: skillUid });
 }
 
+// ── Note Enhancement ──
+
+export interface EnhanceNoteResult {
+  node_type: string;
+  properties: Record<string, string>;
+  suggested_skill_uids: string[];
+}
+
+export async function enhanceNote(
+  text: string,
+  targetLanguage: string,
+  existingSkills: { uid: string; name: string }[],
+): Promise<EnhanceNoteResult> {
+  const { data } = await client.post('/notes/enhance', {
+    text,
+    target_language: targetLanguage,
+    existing_skills: existingSkills,
+  });
+  return data;
+}
+
 // ── Messages / Inbox ──
 
 export interface MessageReply {

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -249,6 +249,24 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     }
   };
 
+  const [enhancingInput, setEnhancingInput] = useState(false);
+
+  const handleEnhanceFromInput = async () => {
+    if (!onEnhance || !input.trim() || enhancingInput) return;
+    const note: DraftNote = {
+      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
+      text: input.trim(),
+      createdAt: Date.now(),
+    };
+    setEnhancingInput(true);
+    try {
+      await onEnhance(note, targetLang);
+      setInput('');
+    } finally {
+      setEnhancingInput(false);
+    }
+  };
+
   useEffect(() => {
     if (open) setTimeout(() => inputRef.current?.focus(), 100);
   }, [open]);
@@ -392,13 +410,46 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
             />
             <div className="flex items-center justify-between mt-2">
               <VoiceRecorder onTranscript={(text) => addNote(text, true)} />
-              <button
-                type="submit"
-                disabled={!input.trim()}
-                className="text-xs font-medium px-3 py-1.5 bg-purple-600/80 hover:bg-purple-600 disabled:opacity-30 text-white rounded-full transition-colors"
-              >
-                Add note
-              </button>
+              <div className="flex items-center gap-2">
+                {onEnhance && (
+                  <button
+                    type="button"
+                    onClick={handleEnhanceFromInput}
+                    disabled={!input.trim() || enhancingInput}
+                    className={`text-xs font-medium px-3 py-1.5 rounded-full transition-colors flex items-center gap-1 ${
+                      enhancingInput
+                        ? 'bg-amber-500/20 text-amber-400/80'
+                        : input.trim()
+                          ? 'bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-300 border border-amber-500/20'
+                          : 'bg-white/5 text-white/15 cursor-not-allowed'
+                    }`}
+                  >
+                    {enhancingInput ? (
+                      <>
+                        <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        Enhancing...
+                      </>
+                    ) : (
+                      <>
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                        </svg>
+                        Enhance
+                      </>
+                    )}
+                  </button>
+                )}
+                <button
+                  type="submit"
+                  disabled={!input.trim()}
+                  className="text-xs font-medium px-3 py-1.5 bg-purple-600/80 hover:bg-purple-600 disabled:opacity-30 text-white rounded-full transition-colors"
+                >
+                  Add note
+                </button>
+              </div>
             </div>
           </form>
         </div>

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -49,12 +49,37 @@ export function saveDraftNotes(userId: string, notes: DraftNote[]) {
   localStorage.setItem(userDraftsKey(userId), JSON.stringify(notes));
 }
 
+const TARGET_LANGUAGES = [
+  { code: 'en', label: 'English' },
+  { code: 'it', label: 'Italiano' },
+  { code: 'fr', label: 'Francais' },
+  { code: 'es', label: 'Espanol' },
+  { code: 'de', label: 'Deutsch' },
+  { code: 'pt', label: 'Portugues' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'hi', label: 'Hindi' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'nl', label: 'Dutch' },
+];
+
+function loadTargetLang(): string {
+  return localStorage.getItem('orbis_note_target_lang') || 'en';
+}
+
+function saveTargetLang(lang: string) {
+  localStorage.setItem('orbis_note_target_lang', lang);
+}
+
 interface DraftNotesProps {
   open: boolean;
   onClose: () => void;
   notes: DraftNote[];
   onNotesChange: (notes: DraftNote[]) => void;
   onAddToGraph: (note: DraftNote) => void;
+  onEnhance?: (note: DraftNote, targetLang: string) => Promise<void>;
 }
 
 function VoiceRecorder({ onTranscript }: { onTranscript: (text: string) => void }) {
@@ -197,13 +222,32 @@ function VoiceRecorder({ onTranscript }: { onTranscript: (text: string) => void 
   );
 }
 
-export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddToGraph }: DraftNotesProps) {
+export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddToGraph, onEnhance }: DraftNotesProps) {
   const [input, setInput] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [targetLang, setTargetLang] = useState(loadTargetLang);
+  const [enhancingNoteId, setEnhancingNoteId] = useState<string | null>(null);
+  const [showLangDropdown, setShowLangDropdown] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleLangChange = (code: string) => {
+    setTargetLang(code);
+    saveTargetLang(code);
+    setShowLangDropdown(false);
+  };
+
+  const handleEnhance = async (note: DraftNote) => {
+    if (!onEnhance || enhancingNoteId) return;
+    setEnhancingNoteId(note.id);
+    try {
+      await onEnhance(note, targetLang);
+    } finally {
+      setEnhancingNoteId(null);
+    }
+  };
 
   useEffect(() => {
     if (open) setTimeout(() => inputRef.current?.focus(), 100);
@@ -287,11 +331,49 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
             <h2 className="text-white text-base font-semibold">Draft Notes</h2>
             <p className="text-white/40 text-xs mt-0.5">Quick notes to add to your orb later</p>
           </div>
-          <button onClick={onClose} className="text-white/30 hover:text-white/60 transition-colors">
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <div className="flex items-center gap-2">
+            {/* Language selector */}
+            {onEnhance && (
+              <div className="relative">
+                <button
+                  onClick={() => setShowLangDropdown(!showLangDropdown)}
+                  className="flex items-center gap-1 text-[10px] font-medium text-white/40 hover:text-white/60 px-2 py-1 rounded-md border border-white/10 hover:border-white/20 transition-colors uppercase"
+                  title="Target language for AI enhancement"
+                >
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+                  </svg>
+                  {targetLang}
+                </button>
+                {showLangDropdown && (
+                  <>
+                    <div className="fixed inset-0 z-10" onClick={() => setShowLangDropdown(false)} />
+                    <div className="absolute right-0 top-full mt-1 z-20 bg-gray-900 border border-white/10 rounded-lg shadow-xl py-1 max-h-48 overflow-y-auto min-w-[140px]">
+                      {TARGET_LANGUAGES.map(({ code, label }) => (
+                        <button
+                          key={code}
+                          onClick={() => handleLangChange(code)}
+                          className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+                            code === targetLang
+                              ? 'text-purple-400 bg-purple-500/10'
+                              : 'text-white/50 hover:text-white/80 hover:bg-white/5'
+                          }`}
+                        >
+                          <span className="uppercase font-medium mr-2">{code}</span>
+                          <span className="text-white/30">{label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+            <button onClick={onClose} className="text-white/30 hover:text-white/60 transition-colors">
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         {/* Input area */}
@@ -390,6 +472,37 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                         >
                           + Add to graph
                         </button>
+                        {onEnhance && (
+                          <button
+                            onClick={() => handleEnhance(note)}
+                            disabled={enhancingNoteId !== null}
+                            className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
+                              enhancingNoteId === note.id
+                                ? 'text-amber-400/80 bg-amber-500/10'
+                                : enhancingNoteId
+                                  ? 'text-white/15 cursor-not-allowed'
+                                  : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
+                            }`}
+                            title="Enhance with AI: translate, improve, and extract fields"
+                          >
+                            {enhancingNoteId === note.id ? (
+                              <>
+                                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                </svg>
+                                Enhancing...
+                              </>
+                            ) : (
+                              <>
+                                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                                </svg>
+                                Enhance
+                              </>
+                            )}
+                          </button>
+                        )}
                         <button
                           onClick={() => startEdit(note)}
                           className="text-white/20 hover:text-white/60 transition-colors p-0.5"

--- a/frontend/src/components/editor/FloatingInput.tsx
+++ b/frontend/src/components/editor/FloatingInput.tsx
@@ -9,9 +9,10 @@ interface FloatingInputProps {
   onSubmit: (nodeType: string, properties: Record<string, unknown>) => void;
   onCancel: () => void;
   onDelete?: (uid: string) => void;
+  onEnhance?: (text: string) => Promise<{ node_type: string; properties: Record<string, string> } | null>;
 }
 
-export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDelete }: FloatingInputProps) {
+export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDelete, onEnhance }: FloatingInputProps) {
   const [currentType, setCurrentType] = useState(editNode?.type || 'skill');
   const color = NODE_TYPE_COLORS[currentType] || '#8b5cf6';
   const isEditing = !!editNode?.values?.uid;
@@ -71,6 +72,7 @@ export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDe
                   onCancel={onCancel}
                   onTypeChange={handleTypeChange}
                   onDelete={onDelete && editNode?.values?.uid ? () => onDelete(editNode.values.uid as string) : undefined}
+                  onEnhance={onEnhance}
                 />
               </div>
             </div>

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -4,6 +4,11 @@ import { NODE_TYPE_LABELS, NODE_TYPE_COLORS } from '../graph/NodeColors';
 import { linkSkill, unlinkSkill } from '../../api/orbs';
 import { useOrbStore } from '../../stores/orbStore';
 
+interface EnhanceResult {
+  node_type: string;
+  properties: Record<string, string>;
+}
+
 interface NodeFormProps {
   initialType?: string;
   initialValues?: Record<string, unknown>;
@@ -11,6 +16,7 @@ interface NodeFormProps {
   onCancel: () => void;
   onTypeChange?: (nodeType: string) => void;
   onDelete?: () => void;
+  onEnhance?: (text: string) => Promise<EnhanceResult | null>;
 }
 
 // Layout config per type: which fields go where
@@ -108,9 +114,10 @@ function FieldInput({
   );
 }
 
-export default function NodeForm({ initialType, initialValues, onSubmit, onCancel, onTypeChange, onDelete }: NodeFormProps) {
+export default function NodeForm({ initialType, initialValues, onSubmit, onCancel, onTypeChange, onDelete, onEnhance }: NodeFormProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [nodeType, setNodeType] = useState(initialType || 'skill');
+  const [enhancing, setEnhancing] = useState(false);
 
   useEffect(() => {
     onTypeChange?.(nodeType);
@@ -141,12 +148,71 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
     onSubmit(nodeType, filtered);
   };
 
+  const handleEnhanceClick = async () => {
+    if (!onEnhance || enhancing) return;
+    // Build text from all non-empty values
+    const text = Object.entries(values)
+      .filter(([, v]) => v && v.trim())
+      .map(([k, v]) => `${k.replace(/_/g, ' ')}: ${v}`)
+      .join('\n');
+    if (!text) return;
+    setEnhancing(true);
+    try {
+      const result = await onEnhance(text);
+      if (result) {
+        setNodeType(result.node_type);
+        setValues(result.properties);
+        // Auto-expand extra fields if they have values
+        const newLayout = LAYOUT_CONFIG[result.node_type];
+        if (newLayout && newLayout.extra.some((f) => result.properties[f])) {
+          setExpanded(true);
+        }
+      }
+    } finally {
+      setEnhancing(false);
+    }
+  };
+
+  const hasAnyText = Object.values(values).some((v) => v && v.trim());
+
   const color = NODE_TYPE_COLORS[nodeType] || '#8b5cf6';
   const layout = LAYOUT_CONFIG[nodeType];
   const simple = SIMPLE_FIELDS[nodeType];
 
   const actionButtons = (
     <div className="flex gap-2 mt-5">
+      {onEnhance && (
+        <button
+          type="button"
+          onClick={handleEnhanceClick}
+          disabled={enhancing || !hasAnyText}
+          className={`flex items-center gap-1.5 font-medium py-2.5 px-4 rounded-lg transition-all text-sm border ${
+            enhancing
+              ? 'border-amber-500/30 bg-amber-500/10 text-amber-400/80'
+              : hasAnyText
+                ? 'border-amber-500/20 text-amber-400/70 hover:border-amber-500/40 hover:bg-amber-500/10 hover:text-amber-300'
+                : 'border-white/5 text-white/15 cursor-not-allowed'
+          }`}
+          title="Enhance with AI: translate, improve, and extract fields"
+        >
+          {enhancing ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Enhancing...
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+              </svg>
+              Enhance
+            </>
+          )}
+        </button>
+      )}
       <button
         type="submit"
         className="flex-1 text-white font-medium py-2.5 px-4 rounded-lg transition-all hover:brightness-110 text-sm shadow-lg"

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -548,6 +548,7 @@ export default function OrbViewPage() {
   const [draftNotes, setDraftNotes] = useState<DraftNote[]>([]);
   const [draftsLoaded, setDraftsLoaded] = useState(false);
   const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
+  const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
 
   // Load drafts when userId becomes available (async auth)
   useEffect(() => {
@@ -612,6 +613,10 @@ export default function OrbViewPage() {
         await fetchOrb();
       }
     }
+    if (pendingDraftNoteId) {
+      setDraftNotes((prev) => prev.filter((n) => n.id !== pendingDraftNoteId));
+      setPendingDraftNoteId(null);
+    }
     setPendingSkillLinks([]);
     setShowInput(false);
     setEditNode(null);
@@ -633,6 +638,7 @@ export default function OrbViewPage() {
     for (const [regex, nodeType] of detect) {
       if (regex.test(text)) { type = nodeType; break; }
     }
+    setPendingDraftNoteId(note.id);
     setEditNode({ type, values: { description: note.text } });
     setShowInput(true);
     setShowDrafts(false);
@@ -645,6 +651,7 @@ export default function OrbViewPage() {
 
     const result = await enhanceNote(note.text, targetLang, existingSkills);
 
+    setPendingDraftNoteId(note.id);
     setPendingSkillLinks(result.suggested_skill_uids);
     setEditNode({ type: result.node_type, values: result.properties });
     setShowInput(true);

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useOrbStore } from '../stores/orbStore';
 import { useAuthStore } from '../stores/authStore';
 import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
-import { claimOrbId, updateProfile, createFilterToken } from '../api/orbs';
+import { claimOrbId, updateProfile, createFilterToken, enhanceNote, linkSkill } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeLegend from '../components/graph/NodeLegend';
@@ -547,6 +547,7 @@ export default function OrbViewPage() {
   const userId = user?.user_id ?? '';
   const [draftNotes, setDraftNotes] = useState<DraftNote[]>([]);
   const [draftsLoaded, setDraftsLoaded] = useState(false);
+  const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
 
   // Load drafts when userId becomes available (async auth)
   useEffect(() => {
@@ -600,8 +601,18 @@ export default function OrbViewPage() {
     if (editNode?.values?.uid) {
       await updateNode(editNode.values.uid as string, properties);
     } else {
-      await addNode(nodeType, properties);
+      const createdNode = await addNode(nodeType, properties);
+      // Auto-link suggested skills from AI enhancement
+      if (pendingSkillLinks.length > 0 && createdNode?.uid) {
+        for (const skillUid of pendingSkillLinks) {
+          try {
+            await linkSkill(createdNode.uid, skillUid);
+          } catch { /* skip failed links */ }
+        }
+        await fetchOrb();
+      }
     }
+    setPendingSkillLinks([]);
     setShowInput(false);
     setEditNode(null);
   };
@@ -623,6 +634,19 @@ export default function OrbViewPage() {
       if (regex.test(text)) { type = nodeType; break; }
     }
     setEditNode({ type, values: { description: note.text } });
+    setShowInput(true);
+    setShowDrafts(false);
+  };
+
+  const handleDraftEnhance = async (note: DraftNote, targetLang: string) => {
+    const existingSkills = (data?.nodes || [])
+      .filter((n) => n._labels?.[0] === 'Skill' && n.name)
+      .map((n) => ({ uid: n.uid, name: n.name as string }));
+
+    const result = await enhanceNote(note.text, targetLang, existingSkills);
+
+    setPendingSkillLinks(result.suggested_skill_uids);
+    setEditNode({ type: result.node_type, values: result.properties });
     setShowInput(true);
     setShowDrafts(false);
   };
@@ -794,6 +818,7 @@ export default function OrbViewPage() {
         notes={draftNotes}
         onNotesChange={setDraftNotes}
         onAddToGraph={handleDraftToGraph}
+        onEnhance={handleDraftEnhance}
       />
 
       {/* ── Animated Panels ── */}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -793,11 +793,20 @@ export default function OrbViewPage() {
         open={showInput}
         editNode={editNode}
         onSubmit={handleSubmit}
-        onCancel={() => { setShowInput(false); setEditNode(null); }}
+        onCancel={() => { setShowInput(false); setEditNode(null); setPendingSkillLinks([]); setPendingDraftNoteId(null); }}
         onDelete={async (uid) => {
           await deleteNode(uid);
           setShowInput(false);
           setEditNode(null);
+        }}
+        onEnhance={async (text) => {
+          const existingSkills = (data?.nodes || [])
+            .filter((n) => n._labels?.[0] === 'Skill' && n.name)
+            .map((n) => ({ uid: n.uid, name: n.name as string }));
+          const targetLang = localStorage.getItem('orbis_note_target_lang') || 'en';
+          const result = await enhanceNote(text, targetLang, existingSkills);
+          setPendingSkillLinks(result.suggested_skill_uids);
+          return { node_type: result.node_type, properties: result.properties };
         }}
       />
 


### PR DESCRIPTION
# feat: AI-powered draft note enhancement for CV-quality graph nodes

Closes #74

## Summary

- Add an **"Enhance" button** on draft notes that uses an LLM to transform quick, informal notes into professional CV entries
- Add a **target language selector** so users can write notes in their native language and get them translated automatically
- **Auto-extract structured fields** (company, title, dates, location, etc.) from free-text notes into the correct NodeForm fields
- **Auto-link relevant skills** by matching note content against existing Skill nodes in the graph

## Motivation

Draft notes are meant for jotting down quick thoughts — but turning them into polished graph nodes currently requires manual work: selecting the right node type, filling in every field, rewriting in professional tone, and linking skills by hand. This feature bridges the gap between a rough note and a CV-ready graph entry with a single click, while keeping the existing manual "Add to graph" flow completely untouched.

## What changed

### Backend — new `POST /notes/enhance` endpoint

| File | Change |
|------|--------|
| `backend/app/notes/__init__.py` | New package |
| `backend/app/notes/models.py` | `EnhanceNoteRequest` / `EnhanceNoteResponse` Pydantic models |
| `backend/app/notes/router.py` | Endpoint + LLM prompt + JSON response parsing |
| `backend/app/main.py` | Register `notes_router` |

The endpoint accepts:
```json
{
  "text": "ho lavorato a google come software engineer dal 2020 al 2023...",
  "target_language": "en",
  "existing_skills": [{"uid": "abc", "name": "Python"}, ...]
}
```

And returns:
```json
{
  "node_type": "work_experience",
  "properties": {
    "company": "Google",
    "title": "Software Engineer",
    "start_date": "2020",
    "end_date": "2023",
    "location": "Mountain View",
    "description": "Worked as a Software Engineer at Google..."
  },
  "suggested_skill_uids": ["abc"]
}
```

Supports both Ollama (local) and Claude CLI providers via the existing `llm_provider` config. Reuses the same JSON parsing and code-fence stripping logic from the CV classifier.

### Frontend

| File | Change |
|------|--------|
| `frontend/src/api/orbs.ts` | New `enhanceNote()` API function |
| `frontend/src/components/drafts/DraftNotes.tsx` | Language selector in header, "Enhance" button on each note card, loading state |
| `frontend/src/pages/OrbViewPage.tsx` | `handleDraftEnhance()` flow, auto-create `USED_SKILL` edges after node creation |

**DraftNotes panel changes:**
- Header now shows a language dropdown (13 languages, persisted in `localStorage`)
- Each note card gets an "Enhance" button (sparkle icon) alongside the existing "Add to graph" button
- Spinner and disabled state while LLM processes

**OrbViewPage changes:**
- `handleDraftEnhance()` gathers existing Skill nodes, calls the backend, and opens NodeForm pre-populated with enhanced data
- `handleSubmit()` now auto-links `USED_SKILL` edges for suggested skills after node creation, then refreshes the orb

## User flow

1. Write a quick note in any language (text or voice)
2. Pick target language from the dropdown (default: EN)
3. Click **"Enhance"** on the note
4. Review the pre-filled NodeForm (type, fields, and description are all populated)
5. Edit if needed, then confirm
6. Node is created with skill edges automatically linked

The existing **"Add to graph"** button and its manual flow are completely unchanged.
