### PR TITLE
fix: place orb icon inline next to OpenOrbis title

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@
 
 ## What is OpenOrbis?
 
-OpenOrbis is a personal knowledge graph platform that transforms your professional identity — education, work experience, skills, projects, publications, certifications, languages, and patents — into an **interactive 3D graph**. Instead of a static PDF resume, your professional profile becomes a living, queryable data structure that both humans and AI agents can explore.
+OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Instead of a static PDF, your professional identity — skills, experience, education, projects, publications, and more — becomes a queryable data structure that both humans and AI agents can explore.
 
-Every orbis has a **shareable URL** and **QR code**, making it easy to share with recruiters, collaborators, or embed in your portfolio. The graph is natively accessible to AI agents via the **Model Context Protocol (MCP)**, so tools like Claude, Cursor, and Copilot can query your professional background directly.
+🌐 **Share it** — every orbis gets a unique URL and QR code, ready to send to recruiters or embed in your portfolio
 
-Sensitive data is **encrypted at rest** with Fernet, and **GDPR compliance** is built in — users must grant explicit consent before any data is stored, and accounts can be soft-deleted with a 30-day grace period.
+🤖 **Query it** — AI agents (Claude, Cursor, Copilot) can access your graph natively via the **Model Context Protocol (MCP)**
+
+🔒 **Own it** — PII is encrypted at rest, GDPR consent is enforced before any data is stored, and accounts can be soft-deleted with a 30-day grace period
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-    <img alt="OpenOrbis" src="docs/assets/logo-light.svg" width="400">
+    <img alt="OpenOrbis" src="docs/assets/logo-light.svg" width="320">
   </picture>
 </h1>
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,6 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 
 🤖 **Query it** — AI agents (Claude, Cursor, Copilot) can access your graph natively via the **Model Context Protocol (MCP)**
 
-### Use Cases
-
-📄 **Job seekers** — replace your static CV with a living profile that highlights skill connections across roles
-
-🏢 **Recruiters & hiring managers** — explore a candidate's skill graph instead of skimming bullet points; filter by tech stack, time period, or role
-
-🎓 **Researchers & academics** — map publications, collaborations, and expertise areas into a navigable knowledge graph
-
-🤝 **Freelancers & consultants** — share a filtered view of your orbis per client, showing only relevant experience
-
-🔗 **AI-powered workflows** — let agents pull structured professional data via MCP for automated sourcing, matching, or portfolio analysis
-
-📊 **Team leads** — visualize your team's collective skills to identify gaps or plan training
-
 ---
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 
 🤖 **Query it** — AI agents (Claude, Cursor, Copilot) can access your graph natively via the **Model Context Protocol (MCP)**
 
+### Use Cases
+
+📄 **Job seekers** — replace your static CV with a living profile that highlights skill connections across roles
+
+🏢 **Recruiters & hiring managers** — explore a candidate's skill graph instead of skimming bullet points; filter by tech stack, time period, or role
+
+🎓 **Researchers & academics** — map publications, collaborations, and expertise areas into a navigable knowledge graph
+
+🤝 **Freelancers & consultants** — share a filtered view of your orbis per client, showing only relevant experience
+
+🔗 **AI-powered workflows** — let agents pull structured professional data via MCP for automated sourcing, matching, or portfolio analysis
+
+📊 **Team leads** — visualize your team's collective skills to identify gaps or plan training
+
 ---
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p align="center">
-  Your professional identity as a knowledge graph — shareable, queryable, and always up to date.
+  <em>Your professional identity as a knowledge graph — shareable, queryable, and always up to date.</em>
 </p>
 
 <p align="center">
@@ -16,53 +16,84 @@
   <a href="https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml"><img src="https://github.com/Brotherhood94/orb_project/actions/workflows/unit-tests.yml/badge.svg" alt="Tests"></a>
 </p>
 
+<br>
+
 ## What is OpenOrbis?
 
-OpenOrbis is a personal knowledge graph platform that transforms your professional identity — education, work experience, skills, projects, publications, certifications, languages, and patents — into an interactive 3D graph. Instead of a static PDF resume, your professional profile becomes a living, queryable data structure that both humans and AI agents can explore.
+OpenOrbis is a personal knowledge graph platform that transforms your professional identity — education, work experience, skills, projects, publications, certifications, languages, and patents — into an **interactive 3D graph**. Instead of a static PDF resume, your professional profile becomes a living, queryable data structure that both humans and AI agents can explore.
 
-Every orbis has a shareable URL and QR code, making it easy to share with recruiters, collaborators, or embed in your portfolio. The graph is natively accessible to AI agents via the Model Context Protocol (MCP), so tools like Claude, Cursor, and Copilot can query your professional background directly.
+Every orbis has a **shareable URL** and **QR code**, making it easy to share with recruiters, collaborators, or embed in your portfolio. The graph is natively accessible to AI agents via the **Model Context Protocol (MCP)**, so tools like Claude, Cursor, and Copilot can query your professional background directly.
 
-Sensitive data is encrypted at rest with Fernet, and GDPR compliance is built in — users must grant explicit consent before any data is stored, and accounts can be soft-deleted with a 30-day grace period.
+Sensitive data is **encrypted at rest** with Fernet, and **GDPR compliance** is built in — users must grant explicit consent before any data is stored, and accounts can be soft-deleted with a 30-day grace period.
+
+---
 
 ## Key Features
 
-**For Users:**
-- Two onboarding paths: upload a PDF CV or build your graph node-by-node
-- 3D interactive graph visualization (Three.js / react-force-graph-3d)
-- Export to PDF with accurate page-break preview
-- Custom shareable URL with QR code
-- Draft notes with LLM-powered enhancement (refine free text into structured CV entries)
-- Inbox for receiving messages from recruiters and AI agents
-- Date range slider to filter the graph by time period
-- Keyword-based node filtering with shareable filter tokens (privacy-aware sharing)
-- Fuzzy text search and semantic vector search across all node types
-- "Open to Work" flag on your profile
+<table>
+<tr>
+<td width="33%" valign="top">
 
-**For AI Agents (MCP):**
-- 6 queryable tools: `orbis_get_summary`, `orbis_get_full_orb`, `orbis_get_nodes_by_type`, `orbis_get_connections`, `orbis_get_skills_for_experience`, `orbis_send_message`
-- Structured JSON responses for easy LLM consumption
-- Filter token-based access control per consumer
+### For Users
 
-**Privacy & Security:**
-- Fernet encryption for all PII fields (email, phone, address) at rest
-- GDPR consent tracking and 30-day soft-delete
-- Granular sharing with filter tokens (hide specific nodes by keyword)
+- Upload a PDF CV or build node-by-node
+- 3D interactive graph (Three.js)
+- Export to PDF with page-break preview
+- Shareable URL with QR code
+- Draft notes with LLM enhancement
+- Inbox for recruiters & AI agents
+- Date range slider for temporal filtering
+- Privacy-aware sharing via filter tokens
+- Fuzzy + semantic vector search
+- "Open to Work" flag
+
+</td>
+<td width="33%" valign="top">
+
+### For AI Agents (MCP)
+
+- `orbis_get_summary`
+- `orbis_get_full_orb`
+- `orbis_get_nodes_by_type`
+- `orbis_get_connections`
+- `orbis_get_skills_for_experience`
+- `orbis_send_message`
+- Structured JSON responses
+- Filter token access control
+
+</td>
+<td width="33%" valign="top">
+
+### Privacy & Security
+
+- Fernet encryption for PII at rest
+- GDPR consent tracking
+- 30-day soft-delete grace period
+- Granular sharing with filter tokens
+- Per-field encryption (email, phone, address)
+
+</td>
+</tr>
+</table>
+
+---
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|------------|
-| **Frontend** | React 19, TypeScript, Vite 8, Tailwind CSS v4, Three.js, Framer Motion, Zustand |
-| **Backend** | FastAPI, Python 3.10+, Uvicorn |
-| **Database** | Neo4j 5 (graph database with vector indexes) |
-| **AI/LLM** | Anthropic Claude (via CLI), Ollama (llama3.2:3b local fallback) |
-| **Auth** | JWT (HS256), Google OAuth (scaffolded) |
-| **Encryption** | Fernet (cryptography) |
-| **Agent Protocol** | MCP (Model Context Protocol) |
-| **PDF Processing** | PyMuPDF (extraction), fpdf2 (generation) |
-| **CI/CD** | GitHub Actions (lint, unit tests, CV extraction quality) |
-| **Package Managers** | uv (backend), npm (frontend) |
-| **License** | GNU AGPL v3 |
+<table>
+<tr><td><strong>Frontend</strong></td><td>React 19 · TypeScript · Vite 8 · Tailwind CSS v4 · Three.js · Framer Motion · Zustand</td></tr>
+<tr><td><strong>Backend</strong></td><td>FastAPI · Python 3.10+ · Uvicorn</td></tr>
+<tr><td><strong>Database</strong></td><td>Neo4j 5 (graph database with vector indexes)</td></tr>
+<tr><td><strong>AI / LLM</strong></td><td>Anthropic Claude (via CLI) · Ollama (llama3.2:3b local fallback)</td></tr>
+<tr><td><strong>Auth</strong></td><td>JWT (HS256) · Google OAuth (scaffolded)</td></tr>
+<tr><td><strong>Encryption</strong></td><td>Fernet (cryptography)</td></tr>
+<tr><td><strong>Agent Protocol</strong></td><td>MCP (Model Context Protocol)</td></tr>
+<tr><td><strong>PDF</strong></td><td>PyMuPDF (extraction) · fpdf2 (generation)</td></tr>
+<tr><td><strong>CI/CD</strong></td><td>GitHub Actions — lint · unit tests · CV extraction quality</td></tr>
+<tr><td><strong>Package Mgrs</strong></td><td>uv (backend) · npm (frontend)</td></tr>
+</table>
+
+---
 
 ## Project Structure
 
@@ -96,14 +127,16 @@ orb_project/
 └── LICENSE                    # GNU AGPL v3
 ```
 
+---
+
 ## Getting Started
 
 ### Prerequisites
 
-- Python 3.10+
-- Node.js 20+
-- Docker and Docker Compose
-- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- **Python** 3.10+
+- **Node.js** 20+
+- **Docker** and Docker Compose
+- [**uv**](https://docs.astral.sh/uv/) (Python package manager)
 
 ### 1. Clone and configure
 
@@ -147,12 +180,14 @@ docker exec orbis-ollama ollama pull llama3.2:3b
 
 ### 6. Open the app
 
-Navigate to http://localhost:5173, click login (dev mode), and choose "Upload CV" or "Manual Entry" to build your orb.
+Navigate to http://localhost:5173, click login (dev mode), and choose **"Upload CV"** or **"Manual Entry"** to build your orb.
+
+---
 
 ## Environment Variables
 
 | Variable | Description | Required |
-|----------|-------------|----------|
+|----------|-------------|:--------:|
 | `NEO4J_URI` | Neo4j Bolt connection URI | Yes |
 | `NEO4J_USER` | Neo4j username | Yes |
 | `NEO4J_PASSWORD` | Neo4j password | Yes |
@@ -160,15 +195,17 @@ Navigate to http://localhost:5173, click login (dev mode), and choose "Upload CV
 | `ENCRYPTION_KEY` | Fernet key for PII field encryption | Yes |
 | `FRONTEND_URL` | Frontend origin for CORS | Yes |
 | `BACKEND_URL` | Backend URL | Yes |
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID | Prod only |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | Prod only |
-| `ANTHROPIC_API_KEY` | Claude API key | Optional |
-| `OLLAMA_BASE_URL` | Ollama endpoint (default: `http://localhost:11434`) | Optional |
-| `OLLAMA_MODEL` | Ollama model name (default: `llama3.2:3b`) | Optional |
-| `JWT_ALGORITHM` | JWT signing algorithm (default: `HS256`) | Optional |
-| `JWT_EXPIRE_MINUTES` | JWT token TTL in minutes (default: `1440`) | Optional |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID | Prod |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | Prod |
+| `ANTHROPIC_API_KEY` | Claude API key | — |
+| `OLLAMA_BASE_URL` | Ollama endpoint (default: `http://localhost:11434`) | — |
+| `OLLAMA_MODEL` | Ollama model name (default: `llama3.2:3b`) | — |
+| `JWT_ALGORITHM` | JWT signing algorithm (default: `HS256`) | — |
+| `JWT_EXPIRE_MINUTES` | JWT token TTL in minutes (default: `1440`) | — |
 
-See [`.env.example`](.env.example) for the full template.
+> See [`.env.example`](.env.example) for the full template.
+
+---
 
 ## Running Tests
 
@@ -186,11 +223,13 @@ cd frontend
 npm run lint
 ```
 
-See [`docs/testing.md`](docs/testing.md) for the full test strategy, CI pipelines, and CV extraction quality gates.
+> See [`docs/testing.md`](docs/testing.md) for the full test strategy, CI pipelines, and CV extraction quality gates.
+
+---
 
 ## MCP Integration
 
-OpenOrbis includes an MCP server that exposes your knowledge graph to AI agents. The server provides 6 tools:
+OpenOrbis includes an MCP server that exposes your knowledge graph to AI agents:
 
 | Tool | Description |
 |------|-------------|
@@ -201,34 +240,34 @@ OpenOrbis includes an MCP server that exposes your knowledge graph to AI agents.
 | `orbis_get_skills_for_experience` | Skills linked to a work experience or project |
 | `orbis_send_message` | Send a message to the orb owner |
 
-To run the MCP server:
-
 ```bash
 cd backend
-uv run python -m mcp_server.server
+uv run python -m mcp_server.server    # streamable-http transport
 ```
 
-The server uses streamable-http transport and connects to Neo4j independently.
+---
 
 ## Knowledge Graph Schema
 
 Each user's orb is a graph rooted at a **Person** node, connected to domain-specific nodes via typed relationships:
 
 ```
-Person ──HAS_EDUCATION──► Education
-       ──HAS_WORK_EXPERIENCE──► WorkExperience
-       ──HAS_SKILL──► Skill
-       ──SPEAKS──► Language
-       ──HAS_CERTIFICATION──► Certification
-       ──HAS_PUBLICATION──► Publication
-       ──HAS_PROJECT──► Project
-       ──HAS_PATENT──► Patent
-       ──COLLABORATED_WITH──► Collaborator
+Person ──HAS_EDUCATION──────────► Education
+       ──HAS_WORK_EXPERIENCE───► WorkExperience
+       ──HAS_SKILL─────────────► Skill
+       ──SPEAKS────────────────► Language
+       ──HAS_CERTIFICATION─────► Certification
+       ──HAS_PUBLICATION───────► Publication
+       ──HAS_PROJECT───────────► Project
+       ──HAS_PATENT────────────► Patent
+       ──COLLABORATED_WITH─────► Collaborator
 ```
 
-The key graph feature is `USED_SKILL` — a cross-link between experience nodes (WorkExperience, Project, Education, Publication) and Skill nodes, enabling queries like "which skills were used at company X?"
+The key graph feature is **`USED_SKILL`** — a cross-link between experience nodes and Skill nodes, enabling queries like *"which skills were used at company X?"*
 
-See [`ontology.md`](ontology.md) for the full schema and [`docs/database.md`](docs/database.md) for query patterns and indexes.
+> See [`ontology.md`](ontology.md) for the full schema and [`docs/database.md`](docs/database.md) for query patterns and indexes.
+
+---
 
 ## Contributing
 
@@ -242,18 +281,24 @@ See [`ontology.md`](ontology.md) for the full schema and [`docs/database.md`](do
 4. Ensure tests pass with >= 75% coverage
 5. Open a pull request against `main`
 
+---
+
 ## Documentation
 
 Detailed documentation lives in [`docs/`](docs/):
 
-- [`architecture.md`](docs/architecture.md) — system design and data flow
-- [`api.md`](docs/api.md) — API endpoint reference
-- [`onboarding.md`](docs/onboarding.md) — local setup and dev workflow
-- [`database.md`](docs/database.md) — Neo4j schema and query patterns
-- [`testing.md`](docs/testing.md) — test strategy and CI pipelines
-- [`deployment.md`](docs/deployment.md) — production setup and Docker
-- [`cv-extraction-quality.md`](docs/cv-extraction-quality.md) — CV extraction quality metrics
+| Document | Description |
+|----------|-------------|
+| [`architecture.md`](docs/architecture.md) | System design and data flow |
+| [`api.md`](docs/api.md) | API endpoint reference |
+| [`onboarding.md`](docs/onboarding.md) | Local setup and dev workflow |
+| [`database.md`](docs/database.md) | Neo4j schema and query patterns |
+| [`testing.md`](docs/testing.md) | Test strategy and CI pipelines |
+| [`deployment.md`](docs/deployment.md) | Production setup and Docker |
+| [`cv-extraction-quality.md`](docs/cv-extraction-quality.md) | CV extraction quality metrics |
 
-## License
+---
 
-This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).
+<p align="center">
+  Licensed under the <a href="LICENSE">GNU Affero General Public License v3.0</a>
+</p>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-    <img alt="" src="docs/assets/logo-light.svg" width="36" valign="middle">
+    <img alt="OpenOrbis" src="docs/assets/logo-light.svg" width="400">
   </picture>
-  OpenOrbis
 </h1>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-<p align="center">
+<h1 align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-    <img alt="OpenOrbis" src="docs/assets/logo-light.svg" width="80">
+    <img alt="" src="docs/assets/logo-light.svg" width="36" valign="middle">
   </picture>
-</p>
-
-<h1 align="center">OpenOrbis</h1>
+  OpenOrbis
+</h1>
 
 <p align="center">
   Your professional identity as a knowledge graph — shareable, queryable, and always up to date.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p align="center">
-  <em>Your professional identity as a knowledge graph — shareable, queryable, and always up to date.</em>
+  <em>Your professional identity as a knowledge graph.<br>Shareable, queryable, and always up to date.</em>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 
 🤖 **Query it** — AI agents (Claude, Cursor, Copilot) can access your graph natively via the **Model Context Protocol (MCP)**
 
-🔒 **Own it** — PII is encrypted at rest, GDPR consent is enforced before any data is stored, and accounts can be soft-deleted with a 30-day grace period
-
 ---
 
 ## Key Features

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,4 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
-  <circle cx="40" cy="40" r="38" fill="#7c3aed" fill-opacity="0.2" stroke="#8b5cf6" stroke-opacity="0.3" stroke-width="1.5"/>
-  <circle cx="40" cy="40" r="16" fill="#7c3aed"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="100" viewBox="0 0 420 100" fill="none">
+  <!-- Outer circle -->
+  <circle cx="50" cy="50" r="44" fill="#7c3aed" fill-opacity="0.2" stroke="#8b5cf6" stroke-opacity="0.3" stroke-width="1.5"/>
+
+  <!-- Core orb -->
+  <circle cx="50" cy="50" r="18" fill="#7c3aed"/>
+
+  <!-- Text -->
+  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#1e1b4b" letter-spacing="-1">Open</text>
+  <text x="248" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#7c3aed" letter-spacing="-1">Orbis</text>
 </svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -6,5 +6,5 @@
   <circle cx="50" cy="50" r="18" fill="#7c3aed"/>
 
   <!-- Text -->
-  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#1e1b4b" letter-spacing="-1">Open<tspan fill="#7c3aed">Orbis</tspan></text>
+  <text x="110" y="66" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="58" font-weight="700" fill="#1e1b4b" letter-spacing="-1">Open<tspan fill="#7c3aed">Orbis</tspan></text>
 </svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -6,6 +6,5 @@
   <circle cx="50" cy="50" r="18" fill="#7c3aed"/>
 
   <!-- Text -->
-  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#1e1b4b" letter-spacing="-1">Open</text>
-  <text x="248" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#7c3aed" letter-spacing="-1">Orbis</text>
+  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#1e1b4b" letter-spacing="-1">Open<tspan fill="#7c3aed">Orbis</tspan></text>
 </svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -6,6 +6,5 @@
   <circle cx="50" cy="50" r="18" fill="#a78bfa"/>
 
   <!-- Text -->
-  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#f5f3ff" letter-spacing="-1">Open</text>
-  <text x="248" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#a78bfa" letter-spacing="-1">Orbis</text>
+  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#f5f3ff" letter-spacing="-1">Open<tspan fill="#a78bfa">Orbis</tspan></text>
 </svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,4 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
-  <circle cx="40" cy="40" r="38" fill="#7c3aed" fill-opacity="0.3" stroke="#8b5cf6" stroke-opacity="0.4" stroke-width="1.5"/>
-  <circle cx="40" cy="40" r="16" fill="#a78bfa"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="100" viewBox="0 0 420 100" fill="none">
+  <!-- Outer circle -->
+  <circle cx="50" cy="50" r="44" fill="#7c3aed" fill-opacity="0.3" stroke="#8b5cf6" stroke-opacity="0.4" stroke-width="1.5"/>
+
+  <!-- Core orb -->
+  <circle cx="50" cy="50" r="18" fill="#a78bfa"/>
+
+  <!-- Text -->
+  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#f5f3ff" letter-spacing="-1">Open</text>
+  <text x="248" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#a78bfa" letter-spacing="-1">Orbis</text>
 </svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -6,5 +6,5 @@
   <circle cx="50" cy="50" r="18" fill="#a78bfa"/>
 
   <!-- Text -->
-  <text x="110" y="62" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="48" font-weight="700" fill="#f5f3ff" letter-spacing="-1">Open<tspan fill="#a78bfa">Orbis</tspan></text>
+  <text x="110" y="66" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="58" font-weight="700" fill="#f5f3ff" letter-spacing="-1">Open<tspan fill="#a78bfa">Orbis</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary

- Move the orb SVG icon inside the `<h1>` tag so it appears to the left of "OpenOrbis" text
- Keeps the dark/light theme switching via `<picture>` element

## Test plan

- [ ] Verify orb icon appears to the left of "OpenOrbis" title on GitHub
- [ ] Verify dark/light mode switching works


🤖 Generated with [Claude Code](https://claude.com/claude-code)