### PR TITLE
fix: polish settings menu layout and transitions

### DIFF
--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -202,7 +202,7 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.92, y: 24 }}
         transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-hidden flex flex-col"
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl h-[420px] max-h-[90vh] overflow-hidden flex flex-col"
       >
         <div className="p-4 sm:p-6 pb-0">
           <h2 className="text-white text-lg font-semibold mb-1">Settings</h2>
@@ -228,7 +228,7 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
           </div>
 
           {/* Tab content */}
-          <div className="flex-1 p-4 sm:p-6 overflow-y-auto">
+          <div className="flex-1 p-4 sm:p-6 overflow-hidden flex flex-col min-h-0">
             <AnimatePresence mode="wait">
             {/* ── Orb ID tab ── */}
             {activeTab === 'orb-id' && (
@@ -263,13 +263,14 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: -8 }}
                 transition={{ duration: 0.15, ease: 'easeInOut' }}
+                className="flex flex-col h-full"
               >
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility Filters</label>
                 <p className="text-[11px] text-gray-500 mt-0.5 mb-3">
                   Add keywords to filter nodes. When a filter is active, nodes containing that keyword become transparent. Filtered nodes are excluded from shared links and CV exports.
                 </p>
 
-                <div className="flex items-center gap-2 mb-3">
+                <div className="flex items-center gap-2 mb-3 flex-shrink-0">
                   <input
                     value={newKeyword}
                     onChange={(e) => setNewKeyword(e.target.value)}
@@ -285,51 +286,53 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                   </button>
                 </div>
 
-                {keywords.length === 0 ? (
-                  <p className="text-gray-600 text-xs italic">No filter keywords configured yet.</p>
-                ) : (
-                  <div className="space-y-1.5">
-                    {keywords.map((kw) => {
-                      const isActive = activeKeywords.includes(kw);
-                      return (
-                        <div
-                          key={kw}
-                          className={`flex items-center justify-between gap-2 px-3 py-2 rounded-lg border transition-all ${
-                            isActive
-                              ? 'bg-amber-600/15 border-amber-500/40'
-                              : 'bg-gray-800/50 border-gray-700/50 hover:border-gray-600'
-                          }`}
-                        >
-                          <span className="text-white text-sm font-mono truncate">{kw}</span>
-                          <div className="flex items-center gap-1.5 flex-shrink-0">
-                            <button
-                              onClick={() => toggleKeyword(kw)}
-                              className={`text-[10px] font-medium px-2 py-1 rounded transition-colors ${
-                                isActive
-                                  ? 'bg-amber-500 text-white'
-                                  : 'bg-gray-700 text-gray-400 hover:text-white hover:bg-gray-600'
-                              }`}
-                            >
-                              {isActive ? 'Active' : 'Activate'}
-                            </button>
-                            <button
-                              onClick={() => removeKeyword(kw)}
-                              className="text-gray-500 hover:text-red-400 transition-colors"
-                              title="Remove"
-                            >
-                              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                              </svg>
-                            </button>
+                <div className="flex-1 min-h-0 overflow-y-auto">
+                  {keywords.length === 0 ? (
+                    <p className="text-gray-600 text-xs italic">No filter keywords configured yet.</p>
+                  ) : (
+                    <div className="space-y-1.5">
+                      {keywords.map((kw) => {
+                        const isActive = activeKeywords.includes(kw);
+                        return (
+                          <div
+                            key={kw}
+                            className={`flex items-center justify-between gap-2 px-3 py-2 rounded-lg border transition-all ${
+                              isActive
+                                ? 'bg-amber-600/15 border-amber-500/40'
+                                : 'bg-gray-800/50 border-gray-700/50 hover:border-gray-600'
+                            }`}
+                          >
+                            <span className="text-white text-sm font-mono truncate">{kw}</span>
+                            <div className="flex items-center gap-1.5 flex-shrink-0">
+                              <button
+                                onClick={() => toggleKeyword(kw)}
+                                className={`text-[10px] font-medium px-2 py-1 rounded transition-colors ${
+                                  isActive
+                                    ? 'bg-amber-500 text-white'
+                                    : 'bg-gray-700 text-gray-400 hover:text-white hover:bg-gray-600'
+                                }`}
+                              >
+                                {isActive ? 'Active' : 'Activate'}
+                              </button>
+                              <button
+                                onClick={() => removeKeyword(kw)}
+                                className="text-gray-500 hover:text-red-400 transition-colors"
+                                title="Remove"
+                              >
+                                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
 
                 {activeKeywords.length > 0 && (
-                  <p className="text-amber-400/70 text-[11px] mt-2">
+                  <p className="text-amber-400/70 text-[11px] mt-2 flex-shrink-0">
                     {activeKeywords.length === 1 ? 'Filter' : 'Filters'} {activeKeywords.map((kw, i) => (
                       <span key={kw}>{i > 0 && ', '}"<span className="font-semibold">{kw}</span>"</span>
                     ))} active. Matching nodes are transparent.

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -229,11 +229,18 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
 
           {/* Tab content */}
           <div className="flex-1 p-4 sm:p-6 overflow-y-auto">
+            <AnimatePresence mode="wait">
             {/* ── Orb ID tab ── */}
             {activeTab === 'orb-id' && (
-              <div>
+              <motion.div
+                key="orb-id"
+                initial={{ opacity: 0, x: 8 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -8 }}
+                transition={{ duration: 0.15, ease: 'easeInOut' }}
+              >
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orb ID</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Choose a memorable ID for your orb. This will be your public URL and MCP identifier.</p>
+                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Choose a memorable ID for your orb. This will be your public URL and MCP identifier.</p>
                 <div className="flex items-center gap-2">
                   <span className="text-gray-500 text-sm">{window.location.origin}/</span>
                   <input value={customId} onChange={(e) => { setCustomId(e.target.value); setError(''); setSuccess(false); }} placeholder="your-name" className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent" />
@@ -245,13 +252,19 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                   <button onClick={handleSave} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm">{saving ? 'Saving...' : 'Save'}</button>
                   <button onClick={onClose} className="flex-1 border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Cancel</button>
                 </div>
-              </div>
+              </motion.div>
             )}
 
             {/* ── Filters tab ── */}
             {activeTab === 'filters' && (
-              <div>
-                <label className="text-xs text-amber-400/80 uppercase tracking-wide font-medium">Visibility Filters</label>
+              <motion.div
+                key="filters"
+                initial={{ opacity: 0, x: 8 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -8 }}
+                transition={{ duration: 0.15, ease: 'easeInOut' }}
+              >
+                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility Filters</label>
                 <p className="text-[11px] text-gray-500 mt-0.5 mb-3">
                   Add keywords to filter nodes. When a filter is active, nodes containing that keyword become transparent. Filtered nodes are excluded from shared links and CV exports.
                 </p>
@@ -322,14 +335,20 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                     ))} active. Matching nodes are transparent.
                   </p>
                 )}
-              </div>
+              </motion.div>
             )}
 
             {/* ── Account tab ── */}
             {activeTab === 'account' && (
-              <div>
+              <motion.div
+                key="account"
+                initial={{ opacity: 0, x: 8 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -8 }}
+                transition={{ duration: 0.15, ease: 'easeInOut' }}
+              >
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Account</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-5">Manage your account and data.</p>
+                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Manage your account and data.</p>
 
                 <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
                   <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
@@ -368,8 +387,9 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                     </div>
                   )}
                 </div>
-              </div>
+              </motion.div>
             )}
+            </AnimatePresence>
           </div>
         </div>
       </motion.div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -238,17 +238,20 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: -8 }}
                 transition={{ duration: 0.15, ease: 'easeInOut' }}
+                className="flex flex-col justify-between h-full"
               >
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orb ID</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Choose a memorable ID for your orb. This will be your public URL and MCP identifier.</p>
-                <div className="flex items-center gap-2">
-                  <span className="text-gray-500 text-sm">{window.location.origin}/</span>
-                  <input value={customId} onChange={(e) => { setCustomId(e.target.value); setError(''); setSuccess(false); }} placeholder="your-name" className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent" />
+                <div>
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orb ID</label>
+                  <p className="text-[11px] text-gray-500 mt-1 mb-5">Choose a memorable ID for your orb. This will be your public URL and MCP identifier.</p>
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-500 text-sm">{window.location.origin}/</span>
+                    <input value={customId} onChange={(e) => { setCustomId(e.target.value); setError(''); setSuccess(false); }} placeholder="your-name" className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent" />
+                  </div>
+                  {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                  {success && <p className="text-green-400 text-xs mt-2">Orb ID updated!</p>}
                 </div>
-                {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
-                {success && <p className="text-green-400 text-xs mt-2">Orb ID updated!</p>}
 
-                <div className="flex gap-3 mt-5">
+                <div className="flex gap-3">
                   <button onClick={handleSave} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm">{saving ? 'Saving...' : 'Save'}</button>
                   <button onClick={onClose} className="flex-1 border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Cancel</button>
                 </div>


### PR DESCRIPTION
## Summary
- **Fixed dialog size**: Set a constant height (`420px`) on the settings panel so it doesn't resize when switching between tabs
- **Better element distribution**: In the Orb ID tab, buttons are pushed to the bottom of the panel with more spacing between description and input
- **Scrollable filters**: The keyword list in the Filters tab scrolls independently within the fixed container
- **Consistent text**: Standardized all tab section labels to `text-gray-500` (Filters previously used `text-amber-400/80`) and unified description margins across tabs
- **Smooth tab transitions**: Added `AnimatePresence mode="wait"` with a 150ms slide + fade animation when switching tabs

## Test plan
- [ ] Open settings via top-left avatar button
- [ ] Switch between all three tabs — dialog should not change size
- [ ] Verify Orb ID tab has buttons at the bottom with good spacing
- [ ] Add several filter keywords and verify the list scrolls within the fixed panel
- [ ] Confirm label text color and spacing is consistent across tabs
- [ ] Verify smooth slide animation when switching tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)