### PR TITLE
docs: add CLAUDE.md and structured docs/ folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# Orbis — Project Guide
+
+> Machine-readable overview for Claude Code sessions and developer onboarding.
+
+## Tech Stack
+
+- **Backend:** FastAPI (Python 3.10+), Neo4j 5 (Community), Anthropic Claude API, Ollama (local fallback)
+- **Frontend:** React 19 + TypeScript, Vite 8, Three.js / React Three Fiber, Tailwind CSS v4, Zustand 5
+- **Auth:** JWT (HS256) — dev-login only for now, Google OAuth scaffolded but not wired
+- **Package managers:** uv (backend), npm (frontend)
+- **Linting:** Ruff (backend, line-length 88), ESLint flat config (frontend)
+- **CI:** GitHub Actions — lint (both stacks), unit tests (75% coverage min), CV extraction quality regression
+
+## Repository Layout
+
+```
+backend/
+  app/
+    auth/        # JWT auth, dev-login, GDPR consent, account lifecycle
+    cv/          # CV PDF parsing (PyMuPDF), LLM classification (Ollama/Claude CLI), rule-based fallback
+    graph/       # Neo4j async driver, Cypher queries, Fernet encryption, embeddings (placeholder)
+    orbs/        # Orb (knowledge graph) CRUD, filter tokens for privacy-aware sharing
+    messages/    # Inbox system (public send, authenticated read/reply/delete)
+    notes/       # LLM-enhanced note-to-node conversion
+    search/      # Semantic (vector index) and fuzzy text search
+    export/      # Public orb export (JSON, JSON-LD, PDF)
+    main.py      # FastAPI app factory, middleware (CORS, SlowAPI), router registration
+    config.py    # Pydantic Settings (env-based)
+    rate_limit.py # SlowAPI limiter (30/min on public endpoints)
+    dependencies.py # get_db, get_current_user (JWT bearer)
+  mcp_server/    # MCP server exposing orb graph to AI agents (6 tools)
+  tests/
+    unit/        # pytest unit tests (mocked Neo4j, no external deps)
+    integration/ # CV extraction quality tests (calls real Claude CLI)
+    fixtures/    # Sample CV text + golden JSON baselines
+    lib/         # Graph comparator (fuzzy matching, F1/recall/composite scoring)
+frontend/
+  src/
+    api/         # Axios client (baseURL /api, auth interceptor, 401 redirect)
+    components/  # React components by domain (graph/, editor/, chat/, cv/, drafts/, landing/, onboarding/)
+    pages/       # Page-level components (Landing, CreateOrb, OrbView, SharedOrb, CvExport, About, Privacy)
+    stores/      # Zustand stores (auth, orb, filter, dateFilter, toast)
+docs/            # Detailed documentation (see below)
+infra/           # Neo4j init script (constraints, indexes, vector indexes)
+```
+
+## Key Conventions
+
+- Backend formatting: `ruff format` (line-length 88, double quotes)
+- Backend linting: `ruff check .` (rules: E, W, F, I, C4, B, UP, C90, SIM, ARG, PTH; max complexity 12)
+- Frontend linting: `eslint .` (flat config with typescript-eslint + react-hooks + react-refresh)
+- Tests: `cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75`
+- All Person node PII fields (email, phone, address) are Fernet-encrypted at rest
+- Environment config: `.env` (both backend and root), see `.env.example` for template
+- No pre-commit hooks — linting enforced via CI only
+- Backend runs directly (not containerized): `cd backend && uv run uvicorn app.main:app --reload`
+- Frontend runs directly: `cd frontend && npm run dev`
+
+## Services (Docker Compose)
+
+- **Neo4j:** ports 7474 (browser), 7687 (bolt) — auth: neo4j/orbis_dev_password
+- **Ollama:** port 11434
+- **Backend API:** port 8000 (run locally, not in Docker)
+- **Frontend dev:** port 5173 (Vite dev server with /api proxy to backend)
+
+## Quick Commands
+
+```bash
+# Backend
+cd backend
+uv sync --all-extras          # Install deps
+uv run uvicorn app.main:app --reload  # Start API
+uv run ruff check .           # Lint
+uv run ruff format .          # Format
+uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75  # Tests
+
+# Frontend
+cd frontend
+npm ci                        # Install deps
+npm run dev                   # Start dev server
+npm run lint                  # ESLint
+npm run build                 # Type-check + build
+
+# Infrastructure
+docker compose up -d          # Start Neo4j + Ollama
+```
+
+## Documentation
+
+Detailed docs live in `docs/`. Key files:
+
+- `docs/architecture.md` — system design, data flow, module interactions
+- `docs/api.md` — API endpoint reference (routes, methods, auth, payloads)
+- `docs/onboarding.md` — local setup, prerequisites, first-run steps
+- `docs/database.md` — Neo4j schema, node types, relationships, encryption
+- `docs/testing.md` — test strategy, running tests, CI pipelines, coverage
+- `docs/deployment.md` — production setup, Docker, environment variables
+- `docs/cv-extraction-quality.md` — CV extraction quality metrics and CI
+
+When making architectural changes, update both this file and the relevant docs.
+
+## Pre-PR Documentation Check (for Claude Code)
+
+Before creating any pull request, you MUST:
+
+1. Run `git diff main...HEAD` to review all changes in the branch
+2. Assess whether changes affect project structure, architecture, API, conventions, or infrastructure
+3. If they do, update `CLAUDE.md` and/or the relevant `docs/*.md` file before committing
+4. Add a "## Documentation" section to the PR description listing which docs were updated, or "No doc changes needed" if the changes are purely internal/cosmetic

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,92 @@
+# API Reference
+
+Base URL: `http://localhost:8000` (dev) — frontend proxies via `/api` prefix.
+
+## Authentication
+
+All protected endpoints require `Authorization: Bearer <jwt>`. JWT is obtained via `POST /auth/dev-login`.
+
+## Health Check
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/health` | No | Returns `{"status": "ok"}` |
+
+## Auth (`/auth`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/auth/dev-login` | No | Creates/retrieves dev user, returns JWT |
+| GET | `/auth/me` | JWT | Returns current user info (`user_id`, `email`, `name`, `gdpr_consent`) |
+| POST | `/auth/gdpr-consent` | JWT | Sets GDPR consent flag on Person node |
+| DELETE | `/auth/account` | JWT | Soft-deletes account (30-day grace period via `deletion_requested_at`) |
+
+## Orbs (`/orbs`)
+
+| Method | Path | Auth | Rate Limit | Description |
+|--------|------|------|------------|-------------|
+| GET | `/orbs/me` | JWT | — | Full orb: person + nodes + links |
+| PUT | `/orbs/me` | JWT | — | Update Person profile fields |
+| PUT | `/orbs/me/orb-id` | JWT | — | Claim/update public orb_id (409 if taken) |
+| POST | `/orbs/me/profile-image` | JWT | — | Upload profile image as base64 (max 2MB) |
+| DELETE | `/orbs/me/profile-image` | JWT | — | Clear profile image |
+| POST | `/orbs/me/nodes` | JWT | — | Create node (any type) linked to Person |
+| PUT | `/orbs/me/nodes/{uid}` | JWT | — | Update node properties |
+| DELETE | `/orbs/me/nodes/{uid}` | JWT | — | Delete node |
+| POST | `/orbs/me/link-skill` | JWT | — | Add `USED_SKILL` relationship |
+| POST | `/orbs/me/unlink-skill` | JWT | — | Remove `USED_SKILL` relationship |
+| POST | `/orbs/me/filter-token` | JWT | — | Generate shareable filter token (JWT with keyword exclusions) |
+| GET | `/orbs/{orb_id}` | No | 30/min | Public orb view (supports `?filter_token=`) |
+
+## CV (`/cv`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/cv/upload` | JWT | Upload PDF (max 10MB). Requires GDPR consent. Returns extracted nodes. |
+| GET | `/cv/processing-count` | No | Count of PDFs currently being processed |
+| POST | `/cv/confirm` | JWT | Persist confirmed nodes to Neo4j. Wipes existing graph first. |
+
+### CV Upload Response
+
+```json
+{
+  "nodes": [{"node_type": "work_experience", "properties": {...}}, ...],
+  "relationships": [{"source_index": 0, "target_index": 5, "type": "USED_SKILL"}],
+  "unmatched": ["line that couldn't be classified", ...],
+  "skipped_nodes": [...],
+  "truncated": false,
+  "cv_owner_name": "John Doe"
+}
+```
+
+## Export (`/export`)
+
+| Method | Path | Auth | Rate Limit | Description |
+|--------|------|------|------------|-------------|
+| GET | `/export/{orb_id}` | No | 30/min | Export orb as JSON, JSON-LD, or PDF |
+
+Query params: `?format=json|jsonld|pdf`, `?filter_token=`, `?filter_keyword=`, `?include_photo=true|false`
+
+## Messages (`/messages`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/messages/{orb_id}` | No | Send message to orb owner (public) |
+| GET | `/messages/me` | JWT | List all messages with replies |
+| POST | `/messages/me/{message_id}/reply` | JWT | Reply to a message |
+| PUT | `/messages/me/{message_id}/read` | JWT | Mark as read (204) |
+| DELETE | `/messages/me/{message_id}` | JWT | Delete message + replies (204) |
+
+## Notes (`/notes`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/notes/enhance` | JWT | LLM-enhanced note classification. Takes free text + target language + existing skills, returns structured node type + properties + suggested skill links. |
+
+## Search (`/search`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/search/semantic` | JWT | Vector similarity search across 5 Neo4j indexes |
+| POST | `/search/text` | JWT | Fuzzy text search on own orb |
+| POST | `/search/text/public` | No | Fuzzy text search on any public orb (supports `?filter_token=`) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,134 @@
+# Architecture
+
+## Overview
+
+Orbis is a personal knowledge graph platform that transforms CVs into interactive 3D graph visualizations. Users upload a PDF CV, an LLM extracts structured data, and the result is stored in Neo4j as a graph of interconnected professional entities (skills, experiences, education, etc.).
+
+## System Components
+
+```
+┌─────────────┐     /api proxy      ┌──────────────┐      Bolt       ┌─────────┐
+│   Frontend   │ ──────────────────► │   Backend    │ ──────────────► │  Neo4j  │
+│  React/Vite  │  localhost:5173     │   FastAPI    │  localhost:7687 │   5.x   │
+│   port 5173  │                     │   port 8000  │                 └─────────┘
+└─────────────┘                     └──────┬───────┘
+                                           │
+                                    ┌──────┴───────┐
+                                    │  LLM Layer   │
+                                    │              │
+                                    ├─ Ollama      │ localhost:11434
+                                    └─ Claude CLI  │ subprocess
+                                                   │
+                                    ┌──────────────┘
+                                    │  MCP Server  │ streamable-http
+                                    └──────────────┘
+```
+
+## Backend Architecture
+
+### App Factory (`app/main.py`)
+
+The FastAPI app uses a lifespan context manager:
+- **Startup:** connects to Neo4j, runs a probe query to validate connectivity
+- **Shutdown:** closes the Neo4j driver
+
+Middleware stack (outermost first):
+1. `SlowAPIMiddleware` — rate limiting on public endpoints
+2. `CORSMiddleware` — allows frontend origin only
+
+### Module Responsibilities
+
+| Module | Responsibility |
+|--------|---------------|
+| `auth/` | JWT creation/validation, dev-login flow, GDPR consent, account deletion |
+| `cv/` | PDF text extraction, LLM classification with fallback chain, graph persistence |
+| `graph/` | Neo4j driver singleton, all Cypher queries, Fernet encryption, embedding generation |
+| `orbs/` | Graph CRUD (nodes, relationships, profile), filter token generation |
+| `messages/` | Inbox (send, list, reply, read, delete), welcome message on registration |
+| `notes/` | Free-text note enhancement via LLM (classify to node type + properties) |
+| `search/` | Vector similarity search (5 indexes) + fuzzy text search (Cypher + Python fallback) |
+| `export/` | Public orb export as JSON, JSON-LD (Schema.org), or PDF (fpdf2) |
+| `mcp_server/` | MCP server exposing 6 tools for AI agent access to orb data |
+
+### Dependency Injection
+
+- `get_db()` — returns the Neo4j async driver instance
+- `get_current_user()` — extracts and validates JWT from `Authorization: Bearer` header, returns `{user_id, email}`
+
+### CV Processing Pipeline
+
+Three-stage pipeline with fallback chain:
+
+```
+PDF Upload
+    │
+    ▼
+Stage 1: PDF → Text (PyMuPDF/fitz, runs in thread pool)
+    │
+    ▼
+Stage 2: LLM Classification
+    ├─ Primary: Ollama or Claude CLI (configurable via LLM_PROVIDER)
+    ├─ Retry: up to 2 retries on parse failure
+    ├─ Fallback 1: Rule-based regex parser (6-language section detection)
+    └─ Fallback 2: Raw text lines as unmatched[] (up to 50 lines)
+    │
+    ▼
+Stage 3: User Review + Confirm
+    ├─ Frontend shows extracted nodes for editing
+    └─ POST /cv/confirm: wipes existing graph, MERGE nodes with dedup keys, creates USED_SKILL links
+```
+
+Text input is capped at 12,000 characters. Claude is called via CLI subprocess (`claude -p --output-format json`), not the Anthropic SDK.
+
+### Authentication Flow
+
+```
+POST /auth/dev-login
+    │
+    ├─ Lookup user by ID in Neo4j
+    ├─ If not found: CREATE Person node + send welcome message
+    └─ Return JWT (HS256, 24h expiry) with {sub: user_id, email}
+```
+
+JWT validation on protected endpoints via `HTTPBearer` scheme. Filter tokens are a separate JWT type with no expiry, encoding `{orb_id, filters[], type: "filter"}`.
+
+### Encryption
+
+Fernet symmetric encryption for PII fields (`email`, `phone`, `address`). Key from `ENCRYPTION_KEY` env var; auto-generated in dev mode if missing (data won't survive restarts).
+
+## Frontend Architecture
+
+### State Management
+
+Four Zustand stores:
+- **authStore** — user session, token (localStorage-backed), login/logout
+- **orbStore** — graph data (person + nodes + links), CRUD actions with automatic re-fetch
+- **filterStore** — keyword-based node filtering (persisted to localStorage)
+- **dateFilterStore** — date range slider state for temporal filtering
+
+### API Layer
+
+Axios instance at `/api` base URL. Vite dev server proxies `/api/*` to `localhost:8000` (stripping the prefix). Request interceptor injects JWT; response interceptor clears token on 401.
+
+### 3D Graph Rendering
+
+Two distinct 3D contexts:
+1. **HeroOrb** (landing page) — React Three Fiber with animated sphere, particles, rays, and Bloom post-processing
+2. **OrbGraph3D** (main app) — react-force-graph-3d with custom THREE.js node rendering, shared geometry pool, node object cache, animated orbital rings, background star field
+
+Performance optimizations: shared geometry (never recreated), node object cache (invalidated on data/filter changes), direct refs for animated objects, single `requestAnimationFrame` loop, ref-based state to avoid React re-renders.
+
+### Routing
+
+| Path | Page | Auth |
+|------|------|------|
+| `/` | LandingPage | Public |
+| `/auth/callback` | AuthCallbackPage | Public |
+| `/create` | CreateOrbPage | Required |
+| `/myorbis` | OrbViewPage | Required |
+| `/cv-export` | CvExportPage | Required |
+| `/:orbId` | SharedOrbPage | Public |
+
+## MCP Server
+
+Separate process (`python -m mcp_server.server`) exposing 6 tools via streamable-http transport. Connects to Neo4j independently (own driver instance). Tools: `orbis_get_summary`, `orbis_get_full_orb`, `orbis_get_nodes_by_type`, `orbis_get_connections`, `orbis_get_skills_for_experience`, `orbis_send_message`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,143 @@
+# Database — Neo4j Schema
+
+Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in `backend/app/graph/queries.py`.
+
+## Node Types
+
+### Person (root node, one per user)
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `user_id` | string | Unique identifier |
+| `orb_id` | string | User-chosen public slug |
+| `email` | string | Fernet-encrypted |
+| `name` | string | |
+| `headline` | string | |
+| `location` | string | |
+| `linkedin_url` | string | |
+| `scholar_url` | string | |
+| `website_url` | string | |
+| `open_to_work` | boolean | |
+| `profile_image` | string | Base64 data URI |
+| `gdpr_consent` | boolean | |
+| `gdpr_consent_at` | string | ISO datetime |
+| `deletion_requested_at` | string | ISO datetime (soft delete) |
+| `created_at` | datetime | Neo4j datetime |
+| `updated_at` | datetime | Neo4j datetime |
+
+### Education
+
+`institution`, `degree`, `field_of_study`, `start_date`, `end_date`, `description`, `location`, `uid`
+
+### WorkExperience
+
+`company`, `title`, `start_date`, `end_date`, `description`, `location`, `company_url`, `uid`
+
+### Skill
+
+`name`, `category` (Programming / Framework / Tool / Methodology / Soft Skill / Other), `proficiency` (Expert / Advanced / Intermediate / Beginner), `uid`, `embedding` (1536-dim vector, stripped from API responses)
+
+### Language
+
+`name`, `proficiency` (Native / Professional / B2 / C1 / etc.), `uid`
+
+### Certification
+
+`name`, `issuing_organization`, `issue_date`, `expiry_date`, `credential_url`, `uid`
+
+### Publication
+
+`title`, `venue`, `date`, `doi`, `url`, `abstract`, `uid`
+
+### Project
+
+`name`, `role`, `description`, `start_date`, `end_date`, `url`, `uid`
+
+### Patent
+
+`title`, `patent_number`, `filing_date`, `grant_date`, `status`, `description`, `url`, `uid`
+
+### Collaborator
+
+`name`, `email` (Fernet-encrypted), `uid`
+
+### Message
+
+`uid`, `sender_name`, `sender_email`, `subject`, `body`, `created_at`, `read`
+
+### Reply
+
+`uid`, `body`, `created_at`, `from_owner`
+
+## Relationships
+
+| Relationship | From | To | Purpose |
+|-------------|------|-----|---------|
+| `HAS_EDUCATION` | Person | Education | |
+| `HAS_WORK_EXPERIENCE` | Person | WorkExperience | |
+| `HAS_SKILL` | Person | Skill | |
+| `SPEAKS` | Person | Language | |
+| `HAS_CERTIFICATION` | Person | Certification | |
+| `HAS_PUBLICATION` | Person | Publication | |
+| `HAS_PROJECT` | Person | Project | |
+| `HAS_PATENT` | Person | Patent | |
+| `COLLABORATED_WITH` | Person | Collaborator | |
+| `HAS_MESSAGE` | Person | Message | Inbox |
+| `HAS_REPLY` | Message | Reply | Reply thread |
+| `USED_SKILL` | WorkExperience / Project / Education / Publication | Skill | Cross-entity skill link |
+
+The `USED_SKILL` relationship is the key graph feature — it connects experience nodes directly to Skill nodes, enabling queries like "which skills were used at company X?"
+
+## Deduplication Keys
+
+Used during `POST /cv/confirm` with Cypher `MERGE`:
+
+| Node Type | Merge Keys |
+|-----------|-----------|
+| Skill | `name` |
+| Language | `name` |
+| WorkExperience | `company`, `title` |
+| Education | `institution`, `degree` |
+| Certification | `name`, `issuing_organization` |
+| Publication | `title` |
+| Project | `name` |
+| Patent | `title` |
+| Collaborator | `name` |
+
+## Vector Indexes
+
+Five vector indexes for semantic search (1536 dimensions, cosine similarity):
+
+- `education_embedding`
+- `work_experience_embedding`
+- `certification_embedding`
+- `publication_embedding`
+- `project_embedding`
+
+Embeddings are currently placeholder (deterministic SHA-512 hash). The infrastructure is in place for real embeddings (OpenAI ada-002 or sentence-transformers).
+
+## Encryption
+
+Fernet symmetric encryption applied to PII fields: `email`, `phone`, `address`. Implemented in `backend/app/graph/encryption.py`.
+
+- `encrypt_properties(dict)` — encrypts only PII fields present in the dict
+- `decrypt_properties(dict)` — decrypts PII fields; logs warning and leaves value as-is on failure
+- Key sourced from `ENCRYPTION_KEY` env var; auto-generated in dev mode (data won't survive restarts)
+
+## Constraints and Indexes
+
+Defined in `infra/neo4j/init.cypher`:
+
+- Uniqueness constraint on `Person.user_id`
+- Uniqueness constraint on `Person.orb_id`
+- Standard indexes on node `uid` fields
+- Vector indexes on embedding fields (1536 dimensions, cosine)
+
+## Query Patterns
+
+All Cypher queries are centralized as string constants in `backend/app/graph/queries.py`. Key patterns:
+
+- **Graph fetch:** `MATCH (p:Person {user_id: $user_id})-[r]->(n) RETURN p, collect({node: n, rel: type(r)})` plus a second query for `USED_SKILL` relationships
+- **Node creation:** `MATCH (p:Person {user_id: $user_id}) CREATE (p)-[:HAS_*]->(n:Type {props}) RETURN n`
+- **CV confirm:** `DELETE_USER_GRAPH` (detach-deletes all nodes except Person) → `MERGE` per node with dedup keys → `CREATE USED_SKILL` links
+- **Public orb:** Same as graph fetch but matches on `orb_id` instead of `user_id`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,119 @@
+# Deployment
+
+## Docker Compose (Development)
+
+The `docker-compose.yml` at project root provides infrastructure services:
+
+```yaml
+services:
+  neo4j:
+    image: neo4j:5-community
+    ports:
+      - "7474:7474"   # Browser UI
+      - "7687:7687"   # Bolt protocol
+    environment:
+      NEO4J_AUTH: neo4j/orbis_dev_password
+    volumes:
+      - neo4j_data:/data
+      - ./infra/neo4j:/import
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: orbis-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+```
+
+The backend and frontend are **not containerized** — they run directly for faster iteration.
+
+### Starting services
+
+```bash
+docker compose up -d          # Start Neo4j + Ollama
+docker compose down           # Stop services
+docker compose down -v        # Stop + delete volumes (resets data)
+```
+
+### Neo4j Initialization
+
+On first run, apply the schema constraints and indexes:
+
+```bash
+# Via Neo4j Browser (http://localhost:7474) or cypher-shell:
+cat infra/neo4j/init.cypher | docker exec -i orb_project-neo4j-1 cypher-shell -u neo4j -p orbis_dev_password
+```
+
+This creates:
+- Uniqueness constraints on `Person.user_id` and `Person.orb_id`
+- Indexes on node `uid` fields
+- Vector indexes (1536 dimensions, cosine) for semantic search
+
+## Environment Variables
+
+All configuration is via environment variables. See `.env.example` for the full list.
+
+### Required for production
+
+| Variable | Purpose |
+|----------|---------|
+| `NEO4J_URI` | Neo4j Bolt connection string |
+| `NEO4J_USER` | Neo4j username |
+| `NEO4J_PASSWORD` | Neo4j password |
+| `JWT_SECRET` | Strong random secret for JWT signing |
+| `ENCRYPTION_KEY` | Fernet key for PII encryption (generate with `Fernet.generate_key()`) |
+| `FRONTEND_URL` | Frontend origin for CORS |
+
+### Optional
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ANTHROPIC_API_KEY` | — | For embedding checks |
+| `LLM_PROVIDER` | `ollama` | CV classifier: `ollama` or `claude` |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama endpoint |
+| `OLLAMA_MODEL` | `llama3.2:3b` | Ollama model |
+| `CLAUDE_MODEL` | `claude-opus-4-6` | Claude model for CV extraction |
+| `GOOGLE_CLIENT_ID` | — | Google OAuth (not yet active) |
+| `GOOGLE_CLIENT_SECRET` | — | Google OAuth (not yet active) |
+
+## MCP Server
+
+The MCP server runs as a separate process:
+
+```bash
+cd backend
+uv run python -m mcp_server.server
+```
+
+It connects to Neo4j independently and exposes 6 tools via streamable-http transport for AI agent access to orb data.
+
+## Running the Backend
+
+```bash
+cd backend
+uv sync --all-extras
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Add `--reload` for development. The app validates Neo4j connectivity on startup.
+
+## Running the Frontend
+
+### Development
+
+```bash
+cd frontend
+npm ci
+npm run dev
+```
+
+### Production build
+
+```bash
+cd frontend
+npm run build    # Output in frontend/dist/
+npm run preview  # Preview the built app
+```
+
+The production build (`tsc -b && vite build`) type-checks and bundles to `frontend/dist/`. Serve with any static file server; configure it to proxy `/api/*` requests to the backend.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,137 @@
+# Onboarding — Local Setup
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Python | 3.10+ | [python.org](https://www.python.org/) |
+| uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| Node.js | 20+ | [nodejs.org](https://nodejs.org/) |
+| Docker + Docker Compose | latest | [docker.com](https://www.docker.com/) |
+| Claude CLI | latest | `npm install -g @anthropic-ai/claude-code` (optional, for CV classification with Claude) |
+
+## First-Time Setup
+
+### 1. Clone and configure environment
+
+```bash
+git clone https://github.com/Brotherhood94/orb_project.git
+cd orb_project
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+- `JWT_SECRET` — any random string (change from default `change-me`)
+- `ENCRYPTION_KEY` — generate with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+- `ANTHROPIC_API_KEY` — if using Claude for CV classification
+
+### 2. Start infrastructure services
+
+```bash
+docker compose up -d
+```
+
+This starts:
+- **Neo4j** on ports 7474 (browser UI) and 7687 (Bolt)
+- **Ollama** on port 11434
+
+Verify Neo4j is running: open http://localhost:7474 and log in with `neo4j` / `orbis_dev_password`.
+
+### 3. Install and start the backend
+
+```bash
+cd backend
+uv sync --all-extras
+uv run uvicorn app.main:app --reload
+```
+
+The API starts on http://localhost:8000. Verify: `curl http://localhost:8000/health` should return `{"status":"ok"}`.
+
+On first startup, the app connects to Neo4j and runs a probe query. If Neo4j isn't ready yet, restart the backend.
+
+### 4. Install and start the frontend
+
+```bash
+cd frontend
+npm ci
+npm run dev
+```
+
+The dev server starts on http://localhost:5173 with hot module replacement. API calls to `/api/*` are proxied to the backend.
+
+### 5. (Optional) Pull Ollama model
+
+If using Ollama for CV classification:
+
+```bash
+docker exec orbis-ollama ollama pull llama3.2:3b
+```
+
+### 6. Login and create your orb
+
+1. Open http://localhost:5173
+2. Click the login button — this calls `POST /auth/dev-login` which creates a dev user
+3. Choose "Upload CV" or "Manual Entry" to start building your knowledge graph
+
+## Development Workflow
+
+### Running linters
+
+```bash
+# Backend
+cd backend
+uv run ruff check .       # Lint
+uv run ruff format .      # Auto-format
+
+# Frontend
+cd frontend
+npm run lint              # ESLint
+```
+
+### Running tests
+
+```bash
+cd backend
+uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75
+```
+
+Integration tests (CV extraction quality) require Claude CLI credentials:
+```bash
+uv run pytest tests/integration/ -v -s -m integration
+```
+
+### Backend Makefile shortcuts
+
+```bash
+cd backend
+make install   # uv sync --all-extras
+make lint      # ruff check
+make format    # ruff format
+make test      # pytest
+```
+
+## LLM Provider Configuration
+
+The CV classification pipeline supports two LLM providers, controlled by `LLM_PROVIDER` in `.env`:
+
+| Provider | Value | Requirements |
+|----------|-------|-------------|
+| Ollama | `ollama` (default) | Ollama running + model pulled |
+| Claude | `claude` | Claude CLI installed + authenticated |
+
+Claude is called via CLI subprocess (`claude -p`), not the Anthropic SDK directly.
+
+## Environment Variables
+
+See `.env.example` for the full list. Key variables:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `NEO4J_URI` | Neo4j Bolt connection | `bolt://localhost:7687` |
+| `NEO4J_PASSWORD` | Neo4j auth | `orbis_dev_password` |
+| `JWT_SECRET` | JWT signing key | `change-me` |
+| `ENCRYPTION_KEY` | Fernet key for PII encryption | auto-generated |
+| `LLM_PROVIDER` | CV classifier: `ollama` or `claude` | `ollama` |
+| `OLLAMA_MODEL` | Ollama model name | `llama3.2:3b` |
+| `CLAUDE_MODEL` | Claude model for CV extraction | `claude-opus-4-6` |
+| `FRONTEND_URL` | CORS allowed origin | `http://localhost:5173` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,111 @@
+# Testing
+
+## Test Structure
+
+```
+backend/tests/
+├── conftest.py               # Shared fixture: cv_fixture (parameterized over fixtures/)
+├── fixtures/                 # CV text files + golden JSON references
+│   ├── *_cv.txt              # Raw CV text input
+│   └── *_golden.json         # Expected extraction output (baseline)
+├── lib/
+│   └── graph_comparator.py   # Fuzzy graph comparison engine
+├── integration/
+│   ├── test_kg_quality.py    # CV extraction quality test (calls real Claude CLI)
+│   └── generate_baseline.py  # CLI script to regenerate golden baselines
+└── unit/
+    ├── conftest.py           # Mock Neo4j driver + TestClient fixtures
+    └── test_*.py             # Unit tests for every module
+```
+
+## Running Tests
+
+### Unit Tests
+
+```bash
+cd backend
+uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75
+```
+
+Unit tests mock Neo4j entirely (no database needed). The `conftest.py` provides:
+- `mock_neo4j_driver` (autouse) — patches `get_driver` and `close_driver` globally
+- `mock_db` — mock AsyncDriver with session/run/single chain
+- `client` — `TestClient` with `get_db` and `get_current_user` overrides
+
+Coverage minimum: **75%** (enforced in CI).
+
+### Integration Tests
+
+```bash
+cd backend
+uv run pytest tests/integration/ -v -s -m integration
+```
+
+Integration tests call the real Claude CLI to classify CVs and measure extraction quality against golden baselines. Requires Claude CLI installed and authenticated.
+
+## CI Pipelines
+
+### Lint (`lint.yml`)
+
+Runs on all PRs and pushes to `main`. Two parallel jobs:
+- **Backend:** `ruff check .` + `ruff format --check .`
+- **Frontend:** `npm run lint`
+
+### Unit Tests (`unit-tests.yml`)
+
+Runs on PRs/pushes to `main` when `backend/**` files change:
+- `uv run pytest tests/unit/ -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=75`
+
+### CV Extraction Quality (`cv-extraction-quality.yml`)
+
+Runs on PRs touching `backend/app/cv/**`, `backend/app/graph/queries.py`, or `backend/tests/**`. Two-phase:
+
+1. **Baseline generation:** checks out `main`, generates golden JSON baselines using `generate_baseline.py`
+2. **Quality check:** checks out PR branch, runs `test_kg_quality.py` against baselines
+
+Quality thresholds:
+
+| Metric | Threshold |
+|--------|-----------|
+| Overall F1 | >= 0.70 |
+| Overall Recall | >= 0.60 |
+| Composite (0.5 x F1 + 0.5 x property similarity) | >= 0.65 |
+
+Per-type recall minimums:
+- Education >= 0.66
+- WorkExperience >= 0.55
+- Language = 1.00
+- Skill >= 0.40
+
+## Graph Comparator
+
+`tests/lib/graph_comparator.py` implements fuzzy matching for extracted graph nodes:
+
+- **Token-level Jaccard similarity** with SequenceMatcher fallback
+- **Match threshold:** 0.4 similarity score
+- **Greedy assignment:** sorts all pairwise similarities, assigns best non-conflicting pairs
+- **Reports:** per-type precision/recall/F1 + overall + mean property similarity + composite score
+
+## pytest Configuration
+
+In `backend/pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = ["integration: tests that call external LLM APIs"]
+```
+
+The `integration` marker is used to skip LLM-calling tests in CI unit test runs.
+
+## Test Fixtures
+
+CV fixtures in `tests/fixtures/`:
+- `*_cv.txt` — raw CV text (used as input to the classifier)
+- `*_golden.json` — expected extraction output (list of `{node_type, properties}`)
+
+To regenerate baselines after intentional changes:
+```bash
+cd backend
+uv run python -m tests.integration.generate_baseline tests/fixtures/
+```


### PR DESCRIPTION
## Summary

- **CLAUDE.md** at repo root: machine-readable project overview for Claude Code sessions and developer onboarding — covers tech stack, repo layout, conventions, quick commands, and a pre-PR documentation check instruction
- **docs/architecture.md**: system design, data flow, module responsibilities, CV pipeline, auth flow, frontend architecture
- **docs/api.md**: complete API endpoint reference (all 7 routers, auth requirements, rate limits)
- **docs/onboarding.md**: local setup prerequisites, first-run steps, environment variables, LLM provider config
- **docs/database.md**: Neo4j node types, relationships, dedup keys, vector indexes, encryption, query patterns
- **docs/testing.md**: test structure, running tests, CI pipelines, quality thresholds, graph comparator
- **docs/deployment.md**: Docker Compose setup, environment variables, MCP server, production build

Closes #122

## Documentation

All files in this PR are documentation. The pre-PR check in CLAUDE.md creates a self-enforcing loop: Claude Code reads it at session start and ensures docs stay current on future PRs.

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify all docs/*.md files render correctly
- [ ] Verify internal links and references are accurate
- [ ] Confirm no existing files were modified


🤖 Generated with [Claude Code](https://claude.com/claude-code)