### PR TITLE
fix: make toolbar hint text responsive on page resize

### DIFF
--- a/frontend/src/pages/CvExportPage.tsx
+++ b/frontend/src/pages/CvExportPage.tsx
@@ -895,12 +895,14 @@ const CV_CSS = `
     font-family: 'Roboto', sans-serif;
   }
   .cv-toolbar-hint {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0.85rem;
+    flex: 1;
+    min-width: 0;
+    font-size: 0.82rem;
     color: var(--md-on-surface-variant);
     font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .cv-toolbar-btn {
     display: inline-flex;
@@ -1399,8 +1401,10 @@ const CV_CSS = `
   @media (max-width: 900px) {
     .cv-sidebar { display: none; }
     .item-delete { right: -28px; width: 20px; height: 20px; font-size: 0.55rem; }
+    .cv-toolbar-hint { font-size: 0.72rem; }
   }
   @media (max-width: 600px) {
+    .cv-toolbar-hint { display: none; }
     .resume-container { padding: 24px 16px; border-radius: 16px; }
     .cv-page-body header { padding: 20px; }
     .cv-page-body h1 { font-size: 2rem; }


### PR DESCRIPTION
## Summary
- Replaces `position: absolute` with `flex: 1` so the hint text participates in the toolbar's flex layout instead of floating over buttons
- Adds `text-overflow: ellipsis` for graceful truncation at intermediate widths
- At `max-width: 900px`: reduces font size to `0.72rem`
- At `max-width: 600px`: hides the hint entirely (`display: none`)

Closes #114

## Test plan
- [ ] Wide screen (>900px): hint text visible, truncates with ellipsis if toolbar is tight
- [ ] Medium screen (600–900px): hint visible but smaller, doesn't overlap buttons
- [ ] Small screen (<600px): hint hidden, only action buttons remain
- [ ] Resize browser window continuously — no layout jumps or overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)