### PR TITLE
fix: account deletion confirmation dialog overflows settings panel

### DIFF
--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -204,7 +204,7 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.92, y: 24 }}
         transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl h-[420px] max-h-[90vh] overflow-hidden flex flex-col"
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl h-[520px] max-h-[90vh] overflow-hidden flex flex-col"
       >
         <div className="p-4 sm:p-6 pb-0">
           <h2 className="text-white text-lg font-semibold mb-1">Settings</h2>


### PR DESCRIPTION
## Summary

The settings panel was `h-[420px]` which was too short to fit the delete account confirmation dialog. Increased to `h-[520px]` so the Cancel/Delete buttons are fully visible without clipping.

Fixes #137

## Documentation

No doc changes needed.

## Test plan

- [ ] Open Settings > Account > click "Delete Account"
- [ ] Verify the confirmation dialog with Cancel/Delete buttons is fully visible
- [ ] Verify other tabs (Orbis ID, Filters) still render correctly
- [ ] Verify panel looks correct on smaller viewports (max-h-[90vh] still applies)


🤖 Generated with [Claude Code](https://claude.com/claude-code)