### PR TITLE
feat: add node type view menu to orb visualization

### DIFF
--- a/frontend/src/components/graph/NodeTypeFilter.tsx
+++ b/frontend/src/components/graph/NodeTypeFilter.tsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useEffect } from 'react';
+import { NODE_COLORS, NODE_TYPE_LABELS } from './NodeColors';
+
+const TYPE_KEY_MAP: Record<string, string> = {
+  Education: 'education',
+  WorkExperience: 'work_experience',
+  Certification: 'certification',
+  Language: 'language',
+  Publication: 'publication',
+  Project: 'project',
+  Skill: 'skill',
+  Collaborator: 'collaborator',
+  Patent: 'patent',
+};
+
+const ALL_TYPES = Object.keys(TYPE_KEY_MAP);
+
+interface NodeTypeFilterProps {
+  hiddenTypes: Set<string>;
+  onToggleType: (type: string) => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+}
+
+export default function NodeTypeFilter({ hiddenTypes, onToggleType, onShowAll, onHideAll }: NodeTypeFilterProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', handleClick);
+    return () => document.removeEventListener('pointerdown', handleClick);
+  }, [open]);
+
+  const allVisible = hiddenTypes.size === 0;
+  const noneVisible = hiddenTypes.size === ALL_TYPES.length;
+
+  return (
+    <div ref={ref} className="absolute bottom-20 right-3 z-30 select-none">
+      {open ? (
+        <div className="bg-gray-900/90 backdrop-blur-sm border border-white/10 rounded-xl shadow-2xl p-3 w-52 animate-in fade-in slide-in-from-bottom-2 duration-200">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-white/70 text-[10px] font-bold uppercase tracking-widest">
+              Node Types
+            </span>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-white/30 hover:text-white/60 transition-colors"
+              aria-label="Close view panel"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Show All / Hide All */}
+          <div className="flex items-center gap-1.5 mb-2">
+            <button
+              onClick={onShowAll}
+              disabled={allVisible}
+              className="text-[10px] font-medium text-purple-400 hover:text-purple-300 disabled:text-white/15 disabled:cursor-default px-1.5 py-0.5 rounded transition-colors"
+            >
+              Show all
+            </button>
+            <span className="text-white/10 text-[10px]">|</span>
+            <button
+              onClick={onHideAll}
+              disabled={noneVisible}
+              className="text-[10px] font-medium text-purple-400 hover:text-purple-300 disabled:text-white/15 disabled:cursor-default px-1.5 py-0.5 rounded transition-colors"
+            >
+              Hide all
+            </button>
+          </div>
+
+          <ul className="space-y-0.5" role="list" aria-label="Node type visibility">
+            {ALL_TYPES.map((type) => {
+              const color = NODE_COLORS[type];
+              const label = NODE_TYPE_LABELS[TYPE_KEY_MAP[type]];
+              const isVisible = !hiddenTypes.has(type);
+
+              return (
+                <li key={type}>
+                  <button
+                    onClick={() => onToggleType(type)}
+                    className="flex items-center gap-2 py-1 px-1 w-full rounded-md hover:bg-white/5 transition-colors group"
+                  >
+                    <span
+                      className="w-3 h-3 rounded-sm flex-shrink-0 transition-opacity"
+                      style={{
+                        backgroundColor: color,
+                        opacity: isVisible ? 1 : 0.15,
+                      }}
+                      aria-hidden="true"
+                    />
+                    <span
+                      className="text-xs flex-1 text-left transition-opacity"
+                      style={{ color: isVisible ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.2)' }}
+                    >
+                      {label}
+                    </span>
+                    {isVisible ? (
+                      <svg className="w-3.5 h-3.5 text-purple-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                      </svg>
+                    ) : (
+                      <svg className="w-3.5 h-3.5 text-white/20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                      </svg>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          className="bg-gray-900/80 backdrop-blur-sm border border-white/10 rounded-lg px-2.5 py-1.5 text-white/50 hover:text-white/80 hover:border-white/20 transition-all text-xs font-medium flex items-center gap-1.5"
+          aria-label="Toggle node type visibility"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+          View
+          {hiddenTypes.size > 0 && (
+            <span className="bg-purple-500 text-white text-[10px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
+              {hiddenTypes.size}
+            </span>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -12,6 +12,8 @@ interface OrbGraph3DProps {
   highlightedNodeIds?: Set<string>;
   /** Node IDs that match the active visibility filter — rendered as transparent */
   filteredNodeIds?: Set<string>;
+  /** PascalCase node types to hide completely (e.g., "Skill", "Education") */
+  hiddenNodeTypes?: Set<string>;
   width?: number;
   height?: number;
 }
@@ -42,7 +44,7 @@ const SHARED_GEO = {
   highlightRing: new THREE.RingGeometry(5.1, 6.0, 24),
 };
 
-export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, filteredNodeIds, width, height }: OrbGraph3DProps) {
+export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, filteredNodeIds, hiddenNodeTypes, width, height }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
@@ -62,6 +64,10 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
   // Use ref for filtered nodes (visibility filter)
   const filteredRef = useRef<Set<string>>(new Set());
   filteredRef.current = filteredNodeIds ?? new Set();
+
+  // Use ref for hidden node types
+  const hiddenTypesRef = useRef<Set<string>>(new Set());
+  hiddenTypesRef.current = hiddenNodeTypes ?? new Set();
 
   // Clear cache when data changes & zoom to fit
   useEffect(() => {
@@ -223,6 +229,18 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     }
   }, [filteredNodeIds]);
 
+  // When hidden node types change, invalidate cache and refresh
+  const prevHiddenTypesKeyRef = useRef<string>('');
+  useEffect(() => {
+    const newKey = hiddenNodeTypes ? Array.from(hiddenNodeTypes).sort().join(',') : '';
+    if (newKey !== prevHiddenTypesKeyRef.current) {
+      prevHiddenTypesKeyRef.current = newKey;
+      nodeObjectCacheRef.current.clear();
+      const fg = fgRef.current;
+      if (fg) fg.refresh();
+    }
+  }, [hiddenNodeTypes]);
+
   const handleNodeHover = useCallback((node: any) => {
     setHoveredNode(node || null);
     const el = document.querySelector('canvas');
@@ -251,6 +269,17 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     if (cached) return cached;
 
     const isPerson = node._labels?.[0] === 'Person';
+    const nodeType = node._labels?.[0] || '';
+    const isHidden = !isPerson && hiddenTypesRef.current.has(nodeType);
+
+    // Hidden nodes: return an empty invisible group
+    if (isHidden) {
+      const empty = new THREE.Group();
+      empty.visible = false;
+      nodeObjectCacheRef.current.set(nodeId, empty);
+      return empty;
+    }
+
     const color = getNodeColor(node._labels || []);
     const radius = isPerson ? 5 : 3;
 
@@ -436,6 +465,18 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
     return map;
   }, [graphData]);
 
+  // Node type map for link visibility
+  const nodeTypeMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const n of graphData.nodes) {
+      map.set(n.id as string, (n as any)._labels?.[0] || '');
+    }
+    return map;
+  }, [graphData]);
+
+  const nodeTypeMapRef = useRef(nodeTypeMap);
+  nodeTypeMapRef.current = nodeTypeMap;
+
   // Link color
   const nodeColorMapRef = useRef(nodeColorMap);
   nodeColorMapRef.current = nodeColorMap;
@@ -444,6 +485,14 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
   linkColorRef.current = (link: any) => {
     const sourceId = typeof link.source === 'object' ? (link.source.id || link.source.uid) : link.source;
     const targetId = typeof link.target === 'object' ? (link.target.id || link.target.uid) : link.target;
+
+    // Hide links to hidden node types
+    const sourceType = nodeTypeMapRef.current.get(sourceId) || '';
+    const targetType = nodeTypeMapRef.current.get(targetId) || '';
+    if (hiddenTypesRef.current.has(sourceType) || hiddenTypesRef.current.has(targetType)) {
+      return 'rgba(0,0,0,0)';
+    }
+
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -7,7 +7,7 @@ import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
 import { claimOrbId, updateProfile, createFilterToken, enhanceNote, linkSkill } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
-import NodeLegend from '../components/graph/NodeLegend';
+import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import FloatingInput from '../components/editor/FloatingInput';
 import ChatBox from '../components/chat/ChatBox';
 import type { ChatMessage } from '../components/chat/ChatBox';
@@ -549,6 +549,7 @@ export default function OrbViewPage() {
   const [draftsLoaded, setDraftsLoaded] = useState(false);
   const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
   const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
+  const [hiddenNodeTypes, setHiddenNodeTypes] = useState<Set<string>>(new Set());
 
   // Load drafts when userId becomes available (async auth)
   useEffect(() => {
@@ -667,6 +668,26 @@ export default function OrbViewPage() {
     [data?.nodes, activeKeywords]
   );
 
+  // Node type filter handlers
+  const handleToggleNodeType = useCallback((type: string) => {
+    setHiddenNodeTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  }, []);
+
+  const handleShowAllNodeTypes = useCallback(() => {
+    setHiddenNodeTypes(new Set());
+  }, []);
+
+  const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Collaborator', 'Patent'];
+
+  const handleHideAllNodeTypes = useCallback(() => {
+    setHiddenNodeTypes(new Set(ALL_FILTERABLE_TYPES));
+  }, []);
+
   if (loading || !data) {
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center">
@@ -781,12 +802,18 @@ export default function OrbViewPage() {
         }}
         highlightedNodeIds={highlightedNodeIds}
         filteredNodeIds={filteredNodeIds}
+        hiddenNodeTypes={hiddenNodeTypes}
         width={dimensions.width}
         height={dimensions.height}
       />
 
-      {/* ── Node Legend ── */}
-      <NodeLegend />
+      {/* ── Node Type View ── */}
+      <NodeTypeFilter
+        hiddenTypes={hiddenNodeTypes}
+        onToggleType={handleToggleNodeType}
+        onShowAll={handleShowAllNodeTypes}
+        onHideAll={handleHideAllNodeTypes}
+      />
 
       {/* ── Floating Input ── */}
       <FloatingInput


### PR DESCRIPTION
## Summary
- Adds a collapsible **View** panel (bottom-right, eye icon) that lets users toggle visibility of each node type in the 3D graph
- All 9 node types visible by default; **Show all** / **Hide all** bulk actions
- Hidden nodes and their links become fully invisible while maintaining graph layout stability
- Collapsed button shows a badge with the count of hidden types
- Person node is never hideable
- Distinct from the existing "Visibility Filters" (keyword-based) in Settings

Closes #86

## Files changed
- **New**: `frontend/src/components/graph/NodeTypeFilter.tsx` — View panel with per-type toggles
- **Modified**: `frontend/src/components/graph/OrbGraph3D.tsx` — accepts `hiddenNodeTypes` prop, hides nodes/links
- **Modified**: `frontend/src/pages/OrbViewPage.tsx` — manages hidden types state, wires up the panel

## Test plan
- [x] `tsc --noEmit` — no TypeScript errors
- [x] `vite build` — production build succeeds
- [ ] Manual: "View" button appears bottom-right with eye icon
- [ ] Manual: toggling types hides/shows nodes and their links
- [ ] Manual: Show All / Hide All work correctly
- [ ] Manual: badge count updates when panel is collapsed
- [ ] Manual: SharedOrbPage (public view) still shows read-only legend

🤖 Generated with [Claude Code](https://claude.com/claude-code)