### PR TITLE
docs: add SVG logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# OpenOrbis
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
+    <img alt="OpenOrbis" src="docs/assets/logo-light.svg" width="400">
+  </picture>
+</p>
 
-> Your professional identity as a knowledge graph — shareable, queryable, and always up to date.
-
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-[![CI](https://github.com/Brotherhood94/orb_project/actions/workflows/lint.yml/badge.svg)](https://github.com/Brotherhood94/orb_project/actions/workflows/lint.yml)
-[![Tests](https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml)
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"></a>
+  <a href="https://github.com/Brotherhood94/orb_project/actions/workflows/lint.yml"><img src="https://github.com/Brotherhood94/orb_project/actions/workflows/lint.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml"><img src="https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml/badge.svg" alt="Tests"></a>
+</p>
 
 ## What is OpenOrbis?
 

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" viewBox="0 0 400 120" fill="none">
+  <!-- Outer glow -->
+  <circle cx="60" cy="60" r="44" fill="#7c3aed" fill-opacity="0.06"/>
+
+  <!-- Outer ring -->
+  <circle cx="60" cy="60" r="36" fill="#7c3aed" fill-opacity="0.12" stroke="#8b5cf6" stroke-opacity="0.3" stroke-width="1.5"/>
+
+  <!-- Orbital ring 1 -->
+  <ellipse cx="60" cy="60" rx="42" ry="14" fill="none" stroke="#a78bfa" stroke-opacity="0.3" stroke-width="1.2" transform="rotate(-30 60 60)"/>
+
+  <!-- Orbital ring 2 -->
+  <ellipse cx="60" cy="60" rx="42" ry="14" fill="none" stroke="#8b5cf6" stroke-opacity="0.2" stroke-width="1" transform="rotate(40 60 60)"/>
+
+  <!-- Mid glow -->
+  <circle cx="60" cy="60" r="20" fill="#7c3aed" fill-opacity="0.1"/>
+
+  <!-- Core orb -->
+  <circle cx="60" cy="60" r="14" fill="#7c3aed"/>
+
+  <!-- Core highlight -->
+  <circle cx="55" cy="55" r="5" fill="#a78bfa" fill-opacity="0.6"/>
+
+  <!-- Small orbiting nodes -->
+  <circle cx="28" cy="42" r="3" fill="#8b5cf6" fill-opacity="0.7"/>
+  <circle cx="88" cy="48" r="2.5" fill="#a78bfa" fill-opacity="0.6"/>
+  <circle cx="42" cy="90" r="2" fill="#7c3aed" fill-opacity="0.5"/>
+  <circle cx="82" cy="78" r="2.5" fill="#8b5cf6" fill-opacity="0.5"/>
+
+  <!-- Connection lines to orbiting nodes -->
+  <line x1="48" y1="52" x2="30" y2="43" stroke="#8b5cf6" stroke-opacity="0.2" stroke-width="0.8"/>
+  <line x1="72" y1="54" x2="86" y2="48" stroke="#a78bfa" stroke-opacity="0.15" stroke-width="0.8"/>
+  <line x1="52" y1="72" x2="43" y2="88" stroke="#7c3aed" stroke-opacity="0.15" stroke-width="0.8"/>
+  <line x1="72" y1="68" x2="80" y2="76" stroke="#8b5cf6" stroke-opacity="0.15" stroke-width="0.8"/>
+
+  <!-- Text: "OpenOrbis" -->
+  <text x="120" y="56" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="38" font-weight="700" fill="#1e1b4b" letter-spacing="-0.5">
+    Open<tspan fill="#7c3aed">Orbis</tspan>
+  </text>
+
+  <!-- Tagline -->
+  <text x="121" y="80" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="400" fill="#6b7280" letter-spacing="0.3">
+    Your professional identity as a knowledge graph
+  </text>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" viewBox="0 0 400 120" fill="none">
+  <!-- Background (transparent) -->
+
+  <!-- Outer glow -->
+  <circle cx="60" cy="60" r="44" fill="#7c3aed" fill-opacity="0.08"/>
+
+  <!-- Outer ring -->
+  <circle cx="60" cy="60" r="36" fill="#7c3aed" fill-opacity="0.2" stroke="#8b5cf6" stroke-opacity="0.4" stroke-width="1.5"/>
+
+  <!-- Orbital ring 1 -->
+  <ellipse cx="60" cy="60" rx="42" ry="14" fill="none" stroke="#a78bfa" stroke-opacity="0.35" stroke-width="1.2" transform="rotate(-30 60 60)"/>
+
+  <!-- Orbital ring 2 -->
+  <ellipse cx="60" cy="60" rx="42" ry="14" fill="none" stroke="#8b5cf6" stroke-opacity="0.25" stroke-width="1" transform="rotate(40 60 60)"/>
+
+  <!-- Mid glow -->
+  <circle cx="60" cy="60" r="20" fill="#7c3aed" fill-opacity="0.15"/>
+
+  <!-- Core orb -->
+  <circle cx="60" cy="60" r="14" fill="#a78bfa"/>
+
+  <!-- Core highlight -->
+  <circle cx="55" cy="55" r="5" fill="#c4b5fd" fill-opacity="0.6"/>
+
+  <!-- Small orbiting nodes -->
+  <circle cx="28" cy="42" r="3" fill="#8b5cf6" fill-opacity="0.7"/>
+  <circle cx="88" cy="48" r="2.5" fill="#a78bfa" fill-opacity="0.6"/>
+  <circle cx="42" cy="90" r="2" fill="#7c3aed" fill-opacity="0.5"/>
+  <circle cx="82" cy="78" r="2.5" fill="#c4b5fd" fill-opacity="0.5"/>
+
+  <!-- Connection lines to orbiting nodes -->
+  <line x1="48" y1="52" x2="30" y2="43" stroke="#8b5cf6" stroke-opacity="0.25" stroke-width="0.8"/>
+  <line x1="72" y1="54" x2="86" y2="48" stroke="#a78bfa" stroke-opacity="0.2" stroke-width="0.8"/>
+  <line x1="52" y1="72" x2="43" y2="88" stroke="#7c3aed" stroke-opacity="0.2" stroke-width="0.8"/>
+  <line x1="72" y1="68" x2="80" y2="76" stroke="#c4b5fd" stroke-opacity="0.2" stroke-width="0.8"/>
+
+  <!-- Text: "OpenOrbis" -->
+  <text x="120" y="56" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="38" font-weight="700" fill="#f5f3ff" letter-spacing="-0.5">
+    Open<tspan fill="#a78bfa">Orbis</tspan>
+  </text>
+
+  <!-- Tagline -->
+  <text x="121" y="80" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="13" font-weight="400" fill="#a1a1aa" letter-spacing="0.3">
+    Your professional identity as a knowledge graph
+  </text>
+</svg>


### PR DESCRIPTION
## Summary

- Add purple orb SVG logo with orbital rings, orbiting nodes, and connection lines — matching the favicon and 3D graph visual language
- Dark and light variants for GitHub theme-aware switching via `<picture>` element
- Center-align README header with badges

## Files

- `docs/assets/logo.svg` — dark mode logo (light text on transparent)
- `docs/assets/logo-light.svg` — light mode logo (dark text on transparent)
- `README.md` — updated header to use the logo

## Documentation

No doc changes needed beyond the README itself.

## Test plan

- [ ] Verify logo renders on GitHub in dark mode
- [ ] Verify logo renders on GitHub in light mode
- [ ] Verify badges remain visible and aligned below the logo


🤖 Generated with [Claude Code](https://claude.com/claude-code)