### PR TITLE
feat: add date range slider to filter orb nodes by time period

### DIFF
--- a/docs/superpowers/plans/2026-04-05-date-range-slider.md
+++ b/docs/superpowers/plans/2026-04-05-date-range-slider.md
@@ -1,0 +1,633 @@
+# Date Range Slider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a vertical dual-handle date range slider to the left edge of the orb UI that filters nodes by time period on both owner and public views.
+
+**Architecture:** New Zustand store (`dateFilterStore`) holds the selected range. A pure function computes which node IDs are outside that range (including cascading visibility for dateless nodes). A new `DateRangeSlider` component renders the vertical slider with drag handles. Both `OrbViewPage` and `SharedOrbPage` integrate the slider and merge filtered IDs into the existing `filteredNodeIds` prop.
+
+**Tech Stack:** React 19, TypeScript, Zustand 5, Tailwind CSS 4, pointer events for drag interaction.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| Create | `frontend/src/stores/dateFilterStore.ts` | Zustand store + `getNodeDates()` + `computeDateFilteredNodeIds()` |
+| Create | `frontend/src/components/graph/DateRangeSlider.tsx` | Vertical dual-handle slider component |
+| Modify | `frontend/src/pages/OrbViewPage.tsx` | Integrate slider + merge date filter with keyword filter |
+| Modify | `frontend/src/pages/SharedOrbPage.tsx` | Integrate slider + date filter |
+
+---
+
+### Task 1: Create the date filter store
+
+**Files:**
+- Create: `frontend/src/stores/dateFilterStore.ts`
+
+- [ ] **Step 1: Create the store with date utilities and filtering logic**
+
+Create `frontend/src/stores/dateFilterStore.ts` with this content:
+
+```typescript
+import { create } from 'zustand';
+
+// ── Date utilities ──
+
+const DATE_FIELDS = [
+  'start_date', 'end_date', 'date',
+  'issue_date', 'expiry_date',
+  'filing_date', 'grant_date',
+] as const;
+
+/**
+ * Normalize a date string to "YYYY-MM" format.
+ * Accepts "YYYY", "YYYY-MM", or "YYYY-MM-DD".
+ */
+function normalizeDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (/^\d{4}$/.test(trimmed)) return `${trimmed}-01`;
+  if (/^\d{4}-\d{2}$/.test(trimmed)) return trimmed;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed.slice(0, 7);
+  return null;
+}
+
+/**
+ * Extract all normalized dates from a node's known date fields.
+ */
+export function getNodeDates(node: Record<string, unknown>): string[] {
+  const dates: string[] = [];
+  for (const field of DATE_FIELDS) {
+    const val = node[field];
+    if (typeof val === 'string' && val) {
+      const norm = normalizeDate(val);
+      if (norm) dates.push(norm);
+    }
+  }
+  return dates;
+}
+
+/**
+ * Check if a dated node overlaps with the selected range.
+ * A node is "in range" if any of its dates fall within [rangeStart, rangeEnd],
+ * OR if it has a span (start_date..end_date etc.) that overlaps the range.
+ */
+function nodeIsInRange(
+  node: Record<string, unknown>,
+  rangeStart: string,
+  rangeEnd: string,
+): boolean {
+  const dates = getNodeDates(node);
+  if (dates.length === 0) return false; // dateless — handled separately
+
+  // Check if any single date is within range
+  for (const d of dates) {
+    if (d >= rangeStart && d <= rangeEnd) return true;
+  }
+
+  // Check span overlap: node's earliest..latest overlaps range
+  const sorted = [...dates].sort();
+  const nodeMin = sorted[0];
+  const nodeMax = sorted[sorted.length - 1];
+  // Overlap: nodeMin <= rangeEnd AND nodeMax >= rangeStart
+  return nodeMin <= rangeEnd && nodeMax >= rangeStart;
+}
+
+/**
+ * Compute node IDs that should be ghosted (transparent) based on the date range.
+ *
+ * Logic:
+ * 1. If range is null, return empty set (no filtering).
+ * 2. Dated nodes outside the range → filtered.
+ * 3. Dateless nodes: visible if at least one connected node is in range; otherwise filtered.
+ * 4. Person node is never filtered.
+ */
+export function computeDateFilteredNodeIds(
+  nodes: Array<Record<string, unknown>>,
+  links: Array<{ source: string; target: string }>,
+  rangeStart: string | null,
+  rangeEnd: string | null,
+): Set<string> {
+  if (!rangeStart || !rangeEnd) return new Set();
+
+  // First pass: determine which dated nodes are in/out of range
+  const inRangeIds = new Set<string>();
+  const outOfRangeIds = new Set<string>();
+  const datelessIds: string[] = [];
+
+  for (const node of nodes) {
+    const uid = node.uid as string;
+    const labels = node._labels as string[] | undefined;
+
+    // Person node is never filtered
+    if (labels?.[0] === 'Person') {
+      inRangeIds.add(uid);
+      continue;
+    }
+
+    const dates = getNodeDates(node);
+    if (dates.length === 0) {
+      datelessIds.push(uid);
+    } else if (nodeIsInRange(node, rangeStart, rangeEnd)) {
+      inRangeIds.add(uid);
+    } else {
+      outOfRangeIds.add(uid);
+    }
+  }
+
+  // Second pass: dateless nodes — check if any connected node is in range
+  // Build adjacency from links
+  const neighbors = new Map<string, string[]>();
+  for (const link of links) {
+    const src = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
+    const tgt = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
+    if (!neighbors.has(src)) neighbors.set(src, []);
+    if (!neighbors.has(tgt)) neighbors.set(tgt, []);
+    neighbors.get(src)!.push(tgt);
+    neighbors.get(tgt)!.push(src);
+  }
+
+  for (const uid of datelessIds) {
+    const adj = neighbors.get(uid) || [];
+    const hasVisibleNeighbor = adj.some((nid) => inRangeIds.has(nid));
+    if (!hasVisibleNeighbor) {
+      outOfRangeIds.add(uid);
+    }
+  }
+
+  return outOfRangeIds;
+}
+
+// ── Zustand store ──
+
+interface DateFilterState {
+  rangeStart: string | null;
+  rangeEnd: string | null;
+  setRange: (start: string, end: string) => void;
+  resetRange: () => void;
+}
+
+export const useDateFilterStore = create<DateFilterState>((set) => ({
+  rangeStart: null,
+  rangeEnd: null,
+  setRange: (start, end) => set({ rangeStart: start, rangeEnd: end }),
+  resetRange: () => set({ rangeStart: null, rangeEnd: null }),
+}));
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: No errors related to `dateFilterStore.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/stores/dateFilterStore.ts
+git commit -m "feat: add date filter store with range computation and cascading visibility"
+```
+
+---
+
+### Task 2: Create the DateRangeSlider component
+
+**Files:**
+- Create: `frontend/src/components/graph/DateRangeSlider.tsx`
+
+- [ ] **Step 1: Create the slider component**
+
+Create `frontend/src/components/graph/DateRangeSlider.tsx` with this content:
+
+```tsx
+import { useCallback, useRef, useMemo } from 'react';
+import { useDateFilterStore } from '../../stores/dateFilterStore';
+
+interface DateRangeSliderProps {
+  minDate: string; // "YYYY-MM"
+  maxDate: string; // "YYYY-MM"
+}
+
+/** Convert "YYYY-MM" to total months since epoch for linear interpolation. */
+function toMonths(ym: string): number {
+  const [y, m] = ym.split('-').map(Number);
+  return y * 12 + (m - 1);
+}
+
+/** Convert total months back to "YYYY-MM". */
+function fromMonths(total: number): string {
+  const y = Math.floor(total / 12);
+  const m = (total % 12) + 1;
+  return `${y}-${String(m).padStart(2, '0')}`;
+}
+
+/** Format "YYYY-MM" to readable label like "Jun 2020". */
+function formatLabel(ym: string): string {
+  const [y, m] = ym.split('-').map(Number);
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return `${months[m - 1]} ${y}`;
+}
+
+export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderProps) {
+  const { rangeStart, rangeEnd, setRange } = useDateFilterStore();
+  const trackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef<'lower' | 'upper' | null>(null);
+
+  const minM = useMemo(() => toMonths(minDate), [minDate]);
+  const maxM = useMemo(() => toMonths(maxDate), [maxDate]);
+  const totalSpan = maxM - minM;
+
+  // Current handle positions (default to full range)
+  const lowerM = rangeStart ? toMonths(rangeStart) : minM;
+  const upperM = rangeEnd ? toMonths(rangeEnd) : maxM;
+
+  // Convert month value to % from BOTTOM of track (bottom = minDate, top = maxDate)
+  const toPercent = useCallback(
+    (m: number) => (totalSpan === 0 ? 0 : ((m - minM) / totalSpan) * 100),
+    [minM, totalSpan],
+  );
+
+  const lowerPct = toPercent(lowerM);
+  const upperPct = toPercent(upperM);
+
+  // Pointer → month value from track position
+  const pointerToMonth = useCallback(
+    (clientY: number): number => {
+      if (!trackRef.current || totalSpan === 0) return minM;
+      const rect = trackRef.current.getBoundingClientRect();
+      // Inverted: top of track = maxDate, bottom = minDate
+      const ratio = 1 - (clientY - rect.top) / rect.height;
+      const clamped = Math.max(0, Math.min(1, ratio));
+      return Math.round(minM + clamped * totalSpan);
+    },
+    [minM, totalSpan],
+  );
+
+  const onPointerDown = useCallback(
+    (handle: 'lower' | 'upper') => (e: React.PointerEvent) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      draggingRef.current = handle;
+    },
+    [],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingRef.current) return;
+      const m = pointerToMonth(e.clientY);
+
+      if (draggingRef.current === 'lower') {
+        const clampedLower = Math.min(m, upperM);
+        setRange(fromMonths(clampedLower), fromMonths(upperM));
+      } else {
+        const clampedUpper = Math.max(m, lowerM);
+        setRange(fromMonths(lowerM), fromMonths(clampedUpper));
+      }
+    },
+    [pointerToMonth, lowerM, upperM, setRange],
+  );
+
+  const onPointerUp = useCallback(() => {
+    draggingRef.current = null;
+  }, []);
+
+  return (
+    <div
+      className="absolute left-2 top-16 bottom-8 w-10 hidden sm:flex flex-col items-center z-20 select-none"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {/* Max date label (top) */}
+      <span className="text-[9px] text-white/30 mb-1 whitespace-nowrap">
+        {formatLabel(maxDate)}
+      </span>
+
+      {/* Track container */}
+      <div ref={trackRef} className="relative flex-1 w-full flex justify-center">
+        {/* Background track */}
+        <div className="absolute top-0 bottom-0 w-[3px] rounded-full bg-white/10" />
+
+        {/* Active range (purple) */}
+        <div
+          className="absolute w-[3px] rounded-full bg-[#785EF0]"
+          style={{
+            bottom: `${lowerPct}%`,
+            top: `${100 - upperPct}%`,
+          }}
+        />
+
+        {/* Upper handle */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
+          style={{ bottom: `${upperPct}%`, transform: `translate(-50%, 50%)` }}
+          onPointerDown={onPointerDown('upper')}
+        >
+          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
+          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
+            {formatLabel(fromMonths(upperM))}
+          </span>
+        </div>
+
+        {/* Lower handle */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
+          style={{ bottom: `${lowerPct}%`, transform: `translate(-50%, 50%)` }}
+          onPointerDown={onPointerDown('lower')}
+        >
+          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
+          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
+            {formatLabel(fromMonths(lowerM))}
+          </span>
+        </div>
+      </div>
+
+      {/* Min date label (bottom) */}
+      <span className="text-[9px] text-white/30 mt-1 whitespace-nowrap">
+        {formatLabel(minDate)}
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: No errors related to `DateRangeSlider.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/graph/DateRangeSlider.tsx
+git commit -m "feat: add DateRangeSlider component with dual draggable handles"
+```
+
+---
+
+### Task 3: Integrate slider into OrbViewPage
+
+**Files:**
+- Modify: `frontend/src/pages/OrbViewPage.tsx`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `OrbViewPage.tsx`, add these imports alongside the existing ones:
+
+```typescript
+import DateRangeSlider from '../components/graph/DateRangeSlider';
+import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
+```
+
+- [ ] **Step 2: Compute date bounds and merge filtered IDs**
+
+In `OrbViewPage.tsx`, find this existing block (around line 847-854):
+
+```typescript
+  const orbId = (data?.person?.orb_id as string) || '';
+  const { activeKeywords } = useFilterStore();
+
+  // Compute which nodes match any active visibility filter
+  const filteredNodeIds = useMemo(
+    () => computeFilteredNodeIds(data?.nodes ?? [], activeKeywords),
+    [data?.nodes, activeKeywords]
+  );
+```
+
+Replace it with:
+
+```typescript
+  const orbId = (data?.person?.orb_id as string) || '';
+  const { activeKeywords } = useFilterStore();
+  const { rangeStart, rangeEnd, resetRange } = useDateFilterStore();
+
+  // Compute date bounds for the slider
+  const dateBounds = useMemo(() => {
+    const allDates: string[] = [];
+    for (const node of data?.nodes ?? []) {
+      allDates.push(...getNodeDates(node as Record<string, unknown>));
+    }
+    if (allDates.length === 0) return null;
+    allDates.sort();
+    const min = allDates[0];
+    const max = allDates[allDates.length - 1];
+    return min === max ? null : { min, max };
+  }, [data?.nodes]);
+
+  // Reset date filter when orb data changes
+  useEffect(() => { resetRange(); }, [data, resetRange]);
+
+  // Compute which nodes match any active visibility filter (keyword + date)
+  const filteredNodeIds = useMemo(() => {
+    const keywordFiltered = computeFilteredNodeIds(data?.nodes ?? [], activeKeywords);
+    const dateFiltered = computeDateFilteredNodeIds(
+      data?.nodes ?? [],
+      data?.links ?? [],
+      rangeStart,
+      rangeEnd,
+    );
+    // Union of both sets
+    const merged = new Set(keywordFiltered);
+    for (const id of dateFiltered) merged.add(id);
+    return merged;
+  }, [data?.nodes, data?.links, activeKeywords, rangeStart, rangeEnd]);
+```
+
+- [ ] **Step 3: Render the slider component**
+
+In `OrbViewPage.tsx`, find the `{/* ── 3D Graph ── */}` comment (around line 996) and add the slider just before it:
+
+```tsx
+      {/* ── Date Range Slider ── */}
+      {dateBounds && (
+        <DateRangeSlider minDate={dateBounds.min} maxDate={dateBounds.max} />
+      )}
+
+      {/* ── 3D Graph ── */}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: No errors.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run:
+```bash
+cd frontend && npm run dev
+```
+
+Open the app, navigate to `/myorbis`. Verify:
+- The slider appears on the left edge if the orb has dated nodes
+- Dragging the handles updates node transparency in real-time
+- Skills connected to visible nodes remain visible
+- The slider is hidden on mobile viewport (<640px)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/OrbViewPage.tsx
+git commit -m "feat: integrate date range slider into OrbViewPage with merged filtering"
+```
+
+---
+
+### Task 4: Integrate slider into SharedOrbPage
+
+**Files:**
+- Modify: `frontend/src/pages/SharedOrbPage.tsx`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `SharedOrbPage.tsx`, add these imports alongside the existing ones:
+
+```typescript
+import DateRangeSlider from '../components/graph/DateRangeSlider';
+import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
+```
+
+- [ ] **Step 2: Add date filtering logic**
+
+Inside the `SharedOrbPage` component, after the existing `useEffect` for resize (line ~33), add:
+
+```typescript
+  const { rangeStart, rangeEnd, resetRange } = useDateFilterStore();
+
+  // Compute date bounds for the slider
+  const dateBounds = useMemo(() => {
+    const allDates: string[] = [];
+    for (const node of data?.nodes ?? []) {
+      allDates.push(...getNodeDates(node as Record<string, unknown>));
+    }
+    if (allDates.length === 0) return null;
+    allDates.sort();
+    const min = allDates[0];
+    const max = allDates[allDates.length - 1];
+    return min === max ? null : { min, max };
+  }, [data?.nodes]);
+
+  // Reset date filter when orb data changes
+  useEffect(() => { resetRange(); }, [data, resetRange]);
+
+  // Compute date-filtered node IDs
+  const dateFilteredNodeIds = useMemo(
+    () => computeDateFilteredNodeIds(
+      data?.nodes ?? [],
+      data?.links ?? [],
+      rangeStart,
+      rangeEnd,
+    ),
+    [data?.nodes, data?.links, rangeStart, rangeEnd],
+  );
+```
+
+Also add `useMemo` to the React import at line 1:
+
+```typescript
+import { useCallback, useEffect, useMemo, useState } from 'react';
+```
+
+- [ ] **Step 3: Render slider and pass filteredNodeIds to OrbGraph3D**
+
+In the return JSX, add the slider before the `{/* ── 3D Graph ── */}` comment, and add `filteredNodeIds` to the `OrbGraph3D` props.
+
+Find this block:
+
+```tsx
+      {/* ── 3D Graph ── */}
+      <OrbGraph3D
+        data={data}
+        onBackgroundClick={() => {
+          if (chatMessages.length > 0) {
+            setChatMessages([]);
+            setHighlightedNodeIds(new Set());
+          }
+        }}
+        highlightedNodeIds={highlightedNodeIds}
+        width={dimensions.width}
+        height={dimensions.height}
+      />
+```
+
+Replace with:
+
+```tsx
+      {/* ── Date Range Slider ── */}
+      {dateBounds && (
+        <DateRangeSlider minDate={dateBounds.min} maxDate={dateBounds.max} />
+      )}
+
+      {/* ── 3D Graph ── */}
+      <OrbGraph3D
+        data={data}
+        onBackgroundClick={() => {
+          if (chatMessages.length > 0) {
+            setChatMessages([]);
+            setHighlightedNodeIds(new Set());
+          }
+        }}
+        highlightedNodeIds={highlightedNodeIds}
+        filteredNodeIds={dateFilteredNodeIds}
+        width={dimensions.width}
+        height={dimensions.height}
+      />
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: No errors.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run the dev server and navigate to a public orb URL (e.g., `/<orbId>`). Verify:
+- The slider appears on the left edge
+- Dragging filters nodes with transparency
+- Dateless nodes follow cascading visibility rules
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/SharedOrbPage.tsx
+git commit -m "feat: integrate date range slider into SharedOrbPage"
+```
+
+---
+
+### Task 5: Final build verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: Zero errors.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+cd frontend && npm run lint
+```
+Expected: No new lint errors.
+
+- [ ] **Step 3: Run production build**
+
+```bash
+cd frontend && npm run build
+```
+Expected: Build succeeds with no errors.

--- a/docs/superpowers/specs/2026-04-05-date-range-slider-design.md
+++ b/docs/superpowers/specs/2026-04-05-date-range-slider-design.md
@@ -1,0 +1,116 @@
+# Date Range Slider — Design Spec
+
+## Overview
+
+A vertical dual-handle date range slider on the left edge of the orb visualization that filters nodes by time period. Nodes outside the selected range become transparent (ghosted). Available on both the owner's `/myorbis` page and public orb views.
+
+## Data Model & Store
+
+### `stores/dateFilterStore.ts`
+
+New Zustand store (no persistence — resets on page load):
+
+```typescript
+interface DateFilterState {
+  rangeStart: string | null;  // "YYYY-MM" e.g. "2018-06"
+  rangeEnd: string | null;    // "YYYY-MM" e.g. "2025-12"
+  setRange: (start: string, end: string) => void;
+  resetRange: () => void;
+}
+```
+
+### `computeDateFilteredNodeIds(nodes, links, rangeStart, rangeEnd) → Set<string>`
+
+Pure function exported from the store file. Logic:
+
+1. If `rangeStart` and `rangeEnd` are both null, return empty set (no filtering).
+2. For each node, extract **all dates** from known date fields: `start_date`, `end_date`, `date`, `issue_date`, `expiry_date`, `filing_date`, `grant_date`.
+3. **Dated nodes**: A node is considered **in range** if any of its dates fall within `[rangeStart, rangeEnd]`. For nodes with a span (e.g. `start_date` to `end_date`), the node is in range if the span overlaps with the selected range at all. If none of the node's dates overlap with the range, add to the filtered set.
+4. **Dateless nodes** (Skill, Language, Collaborator — no date fields): Check all connected nodes via `links`. If **at least one** connected node is **inside** the range (not filtered), the dateless node stays visible. If all connected nodes are outside the range, add the dateless node to the filtered set.
+5. The Person node is never filtered.
+
+### Date extraction utility
+
+A helper `getNodeDates(node): string[]` that checks known date fields and returns all found dates normalized to `"YYYY-MM"`. Date fields may be formatted as `"YYYY-MM"`, `"YYYY-MM-DD"`, or `"YYYY"` — normalize all to `"YYYY-MM"` (day-of-month is ignored, year-only becomes `"YYYY-01"`). Returns empty array if the node has no date fields.
+
+For computing slider bounds (min/max), scan all returned dates across all nodes and take the global min and max.
+
+## Slider Component
+
+### `components/graph/DateRangeSlider.tsx`
+
+**Props:**
+```typescript
+interface DateRangeSliderProps {
+  minDate: string;  // "YYYY-MM" — oldest date across all nodes
+  maxDate: string;  // "YYYY-MM" — newest date across all nodes
+}
+```
+
+**Layout:**
+- Absolutely positioned on the left edge of the orb container
+- ~40px wide, vertically spanning from below the header to near the bottom
+- Top of track = `maxDate` (most recent), bottom of track = `minDate` (oldest)
+
+**Elements:**
+- **Track**: Thin vertical line, `rgba(255,255,255,0.1)`
+- **Active range**: Purple (`#785EF0`) segment between the two handles
+- **Upper handle**: Draggable circle at the top boundary of the selected range
+- **Lower handle**: Draggable circle at the bottom boundary of the selected range
+- **Handle labels**: Date text (e.g. "Jun 2020") shown next to each handle
+- **Boundary labels**: `minDate` at bottom, `maxDate` at top, in small muted text
+
+**Interaction:**
+- Drag handles via pointer events (`onPointerDown` / `onPointerMove` / `onPointerUp`)
+- Handles cannot cross each other (upper always >= lower)
+- Snaps to month granularity
+- On drag, calls `dateFilterStore.setRange()` — triggers real-time filtering
+- On initial render, both handles at extremes (full range, all nodes visible)
+
+**Responsive:**
+- Hidden on mobile (`< 640px`) via Tailwind `hidden sm:flex`
+
+**Styling:**
+- Dark theme consistent with existing UI
+- Handles: small purple circles with white border (`#785EF0`, 14px diameter, 2px white border)
+- Labels: `text-[10px] text-white/40`
+- No extra dependencies — pure React + pointer events + Tailwind
+
+## Integration
+
+### OrbViewPage.tsx
+
+1. Compute `minDate` / `maxDate` from `data.nodes` by scanning all date fields via `getNodeDates()`.
+2. Render `<DateRangeSlider minDate={minDate} maxDate={maxDate} />` as a sibling to `<OrbGraph3D>`.
+3. Read `rangeStart` / `rangeEnd` from `useDateFilterStore()`.
+4. Compute `dateFilteredIds = computeDateFilteredNodeIds(nodes, links, rangeStart, rangeEnd)`.
+5. Merge with existing keyword filter: `mergedFilteredIds = union(keywordFilteredIds, dateFilteredIds)`.
+6. Pass `mergedFilteredIds` as `filteredNodeIds` to `<OrbGraph3D>`.
+
+### SharedOrbPage.tsx
+
+Same integration as OrbViewPage:
+1. Compute `minDate` / `maxDate` from data.
+2. Render `<DateRangeSlider>`.
+3. Compute `dateFilteredIds` and pass to `<OrbGraph3D filteredNodeIds={dateFilteredIds}>`.
+   (SharedOrbPage currently has no keyword filtering, so no merge needed.)
+
+### OrbGraph3D.tsx
+
+No changes. Already handles `filteredNodeIds` by rendering matched nodes as transparent.
+
+## Edge Cases
+
+- **No dated nodes**: If all nodes lack dates, don't render the slider.
+- **Single date**: If min === max, don't render the slider (no range to filter).
+- **Partial dates**: `"2020"` → normalized to `"2020-01"`. `"2020-06-15"` → `"2020-06"`.
+- **Person node**: Never filtered, always visible regardless of slider position.
+- **Reset on data change**: When orb data reloads, call `resetRange()` and recompute bounds.
+
+## Files to Create
+- `frontend/src/stores/dateFilterStore.ts`
+- `frontend/src/components/graph/DateRangeSlider.tsx`
+
+## Files to Modify
+- `frontend/src/pages/OrbViewPage.tsx` — add slider + merge date filter IDs
+- `frontend/src/pages/SharedOrbPage.tsx` — add slider + date filter IDs

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -94,8 +94,8 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
   return (
     <div
-      className="absolute left-1/2 -translate-x-1/2 top-24 bottom-32 hidden sm:flex flex-col items-center z-20 select-none"
-      style={{ width: '52px' }}
+      className="absolute left-3 top-1/2 -translate-y-1/2 hidden sm:flex flex-col items-center z-20 select-none"
+      style={{ height: '55vh', width: '52px' }}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -94,7 +94,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
   return (
     <div
-      className="absolute left-3 top-24 bottom-32 hidden sm:flex flex-col items-center z-20 select-none"
+      className="absolute left-1/2 -translate-x-1/2 top-24 bottom-32 hidden sm:flex flex-col items-center z-20 select-none"
       style={{ width: '52px' }}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -179,19 +179,18 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
         </span>
 
         {/* Reset button */}
-        {isFiltered && (
-          <button
-            onClick={resetRange}
-            className="mt-2 w-7 h-7 rounded-lg bg-white/[0.06] hover:bg-white/[0.12] border border-white/[0.08] hover:border-white/[0.15]
-              flex items-center justify-center transition-all group"
-            title="Reset date filter"
-          >
-            <svg className="w-3 h-3 text-white/40 group-hover:text-white/70 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-              <path d="M3 12a9 9 0 1 1 9 9" />
-              <polyline points="3 3 3 12 12 12" />
-            </svg>
-          </button>
-        )}
+        <button
+          onClick={resetRange}
+          disabled={!isFiltered}
+          className="mt-2 w-7 h-7 rounded-lg bg-white/[0.06] hover:bg-white/[0.12] disabled:hover:bg-white/[0.06] border border-white/[0.08] hover:border-white/[0.15] disabled:hover:border-white/[0.08]
+            flex items-center justify-center transition-all group disabled:opacity-30 disabled:cursor-default"
+          title="Reset date filter"
+        >
+          <svg className="w-3 h-3 text-white/40 group-hover:text-white/70 group-disabled:text-white/40 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 12a9 9 0 1 1 9 9" />
+            <polyline points="3 3 3 12 12 12" />
+          </svg>
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -94,7 +94,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
   return (
     <div
-      className="absolute left-3 top-14 bottom-24 hidden sm:flex flex-col items-center z-20 select-none"
+      className="absolute left-3 top-24 bottom-32 hidden sm:flex flex-col items-center z-20 select-none"
       style={{ width: '52px' }}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -186,7 +186,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
             flex items-center justify-center transition-all group disabled:opacity-30 disabled:cursor-default"
           title="Reset date filter"
         >
-          <svg className="w-3 h-3 text-white/40 group-hover:text-white/70 group-disabled:text-white/40 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+          <svg className="w-3 h-3 text-amber-400/60 group-hover:text-amber-400 group-disabled:text-amber-400/20 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
             <path d="M3 12a9 9 0 1 1 9 9" />
             <polyline points="3 3 3 12 12 12" />
           </svg>

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -106,7 +106,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
       {/* Content */}
       <div className="relative flex flex-col items-center w-full h-full py-3 px-1">
         {/* Max date label (top) */}
-        <span className="text-[8px] font-medium text-white/25 tracking-wide uppercase whitespace-nowrap mb-2">
+        <span className="text-[10px] font-medium text-white/30 tracking-wide uppercase whitespace-nowrap mb-2">
           {formatLabel(maxDate)}
         </span>
 
@@ -148,7 +148,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
             <div className="w-3 h-3 rounded-full bg-white border-[1.5px] border-[#785EF0] shadow-[0_0_8px_rgba(120,94,240,0.5)]
               transition-transform active:scale-125" />
             {/* Date label */}
-            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-[10px] font-medium text-white/60 whitespace-nowrap pointer-events-none
+            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-xs font-medium text-white/60 whitespace-nowrap pointer-events-none
               bg-black/40 backdrop-blur-sm rounded px-1.5 py-0.5 border border-white/[0.06]">
               {formatLabel(fromMonths(upperM))}
             </span>
@@ -166,7 +166,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
             <div className="w-3 h-3 rounded-full bg-white border-[1.5px] border-[#785EF0] shadow-[0_0_8px_rgba(120,94,240,0.5)]
               transition-transform active:scale-125" />
             {/* Date label */}
-            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-[10px] font-medium text-white/60 whitespace-nowrap pointer-events-none
+            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-xs font-medium text-white/60 whitespace-nowrap pointer-events-none
               bg-black/40 backdrop-blur-sm rounded px-1.5 py-0.5 border border-white/[0.06]">
               {formatLabel(fromMonths(lowerM))}
             </span>
@@ -174,7 +174,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
         </div>
 
         {/* Min date label (bottom) */}
-        <span className="text-[8px] font-medium text-white/25 tracking-wide uppercase whitespace-nowrap mt-2">
+        <span className="text-[10px] font-medium text-white/30 tracking-wide uppercase whitespace-nowrap mt-2">
           {formatLabel(minDate)}
         </span>
 

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useRef, useMemo } from 'react';
+import { useDateFilterStore } from '../../stores/dateFilterStore';
+
+interface DateRangeSliderProps {
+  minDate: string; // "YYYY-MM"
+  maxDate: string; // "YYYY-MM"
+}
+
+/** Convert "YYYY-MM" to total months since epoch for linear interpolation. */
+function toMonths(ym: string): number {
+  const [y, m] = ym.split('-').map(Number);
+  return y * 12 + (m - 1);
+}
+
+/** Convert total months back to "YYYY-MM". */
+function fromMonths(total: number): string {
+  const y = Math.floor(total / 12);
+  const m = (total % 12) + 1;
+  return `${y}-${String(m).padStart(2, '0')}`;
+}
+
+/** Format "YYYY-MM" to readable label like "Jun 2020". */
+function formatLabel(ym: string): string {
+  const [y, m] = ym.split('-').map(Number);
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return `${months[m - 1]} ${y}`;
+}
+
+export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderProps) {
+  const { rangeStart, rangeEnd, setRange } = useDateFilterStore();
+  const trackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef<'lower' | 'upper' | null>(null);
+
+  const minM = useMemo(() => toMonths(minDate), [minDate]);
+  const maxM = useMemo(() => toMonths(maxDate), [maxDate]);
+  const totalSpan = maxM - minM;
+
+  // Current handle positions (default to full range)
+  const lowerM = rangeStart ? toMonths(rangeStart) : minM;
+  const upperM = rangeEnd ? toMonths(rangeEnd) : maxM;
+
+  // Convert month value to % from BOTTOM of track (bottom = minDate, top = maxDate)
+  const toPercent = useCallback(
+    (m: number) => (totalSpan === 0 ? 0 : ((m - minM) / totalSpan) * 100),
+    [minM, totalSpan],
+  );
+
+  const lowerPct = toPercent(lowerM);
+  const upperPct = toPercent(upperM);
+
+  // Pointer → month value from track position
+  const pointerToMonth = useCallback(
+    (clientY: number): number => {
+      if (!trackRef.current || totalSpan === 0) return minM;
+      const rect = trackRef.current.getBoundingClientRect();
+      // Inverted: top of track = maxDate, bottom = minDate
+      const ratio = 1 - (clientY - rect.top) / rect.height;
+      const clamped = Math.max(0, Math.min(1, ratio));
+      return Math.round(minM + clamped * totalSpan);
+    },
+    [minM, totalSpan],
+  );
+
+  const onPointerDown = useCallback(
+    (handle: 'lower' | 'upper') => (e: React.PointerEvent) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      draggingRef.current = handle;
+    },
+    [],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingRef.current) return;
+      const m = pointerToMonth(e.clientY);
+
+      if (draggingRef.current === 'lower') {
+        const clampedLower = Math.min(m, upperM);
+        setRange(fromMonths(clampedLower), fromMonths(upperM));
+      } else {
+        const clampedUpper = Math.max(m, lowerM);
+        setRange(fromMonths(lowerM), fromMonths(clampedUpper));
+      }
+    },
+    [pointerToMonth, lowerM, upperM, setRange],
+  );
+
+  const onPointerUp = useCallback(() => {
+    draggingRef.current = null;
+  }, []);
+
+  return (
+    <div
+      className="absolute left-2 top-16 bottom-8 w-10 hidden sm:flex flex-col items-center z-20 select-none"
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {/* Max date label (top) */}
+      <span className="text-[9px] text-white/30 mb-1 whitespace-nowrap">
+        {formatLabel(maxDate)}
+      </span>
+
+      {/* Track container */}
+      <div ref={trackRef} className="relative flex-1 w-full flex justify-center">
+        {/* Background track */}
+        <div className="absolute top-0 bottom-0 w-[3px] rounded-full bg-white/10" />
+
+        {/* Active range (purple) */}
+        <div
+          className="absolute w-[3px] rounded-full bg-[#785EF0]"
+          style={{
+            bottom: `${lowerPct}%`,
+            top: `${100 - upperPct}%`,
+          }}
+        />
+
+        {/* Upper handle */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
+          style={{ bottom: `${upperPct}%`, transform: `translate(-50%, 50%)` }}
+          onPointerDown={onPointerDown('upper')}
+        >
+          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
+          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
+            {formatLabel(fromMonths(upperM))}
+          </span>
+        </div>
+
+        {/* Lower handle */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
+          style={{ bottom: `${lowerPct}%`, transform: `translate(-50%, 50%)` }}
+          onPointerDown={onPointerDown('lower')}
+        >
+          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
+          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
+            {formatLabel(fromMonths(lowerM))}
+          </span>
+        </div>
+      </div>
+
+      {/* Min date label (bottom) */}
+      <span className="text-[9px] text-white/30 mt-1 whitespace-nowrap">
+        {formatLabel(minDate)}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -19,11 +19,12 @@ function fromMonths(total: number): string {
   return `${y}-${String(m).padStart(2, '0')}`;
 }
 
+const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
 /** Format "YYYY-MM" to readable label like "Jun 2020". */
 function formatLabel(ym: string): string {
   const [y, m] = ym.split('-').map(Number);
-  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  return `${months[m - 1]} ${y}`;
+  return `${MONTH_NAMES[m - 1]} ${y}`;
 }
 
 export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderProps) {
@@ -35,9 +36,9 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
   const maxM = useMemo(() => toMonths(maxDate), [maxDate]);
   const totalSpan = maxM - minM;
 
-  // Current handle positions (default to full range)
-  const lowerM = rangeStart ? toMonths(rangeStart) : minM;
-  const upperM = rangeEnd ? toMonths(rangeEnd) : maxM;
+  // Current handle positions (default to full range, clamped to bounds)
+  const lowerM = Math.max(minM, Math.min(maxM, rangeStart ? toMonths(rangeStart) : minM));
+  const upperM = Math.max(minM, Math.min(maxM, rangeEnd ? toMonths(rangeEnd) : maxM));
 
   // Convert month value to % from BOTTOM of track (bottom = minDate, top = maxDate)
   const toPercent = useCallback(
@@ -95,6 +96,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
       className="absolute left-2 top-16 bottom-8 w-10 hidden sm:flex flex-col items-center z-20 select-none"
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
     >
       {/* Max date label (top) */}
       <span className="text-[9px] text-white/30 mb-1 whitespace-nowrap">
@@ -117,8 +119,8 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
         {/* Upper handle */}
         <div
-          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
-          style={{ bottom: `${upperPct}%`, transform: `translate(-50%, 50%)` }}
+          className="absolute cursor-grab active:cursor-grabbing touch-none"
+          style={{ left: '50%', bottom: `${upperPct}%`, transform: `translate(-50%, 50%)` }}
           onPointerDown={onPointerDown('upper')}
         >
           <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
@@ -129,8 +131,8 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
         {/* Lower handle */}
         <div
-          className="absolute left-1/2 -translate-x-1/2 cursor-grab active:cursor-grabbing touch-none"
-          style={{ bottom: `${lowerPct}%`, transform: `translate(-50%, 50%)` }}
+          className="absolute cursor-grab active:cursor-grabbing touch-none"
+          style={{ left: '50%', bottom: `${lowerPct}%`, transform: `translate(-50%, 50%)` }}
           onPointerDown={onPointerDown('lower')}
         >
           <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -28,7 +28,8 @@ function formatLabel(ym: string): string {
 }
 
 export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderProps) {
-  const { rangeStart, rangeEnd, setRange } = useDateFilterStore();
+  const { rangeStart, rangeEnd, setRange, resetRange } = useDateFilterStore();
+  const isFiltered = rangeStart !== null || rangeEnd !== null;
   const trackRef = useRef<HTMLDivElement>(null);
   const draggingRef = useRef<'lower' | 'upper' | null>(null);
 
@@ -93,7 +94,7 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
   return (
     <div
-      className="absolute left-2 top-16 bottom-8 w-10 hidden sm:flex flex-col items-center z-20 select-none"
+      className="absolute left-5 top-16 bottom-24 w-10 hidden sm:flex flex-col items-center z-20 select-none"
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
@@ -146,6 +147,20 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
       <span className="text-[9px] text-white/30 mt-1 whitespace-nowrap">
         {formatLabel(minDate)}
       </span>
+
+      {/* Reset button */}
+      {isFiltered && (
+        <button
+          onClick={resetRange}
+          className="mt-2 w-6 h-6 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-colors"
+          title="Reset date filter"
+        >
+          <svg className="w-3 h-3 text-white/50" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 12a9 9 0 1 1 9 9" />
+            <polyline points="3 3 3 12 12 12" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/graph/DateRangeSlider.tsx
+++ b/frontend/src/components/graph/DateRangeSlider.tsx
@@ -94,73 +94,105 @@ export default function DateRangeSlider({ minDate, maxDate }: DateRangeSliderPro
 
   return (
     <div
-      className="absolute left-5 top-16 bottom-24 w-10 hidden sm:flex flex-col items-center z-20 select-none"
+      className="absolute left-3 top-14 bottom-24 hidden sm:flex flex-col items-center z-20 select-none"
+      style={{ width: '52px' }}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
     >
-      {/* Max date label (top) */}
-      <span className="text-[9px] text-white/30 mb-1 whitespace-nowrap">
-        {formatLabel(maxDate)}
-      </span>
+      {/* Glass panel background */}
+      <div className="absolute inset-0 rounded-2xl bg-white/[0.03] backdrop-blur-sm border border-white/[0.06]" />
 
-      {/* Track container */}
-      <div ref={trackRef} className="relative flex-1 w-full flex justify-center">
-        {/* Background track */}
-        <div className="absolute top-0 bottom-0 w-[3px] rounded-full bg-white/10" />
+      {/* Content */}
+      <div className="relative flex flex-col items-center w-full h-full py-3 px-1">
+        {/* Max date label (top) */}
+        <span className="text-[8px] font-medium text-white/25 tracking-wide uppercase whitespace-nowrap mb-2">
+          {formatLabel(maxDate)}
+        </span>
 
-        {/* Active range (purple) */}
-        <div
-          className="absolute w-[3px] rounded-full bg-[#785EF0]"
-          style={{
-            bottom: `${lowerPct}%`,
-            top: `${100 - upperPct}%`,
-          }}
-        />
+        {/* Track container */}
+        <div ref={trackRef} className="relative flex-1 w-full flex justify-center">
+          {/* Background track */}
+          <div className="absolute top-0 bottom-0 w-[2px] rounded-full bg-white/[0.08]" />
 
-        {/* Upper handle */}
-        <div
-          className="absolute cursor-grab active:cursor-grabbing touch-none"
-          style={{ left: '50%', bottom: `${upperPct}%`, transform: `translate(-50%, 50%)` }}
-          onPointerDown={onPointerDown('upper')}
-        >
-          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
-          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
-            {formatLabel(fromMonths(upperM))}
-          </span>
+          {/* Active range (purple gradient) */}
+          <div
+            className="absolute w-[2px] rounded-full"
+            style={{
+              bottom: `${lowerPct}%`,
+              top: `${100 - upperPct}%`,
+              background: 'linear-gradient(to top, #6347d6, #9b7eff)',
+            }}
+          />
+          {/* Active range glow */}
+          <div
+            className="absolute w-[6px] rounded-full opacity-30 blur-[2px]"
+            style={{
+              bottom: `${lowerPct}%`,
+              top: `${100 - upperPct}%`,
+              background: 'linear-gradient(to top, #6347d6, #9b7eff)',
+              left: '50%',
+              transform: 'translateX(-50%)',
+            }}
+          />
+
+          {/* Upper handle */}
+          <div
+            className="absolute cursor-grab active:cursor-grabbing touch-none"
+            style={{ left: '50%', bottom: `${upperPct}%`, transform: 'translate(-50%, 50%)' }}
+            onPointerDown={onPointerDown('upper')}
+          >
+            {/* Larger invisible hit area */}
+            <div className="absolute -inset-2" />
+            {/* Handle visual */}
+            <div className="w-3 h-3 rounded-full bg-white border-[1.5px] border-[#785EF0] shadow-[0_0_8px_rgba(120,94,240,0.5)]
+              transition-transform active:scale-125" />
+            {/* Date label */}
+            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-[10px] font-medium text-white/60 whitespace-nowrap pointer-events-none
+              bg-black/40 backdrop-blur-sm rounded px-1.5 py-0.5 border border-white/[0.06]">
+              {formatLabel(fromMonths(upperM))}
+            </span>
+          </div>
+
+          {/* Lower handle */}
+          <div
+            className="absolute cursor-grab active:cursor-grabbing touch-none"
+            style={{ left: '50%', bottom: `${lowerPct}%`, transform: 'translate(-50%, 50%)' }}
+            onPointerDown={onPointerDown('lower')}
+          >
+            {/* Larger invisible hit area */}
+            <div className="absolute -inset-2" />
+            {/* Handle visual */}
+            <div className="w-3 h-3 rounded-full bg-white border-[1.5px] border-[#785EF0] shadow-[0_0_8px_rgba(120,94,240,0.5)]
+              transition-transform active:scale-125" />
+            {/* Date label */}
+            <span className="absolute left-6 top-1/2 -translate-y-1/2 text-[10px] font-medium text-white/60 whitespace-nowrap pointer-events-none
+              bg-black/40 backdrop-blur-sm rounded px-1.5 py-0.5 border border-white/[0.06]">
+              {formatLabel(fromMonths(lowerM))}
+            </span>
+          </div>
         </div>
 
-        {/* Lower handle */}
-        <div
-          className="absolute cursor-grab active:cursor-grabbing touch-none"
-          style={{ left: '50%', bottom: `${lowerPct}%`, transform: `translate(-50%, 50%)` }}
-          onPointerDown={onPointerDown('lower')}
-        >
-          <div className="w-[14px] h-[14px] rounded-full bg-[#785EF0] border-2 border-white shadow-lg shadow-purple-500/30" />
-          <span className="absolute left-5 top-1/2 -translate-y-1/2 text-[10px] text-white/50 whitespace-nowrap pointer-events-none">
-            {formatLabel(fromMonths(lowerM))}
-          </span>
-        </div>
+        {/* Min date label (bottom) */}
+        <span className="text-[8px] font-medium text-white/25 tracking-wide uppercase whitespace-nowrap mt-2">
+          {formatLabel(minDate)}
+        </span>
+
+        {/* Reset button */}
+        {isFiltered && (
+          <button
+            onClick={resetRange}
+            className="mt-2 w-7 h-7 rounded-lg bg-white/[0.06] hover:bg-white/[0.12] border border-white/[0.08] hover:border-white/[0.15]
+              flex items-center justify-center transition-all group"
+            title="Reset date filter"
+          >
+            <svg className="w-3 h-3 text-white/40 group-hover:text-white/70 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 12a9 9 0 1 1 9 9" />
+              <polyline points="3 3 3 12 12 12" />
+            </svg>
+          </button>
+        )}
       </div>
-
-      {/* Min date label (bottom) */}
-      <span className="text-[9px] text-white/30 mt-1 whitespace-nowrap">
-        {formatLabel(minDate)}
-      </span>
-
-      {/* Reset button */}
-      {isFiltered && (
-        <button
-          onClick={resetRange}
-          className="mt-2 w-6 h-6 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-colors"
-          title="Reset date filter"
-        >
-          <svg className="w-3 h-3 text-white/50" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 12a9 9 0 1 1 9 9" />
-            <polyline points="3 3 3 12 12 12" />
-          </svg>
-        </button>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -874,12 +874,14 @@ export default function OrbViewPage() {
       data?.links ?? [],
       rangeStart,
       rangeEnd,
+      dateBounds?.min,
+      dateBounds?.max,
     );
     // Union of both sets
     const merged = new Set(keywordFiltered);
     for (const id of dateFiltered) merged.add(id);
     return merged;
-  }, [data?.nodes, data?.links, activeKeywords, rangeStart, rangeEnd]);
+  }, [data?.nodes, data?.links, activeKeywords, rangeStart, rangeEnd, dateBounds]);
 
   // Node type filter handlers
   const handleToggleNodeType = useCallback((type: string) => {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -4,6 +4,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useOrbStore } from '../stores/orbStore';
 import { useAuthStore } from '../stores/authStore';
 import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
+import DateRangeSlider from '../components/graph/DateRangeSlider';
+import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
 import { claimOrbId, updateProfile, uploadProfileImage, deleteProfileImage, createFilterToken, enhanceNote, linkSkill } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
@@ -846,12 +848,38 @@ export default function OrbViewPage() {
 
   const orbId = (data?.person?.orb_id as string) || '';
   const { activeKeywords } = useFilterStore();
+  const { rangeStart, rangeEnd, resetRange } = useDateFilterStore();
 
-  // Compute which nodes match any active visibility filter
-  const filteredNodeIds = useMemo(
-    () => computeFilteredNodeIds(data?.nodes ?? [], activeKeywords),
-    [data?.nodes, activeKeywords]
-  );
+  // Compute date bounds for the slider
+  const dateBounds = useMemo(() => {
+    const allDates: string[] = [];
+    for (const node of data?.nodes ?? []) {
+      allDates.push(...getNodeDates(node as Record<string, unknown>));
+    }
+    if (allDates.length === 0) return null;
+    allDates.sort();
+    const min = allDates[0];
+    const max = allDates[allDates.length - 1];
+    return min === max ? null : { min, max };
+  }, [data?.nodes]);
+
+  // Reset date filter when orb data changes
+  useEffect(() => { resetRange(); }, [data, resetRange]);
+
+  // Compute which nodes match any active visibility filter (keyword + date)
+  const filteredNodeIds = useMemo(() => {
+    const keywordFiltered = computeFilteredNodeIds(data?.nodes ?? [], activeKeywords);
+    const dateFiltered = computeDateFilteredNodeIds(
+      data?.nodes ?? [],
+      data?.links ?? [],
+      rangeStart,
+      rangeEnd,
+    );
+    // Union of both sets
+    const merged = new Set(keywordFiltered);
+    for (const id of dateFiltered) merged.add(id);
+    return merged;
+  }, [data?.nodes, data?.links, activeKeywords, rangeStart, rangeEnd]);
 
   // Node type filter handlers
   const handleToggleNodeType = useCallback((type: string) => {
@@ -991,6 +1019,11 @@ export default function OrbViewPage() {
             </motion.div>
           </motion.div>
         </div>
+      )}
+
+      {/* ── Date Range Slider ── */}
+      {dateBounds && (
+        <DateRangeSlider minDate={dateBounds.min} maxDate={dateBounds.max} />
       )}
 
       {/* ── 3D Graph ── */}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -863,8 +863,8 @@ export default function OrbViewPage() {
     return min === max ? null : { min, max };
   }, [data?.nodes]);
 
-  // Reset date filter when orb data changes
-  useEffect(() => { resetRange(); }, [data, resetRange]);
+  // Reset date filter when switching to a different orb (not on node edits)
+  useEffect(() => { resetRange(); }, [orbId, resetRange]);
 
   // Compute which nodes match any active visibility filter (keyword + date)
   const filteredNodeIds = useMemo(() => {

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useOrbStore } from '../stores/orbStore';
 import { publicTextSearch } from '../api/orbs';
@@ -6,6 +6,8 @@ import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeLegend from '../components/graph/NodeLegend';
 import ChatBox from '../components/chat/ChatBox';
 import type { ChatMessage } from '../components/chat/ChatBox';
+import DateRangeSlider from '../components/graph/DateRangeSlider';
+import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
 
 export default function SharedOrbPage() {
   const { orbId } = useParams<{ orbId: string }>();
@@ -31,6 +33,35 @@ export default function SharedOrbPage() {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  const { rangeStart, rangeEnd, resetRange } = useDateFilterStore();
+
+  // Compute date bounds for the slider
+  const dateBounds = useMemo(() => {
+    const allDates: string[] = [];
+    for (const node of data?.nodes ?? []) {
+      allDates.push(...getNodeDates(node as Record<string, unknown>));
+    }
+    if (allDates.length === 0) return null;
+    allDates.sort();
+    const min = allDates[0];
+    const max = allDates[allDates.length - 1];
+    return min === max ? null : { min, max };
+  }, [data?.nodes]);
+
+  // Reset date filter when viewing a different orb
+  useEffect(() => { resetRange(); }, [orbId, resetRange]);
+
+  // Compute date-filtered node IDs
+  const dateFilteredNodeIds = useMemo(
+    () => computeDateFilteredNodeIds(
+      data?.nodes ?? [],
+      data?.links ?? [],
+      rangeStart,
+      rangeEnd,
+    ),
+    [data?.nodes, data?.links, rangeStart, rangeEnd],
+  );
 
   if (loading) {
     return (
@@ -79,6 +110,11 @@ export default function SharedOrbPage() {
         </div>
       </div>
 
+      {/* ── Date Range Slider ── */}
+      {dateBounds && (
+        <DateRangeSlider minDate={dateBounds.min} maxDate={dateBounds.max} />
+      )}
+
       {/* ── 3D Graph ── */}
       <OrbGraph3D
         data={data}
@@ -89,6 +125,7 @@ export default function SharedOrbPage() {
           }
         }}
         highlightedNodeIds={highlightedNodeIds}
+        filteredNodeIds={dateFilteredNodeIds}
         width={dimensions.width}
         height={dimensions.height}
       />

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { useOrbStore } from '../stores/orbStore';
 import { publicTextSearch } from '../api/orbs';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
-import NodeLegend from '../components/graph/NodeLegend';
+import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import ChatBox from '../components/chat/ChatBox';
 import type { ChatMessage } from '../components/chat/ChatBox';
 import DateRangeSlider from '../components/graph/DateRangeSlider';
@@ -17,6 +17,26 @@ export default function SharedOrbPage() {
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set());
+  const [hiddenNodeTypes, setHiddenNodeTypes] = useState<Set<string>>(new Set());
+
+  const handleToggleNodeType = useCallback((type: string) => {
+    setHiddenNodeTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  }, []);
+
+  const handleShowAllNodeTypes = useCallback(() => {
+    setHiddenNodeTypes(new Set());
+  }, []);
+
+  const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Collaborator', 'Patent'];
+
+  const handleHideAllNodeTypes = useCallback(() => {
+    setHiddenNodeTypes(new Set(ALL_FILTERABLE_TYPES));
+  }, []);
 
   // Public search bound to this orb — respects filter_token privacy
   const searchFn = useCallback(
@@ -101,12 +121,20 @@ export default function SharedOrbPage() {
             </div>
           </div>
 
-          <a
-            href="/"
-            className="text-purple-400 hover:text-purple-300 text-sm font-medium transition-colors"
-          >
-            Create your own Orb
-          </a>
+          <div className="flex items-center gap-1">
+            <NodeTypeFilter
+              hiddenTypes={hiddenNodeTypes}
+              onToggleType={handleToggleNodeType}
+              onShowAll={handleShowAllNodeTypes}
+              onHideAll={handleHideAllNodeTypes}
+            />
+            <a
+              href="/"
+              className="text-purple-400 hover:text-purple-300 text-sm font-medium transition-colors"
+            >
+              Create your own Orb
+            </a>
+          </div>
         </div>
       </div>
 
@@ -126,12 +154,10 @@ export default function SharedOrbPage() {
         }}
         highlightedNodeIds={highlightedNodeIds}
         filteredNodeIds={dateFilteredNodeIds}
+        hiddenNodeTypes={hiddenNodeTypes}
         width={dimensions.width}
         height={dimensions.height}
       />
-
-      {/* ── Node Legend ── */}
-      <NodeLegend />
 
       {/* ── Chat Box (no Add / Share buttons) ── */}
       <ChatBox

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -79,8 +79,10 @@ export default function SharedOrbPage() {
       data?.links ?? [],
       rangeStart,
       rangeEnd,
+      dateBounds?.min,
+      dateBounds?.max,
     ),
-    [data?.nodes, data?.links, rangeStart, rangeEnd],
+    [data?.nodes, data?.links, rangeStart, rangeEnd, dateBounds],
   );
 
   if (loading) {

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -53,7 +53,8 @@ function nodeIsInRange(
     if (d >= rangeStart && d <= rangeEnd) return true;
   }
 
-  // Check span overlap: node's earliest..latest overlaps range
+  // Span check: catches nodes whose date range brackets the selected range entirely
+  // (e.g., start_date before rangeStart AND end_date after rangeEnd)
   const sorted = [...dates].sort();
   const nodeMin = sorted[0];
   const nodeMax = sorted[sorted.length - 1];
@@ -107,6 +108,8 @@ export function computeDateFilteredNodeIds(
   // Build adjacency from links
   const neighbors = new Map<string, string[]>();
   for (const link of links) {
+    // react-force-graph-3d resolves source/target strings into node objects at runtime;
+    // this guard handles both the pre-simulation string form and the post-simulation object form.
     const src = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
     const tgt = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
     if (!neighbors.has(src)) neighbors.set(src, []);

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -90,8 +90,12 @@ export function computeDateFilteredNodeIds(
   _links: Array<{ source: string; target: string }>,
   rangeStart: string | null,
   rangeEnd: string | null,
+  boundsMin?: string | null,
+  boundsMax?: string | null,
 ): Set<string> {
   if (!rangeStart || !rangeEnd) return new Set();
+  // If range covers the full bounds, no filtering needed
+  if (boundsMin && boundsMax && rangeStart <= boundsMin && rangeEnd >= boundsMax) return new Set();
 
   const outOfRangeIds = new Set<string>();
 

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -82,71 +82,31 @@ function nodeIsInRange(
  * Logic:
  * 1. If range is null, return empty set (no filtering).
  * 2. Dated nodes outside the range → filtered.
- * 3. Dateless nodes: visible if at least one connected node is in range; otherwise filtered.
+ * 3. Dateless nodes (Skill, Language, Collaborator) are always visible.
  * 4. Person node is never filtered.
  */
 export function computeDateFilteredNodeIds(
   nodes: Array<Record<string, unknown>>,
-  links: Array<{ source: string; target: string }>,
+  _links: Array<{ source: string; target: string }>,
   rangeStart: string | null,
   rangeEnd: string | null,
 ): Set<string> {
   if (!rangeStart || !rangeEnd) return new Set();
 
-  // First pass: determine which dated nodes are in/out of range
-  const inRangeIds = new Set<string>();
   const outOfRangeIds = new Set<string>();
-  const datelessIds: string[] = [];
 
   for (const node of nodes) {
     const uid = node.uid as string;
     const labels = node._labels as string[] | undefined;
 
     // Person node is never filtered
-    if (labels?.[0] === 'Person') {
-      inRangeIds.add(uid);
-      continue;
-    }
+    if (labels?.[0] === 'Person') continue;
 
     const dates = getNodeDates(node);
-    if (dates.length === 0) {
-      datelessIds.push(uid);
-    } else if (nodeIsInRange(node, rangeStart, rangeEnd)) {
-      inRangeIds.add(uid);
-    } else {
-      outOfRangeIds.add(uid);
-    }
-  }
+    // Dateless nodes are always visible
+    if (dates.length === 0) continue;
 
-  // The Person node lives in data.person, not data.nodes, so the loop above
-  // never encounters it. Seed inRangeIds with any IDs that appear in links
-  // but not in nodes — this captures the Person node (always visible).
-  const nodeUidSet = new Set(nodes.map((n) => n.uid as string));
-  for (const link of links) {
-    const s = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
-    const t = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
-    if (s && !nodeUidSet.has(s)) inRangeIds.add(s);
-    if (t && !nodeUidSet.has(t)) inRangeIds.add(t);
-  }
-
-  // Second pass: dateless nodes — check if any connected node is in range
-  // Build adjacency from links
-  const neighbors = new Map<string, string[]>();
-  for (const link of links) {
-    // react-force-graph-3d resolves source/target strings into node objects at runtime;
-    // this guard handles both the pre-simulation string form and the post-simulation object form.
-    const src = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
-    const tgt = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
-    if (!neighbors.has(src)) neighbors.set(src, []);
-    if (!neighbors.has(tgt)) neighbors.set(tgt, []);
-    neighbors.get(src)!.push(tgt);
-    neighbors.get(tgt)!.push(src);
-  }
-
-  for (const uid of datelessIds) {
-    const adj = neighbors.get(uid) || [];
-    const hasVisibleNeighbor = adj.some((nid) => inRangeIds.has(nid));
-    if (!hasVisibleNeighbor) {
+    if (!nodeIsInRange(node, rangeStart, rangeEnd)) {
       outOfRangeIds.add(uid);
     }
   }

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -104,6 +104,17 @@ export function computeDateFilteredNodeIds(
     }
   }
 
+  // The Person node lives in data.person, not data.nodes, so the loop above
+  // never encounters it. Seed inRangeIds with any IDs that appear in links
+  // but not in nodes — this captures the Person node (always visible).
+  const nodeUidSet = new Set(nodes.map((n) => n.uid as string));
+  for (const link of links) {
+    const s = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
+    const t = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
+    if (s && !nodeUidSet.has(s)) inRangeIds.add(s);
+    if (t && !nodeUidSet.has(t)) inRangeIds.add(t);
+  }
+
   // Second pass: dateless nodes — check if any connected node is in range
   // Build adjacency from links
   const neighbors = new Map<string, string[]>();

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -10,13 +10,27 @@ const DATE_FIELDS = [
 
 /**
  * Normalize a date string to "YYYY-MM" format.
- * Accepts "YYYY", "YYYY-MM", or "YYYY-MM-DD".
+ * Accepts: "YYYY", "YYYY-MM", "YYYY-MM-DD", "YYYY-MM-DDTHH:MM:SS...",
+ * "MM/YYYY", "DD/MM/YYYY". Skips non-date values like "present".
  */
 function normalizeDate(raw: string): string | null {
-  const trimmed = raw.trim();
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || trimmed === 'present' || trimmed === 'current') return null;
+
+  // "YYYY"
   if (/^\d{4}$/.test(trimmed)) return `${trimmed}-01`;
+  // "YYYY-MM"
   if (/^\d{4}-\d{2}$/.test(trimmed)) return trimmed;
-  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed.slice(0, 7);
+  // "YYYY-MM-DD" optionally followed by time component (ISO datetime)
+  const isoMatch = trimmed.match(/^(\d{4}-\d{2})-\d{2}/);
+  if (isoMatch) return isoMatch[1];
+  // "MM/YYYY"
+  const mmYyyy = trimmed.match(/^(\d{1,2})\/(\d{4})$/);
+  if (mmYyyy) return `${mmYyyy[2]}-${mmYyyy[1].padStart(2, '0')}`;
+  // "DD/MM/YYYY"
+  const ddMmYyyy = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (ddMmYyyy) return `${ddMmYyyy[3]}-${ddMmYyyy[2].padStart(2, '0')}`;
+
   return null;
 }
 

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -103,8 +103,11 @@ export function computeDateFilteredNodeIds(
     if (labels?.[0] === 'Person') continue;
 
     const dates = getNodeDates(node);
-    // Dateless nodes are always visible
-    if (dates.length === 0) continue;
+    // Dateless nodes are hidden when slider is not at full range
+    if (dates.length === 0) {
+      outOfRangeIds.add(uid);
+      continue;
+    }
 
     if (!nodeIsInRange(node, rangeStart, rangeEnd)) {
       outOfRangeIds.add(uid);

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -1,0 +1,143 @@
+import { create } from 'zustand';
+
+// ── Date utilities ──
+
+const DATE_FIELDS = [
+  'start_date', 'end_date', 'date',
+  'issue_date', 'expiry_date',
+  'filing_date', 'grant_date',
+] as const;
+
+/**
+ * Normalize a date string to "YYYY-MM" format.
+ * Accepts "YYYY", "YYYY-MM", or "YYYY-MM-DD".
+ */
+function normalizeDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (/^\d{4}$/.test(trimmed)) return `${trimmed}-01`;
+  if (/^\d{4}-\d{2}$/.test(trimmed)) return trimmed;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed.slice(0, 7);
+  return null;
+}
+
+/**
+ * Extract all normalized dates from a node's known date fields.
+ */
+export function getNodeDates(node: Record<string, unknown>): string[] {
+  const dates: string[] = [];
+  for (const field of DATE_FIELDS) {
+    const val = node[field];
+    if (typeof val === 'string' && val) {
+      const norm = normalizeDate(val);
+      if (norm) dates.push(norm);
+    }
+  }
+  return dates;
+}
+
+/**
+ * Check if a dated node overlaps with the selected range.
+ * A node is "in range" if any of its dates fall within [rangeStart, rangeEnd],
+ * OR if it has a span (start_date..end_date etc.) that overlaps the range.
+ */
+function nodeIsInRange(
+  node: Record<string, unknown>,
+  rangeStart: string,
+  rangeEnd: string,
+): boolean {
+  const dates = getNodeDates(node);
+  if (dates.length === 0) return false; // dateless — handled separately
+
+  // Check if any single date is within range
+  for (const d of dates) {
+    if (d >= rangeStart && d <= rangeEnd) return true;
+  }
+
+  // Check span overlap: node's earliest..latest overlaps range
+  const sorted = [...dates].sort();
+  const nodeMin = sorted[0];
+  const nodeMax = sorted[sorted.length - 1];
+  // Overlap: nodeMin <= rangeEnd AND nodeMax >= rangeStart
+  return nodeMin <= rangeEnd && nodeMax >= rangeStart;
+}
+
+/**
+ * Compute node IDs that should be ghosted (transparent) based on the date range.
+ *
+ * Logic:
+ * 1. If range is null, return empty set (no filtering).
+ * 2. Dated nodes outside the range → filtered.
+ * 3. Dateless nodes: visible if at least one connected node is in range; otherwise filtered.
+ * 4. Person node is never filtered.
+ */
+export function computeDateFilteredNodeIds(
+  nodes: Array<Record<string, unknown>>,
+  links: Array<{ source: string; target: string }>,
+  rangeStart: string | null,
+  rangeEnd: string | null,
+): Set<string> {
+  if (!rangeStart || !rangeEnd) return new Set();
+
+  // First pass: determine which dated nodes are in/out of range
+  const inRangeIds = new Set<string>();
+  const outOfRangeIds = new Set<string>();
+  const datelessIds: string[] = [];
+
+  for (const node of nodes) {
+    const uid = node.uid as string;
+    const labels = node._labels as string[] | undefined;
+
+    // Person node is never filtered
+    if (labels?.[0] === 'Person') {
+      inRangeIds.add(uid);
+      continue;
+    }
+
+    const dates = getNodeDates(node);
+    if (dates.length === 0) {
+      datelessIds.push(uid);
+    } else if (nodeIsInRange(node, rangeStart, rangeEnd)) {
+      inRangeIds.add(uid);
+    } else {
+      outOfRangeIds.add(uid);
+    }
+  }
+
+  // Second pass: dateless nodes — check if any connected node is in range
+  // Build adjacency from links
+  const neighbors = new Map<string, string[]>();
+  for (const link of links) {
+    const src = typeof link.source === 'string' ? link.source : (link.source as any).id ?? link.source;
+    const tgt = typeof link.target === 'string' ? link.target : (link.target as any).id ?? link.target;
+    if (!neighbors.has(src)) neighbors.set(src, []);
+    if (!neighbors.has(tgt)) neighbors.set(tgt, []);
+    neighbors.get(src)!.push(tgt);
+    neighbors.get(tgt)!.push(src);
+  }
+
+  for (const uid of datelessIds) {
+    const adj = neighbors.get(uid) || [];
+    const hasVisibleNeighbor = adj.some((nid) => inRangeIds.has(nid));
+    if (!hasVisibleNeighbor) {
+      outOfRangeIds.add(uid);
+    }
+  }
+
+  return outOfRangeIds;
+}
+
+// ── Zustand store ──
+
+interface DateFilterState {
+  rangeStart: string | null;
+  rangeEnd: string | null;
+  setRange: (start: string, end: string) => void;
+  resetRange: () => void;
+}
+
+export const useDateFilterStore = create<DateFilterState>((set) => ({
+  rangeStart: null,
+  rangeEnd: null,
+  setRange: (start, end) => set({ rangeStart: start, rangeEnd: end }),
+  resetRange: () => set({ rangeStart: null, rangeEnd: null }),
+}));


### PR DESCRIPTION
## Summary

Closes #110

- Add a vertical dual-handle date range slider on the left side of the orb UI that filters nodes by time period
- Nodes outside the selected range become transparent (ghosted); dateless nodes are hidden when the slider is not at full range
- Available on both `/myorbis` (owner view) and public orb views
- Replace read-only Legend button with interactive View button on SharedOrbPage

## Changes

- **New:** `frontend/src/stores/dateFilterStore.ts` — Zustand store with date extraction utilities and filtering logic
- **New:** `frontend/src/components/graph/DateRangeSlider.tsx` — Vertical slider component with glass panel styling, draggable handles, and reset button
- **Modified:** `frontend/src/pages/OrbViewPage.tsx` — Integrate slider with merged keyword + date filtering
- **Modified:** `frontend/src/pages/SharedOrbPage.tsx` — Integrate slider + replace NodeLegend with NodeTypeFilter

## Test plan

- [ ] Navigate to `/myorbis` — slider appears on the left, vertically centered
- [ ] Drag handles to narrow the date range — out-of-range nodes become transparent
- [ ] Dateless nodes (Skills, Languages) ghost when slider is not at full range
- [ ] Drag handles back to extremes — all nodes reappear
- [ ] Click the gold reset button — slider returns to full range, all nodes visible
- [ ] Navigate to a public orb (`/<orbId>`) — slider works the same way
- [ ] View button in header toggles node type visibility on public orb view
- [ ] Slider hidden on mobile viewports (< 640px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)