### PR TITLE
feat: MCP endpoint contract tests and filter_token support

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -32,40 +32,59 @@ async def _get_driver():
 
 
 @mcp.tool()
-async def orbis_get_summary(orb_id: str) -> dict:
-    """Get a summary of a person's professional profile including name, headline, location, and counts of each node type (education, work, skills, etc.)."""
+async def orbis_get_summary(orb_id: str, filter_token: str | None = None) -> dict:
+    """Get a summary of a person's professional profile including name, headline, location, and counts of each node type (education, work, skills, etc.).
+
+    If a filter_token is provided, nodes matching the filter keywords will be excluded from counts.
+    """
     driver = await _get_driver()
-    return await get_orb_summary(driver, orb_id)
+    return await get_orb_summary(driver, orb_id, filter_token)
 
 
 @mcp.tool()
-async def orbis_get_full_orb(orb_id: str) -> dict:
-    """Get the complete graph data for a person's orb, including all nodes (education, work experience, skills, publications, projects, certifications, languages, collaborators) and their properties."""
+async def orbis_get_full_orb(orb_id: str, filter_token: str | None = None) -> dict:
+    """Get the complete graph data for a person's orb, including all nodes and their properties.
+
+    If a filter_token is provided, matching nodes will be omitted from the results.
+    """
     driver = await _get_driver()
-    return await get_orb_full(driver, orb_id)
+    return await get_orb_full(driver, orb_id, filter_token)
 
 
 @mcp.tool()
-async def orbis_get_nodes_by_type(orb_id: str, node_type: str) -> list[dict]:
-    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, collaborator."""
+async def orbis_get_nodes_by_type(
+    orb_id: str, node_type: str, filter_token: str | None = None
+) -> list[dict]:
+    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, collaborator.
+
+    If a filter_token is provided, matching nodes will be omitted.
+    """
     driver = await _get_driver()
-    return await get_nodes_by_type(driver, orb_id, node_type)
+    return await get_nodes_by_type(driver, orb_id, node_type, filter_token)
 
 
 @mcp.tool()
-async def orbis_get_connections(orb_id: str, node_uid: str) -> dict:
-    """Get all relationships and connected nodes for a specific node identified by its uid."""
+async def orbis_get_connections(
+    orb_id: str, node_uid: str, filter_token: str | None = None
+) -> dict:
+    """Get all relationships and connected nodes for a specific node identified by its uid.
+
+    If a filter_token is provided, connected nodes matching the filters will be omitted.
+    """
     driver = await _get_driver()
-    return await get_connections(driver, orb_id, node_uid)
+    return await get_connections(driver, orb_id, node_uid, filter_token)
 
 
 @mcp.tool()
 async def orbis_get_skills_for_experience(
-    orb_id: str, experience_uid: str
+    orb_id: str, experience_uid: str, filter_token: str | None = None
 ) -> list[dict]:
-    """Get all skills that were used in a specific work experience or project, identified by the experience's uid."""
+    """Get all skills that were used in a specific work experience or project, identified by the experience's uid.
+
+    If a filter_token is provided, matching skills will be omitted.
+    """
     driver = await _get_driver()
-    return await get_skills_for_experience(driver, orb_id, experience_uid)
+    return await get_skills_for_experience(driver, orb_id, experience_uid, filter_token)
 
 
 @mcp.tool()

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -10,9 +10,12 @@ from app.graph.queries import (
     NODE_TYPE_LABELS,
     NODE_TYPE_RELATIONSHIPS,
 )
+from app.orbs.filter_token import decode_filter_token, node_matches_filters
 
 
-async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
+async def get_orb_summary(
+    driver: AsyncDriver, orb_id: str, filter_token: str | None = None
+) -> dict:
     """Get a structured summary of a person's professional profile."""
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
@@ -25,11 +28,23 @@ async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
         person.pop("encryption_key_id", None)
         person.pop("embedding", None)
 
+        # Get filter keywords if token is valid
+        filters = []
+        if filter_token:
+            decoded = decode_filter_token(filter_token)
+            if decoded and decoded["orb_id"] == orb_id:
+                filters = decoded["filters"]
+
         # Count nodes by type
         type_counts: dict[str, int] = {}
         for conn in record["connections"]:
             if conn["node"] is None:
                 continue
+
+            node_data = decrypt_properties(dict(conn["node"]))
+            if filters and node_matches_filters(node_data, filters):
+                continue
+
             labels = list(conn["node"].labels)
             label = labels[0] if labels else "Unknown"
             type_counts[label] = type_counts.get(label, 0) + 1
@@ -45,7 +60,9 @@ async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
         }
 
 
-async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
+async def get_orb_full(
+    driver: AsyncDriver, orb_id: str, filter_token: str | None = None
+) -> dict:
     """Get the complete graph data for an orb."""
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
@@ -57,11 +74,21 @@ async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
         person.pop("user_id", None)
         person.pop("encryption_key_id", None)
 
+        # Get filter keywords if token is valid
+        filters = []
+        if filter_token:
+            decoded = decode_filter_token(filter_token)
+            if decoded and decoded["orb_id"] == orb_id:
+                filters = decoded["filters"]
+
         nodes = []
         for conn in record["connections"]:
             if conn["node"] is None:
                 continue
             node = decrypt_properties(dict(conn["node"]))
+            if filters and node_matches_filters(node, filters):
+                continue
+
             node.pop("embedding", None)
             node["_type"] = list(conn["node"].labels)[0]
             node["_relationship"] = conn["rel"]
@@ -71,7 +98,10 @@ async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
 
 
 async def get_nodes_by_type(
-    driver: AsyncDriver, orb_id: str, node_type: str
+    driver: AsyncDriver,
+    orb_id: str,
+    node_type: str,
+    filter_token: str | None = None,
 ) -> list[dict]:
     """Get all nodes of a specific type from an orb."""
     if node_type not in NODE_TYPE_LABELS:
@@ -84,6 +114,13 @@ async def get_nodes_by_type(
     label = NODE_TYPE_LABELS[node_type]
     rel_type = NODE_TYPE_RELATIONSHIPS[node_type]
 
+    # Get filter keywords if token is valid
+    filters = []
+    if filter_token:
+        decoded = decode_filter_token(filter_token)
+        if decoded and decoded["orb_id"] == orb_id:
+            filters = decoded["filters"]
+
     query = f"""
     MATCH (p:Person {{orb_id: $orb_id}})-[:{rel_type}]->(n:{label})
     RETURN n
@@ -94,13 +131,24 @@ async def get_nodes_by_type(
         nodes = []
         async for record in result:
             node = decrypt_properties(dict(record["n"]))
+            if filters and node_matches_filters(node, filters):
+                continue
             node.pop("embedding", None)
             nodes.append(node)
         return nodes
 
 
-async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> dict:
+async def get_connections(
+    driver: AsyncDriver, orb_id: str, node_uid: str, filter_token: str | None = None
+) -> dict:
     """Get all relationships for a specific node."""
+    # Get filter keywords if token is valid
+    filters = []
+    if filter_token:
+        decoded = decode_filter_token(filter_token)
+        if decoded and decoded["orb_id"] == orb_id:
+            filters = decoded["filters"]
+
     query = """
     MATCH (n {uid: $node_uid})-[r]-(connected)
     MATCH (p:Person {orb_id: $orb_id})-[*1..2]-(n)
@@ -112,6 +160,11 @@ async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> di
         connections = []
         async for record in result:
             conn_node = decrypt_properties(dict(record["connected"]))
+
+            # Filter out if the connected node matches filter keywords
+            if filters and node_matches_filters(conn_node, filters):
+                continue
+
             conn_node.pop("embedding", None)
             conn_node["_labels"] = record["connected_labels"]
             connections.append(
@@ -124,9 +177,19 @@ async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> di
 
 
 async def get_skills_for_experience(
-    driver: AsyncDriver, orb_id: str, experience_uid: str
+    driver: AsyncDriver,
+    orb_id: str,
+    experience_uid: str,
+    filter_token: str | None = None,
 ) -> list[dict]:
     """Get skills associated with a specific work experience or project."""
+    # Get filter keywords if token is valid
+    filters = []
+    if filter_token:
+        decoded = decode_filter_token(filter_token)
+        if decoded and decoded["orb_id"] == orb_id:
+            filters = decoded["filters"]
+
     query = """
     MATCH (p:Person {orb_id: $orb_id})-[]->(exp {uid: $experience_uid})
     MATCH (exp)-[:USED_SKILL]->(s:Skill)
@@ -138,6 +201,8 @@ async def get_skills_for_experience(
         skills = []
         async for record in result:
             skill = dict(record["s"])
+            if filters and node_matches_filters(skill, filters):
+                continue
             skill.pop("embedding", None)
             skills.append(skill)
         return skills

--- a/backend/tests/fixtures/mcp_schemas.py
+++ b/backend/tests/fixtures/mcp_schemas.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, RootModel
+
+
+class ErrorResponse(BaseModel):
+    """Schema for error responses from MCP tools."""
+
+    error: str
+
+
+class SummaryResponse(BaseModel):
+    """Schema for orbis_get_summary response."""
+
+    name: str
+    headline: str
+    location: str
+    orb_id: str
+    open_to_work: bool
+    node_counts: dict[str, int]
+    total_nodes: int
+
+
+class FullOrbResponse(BaseModel):
+    """Schema for orbis_get_full_orb response."""
+
+    person: dict[str, Any]
+    nodes: list[dict[str, Any]]
+
+
+class NodeResponse(BaseModel):
+    """Schema for a single node in a list (used by get_nodes_by_type and get_skills_for_experience)."""
+
+    uid: str
+    # Other fields are dynamic based on node type
+
+
+class NodeListResponse(RootModel):
+    """Schema for orbis_get_nodes_by_type and orbis_get_skills_for_experience responses."""
+
+    root: list[dict[str, Any]]
+
+
+class ConnectionItem(BaseModel):
+    """Schema for a single connection in orbis_get_connections."""
+
+    relationship: str
+    node: dict[str, Any]
+
+
+class ConnectionsResponse(BaseModel):
+    """Schema for orbis_get_connections response."""
+
+    node_uid: str
+    connections: list[ConnectionItem]
+
+
+class MessageResponse(BaseModel):
+    """Schema for orbis_send_message response."""
+
+    uid: str
+    detail: str
+
+
+# Union types for easy validation in tests
+McpResponse = (
+    SummaryResponse
+    | FullOrbResponse
+    | NodeListResponse
+    | ConnectionsResponse
+    | MessageResponse
+    | ErrorResponse
+)

--- a/backend/tests/integration/test_mcp_contract.py
+++ b/backend/tests/integration/test_mcp_contract.py
@@ -1,0 +1,208 @@
+import os
+import uuid
+
+import pytest
+from neo4j import AsyncGraphDatabase
+
+from app.config import settings
+from app.orbs.filter_token import create_filter_token
+from mcp_server.server import orbis_send_message
+from mcp_server.tools import (
+    get_connections,
+    get_nodes_by_type,
+    get_orb_full,
+    get_orb_summary,
+    get_skills_for_experience,
+)
+from tests.fixtures.mcp_schemas import (
+    ConnectionsResponse,
+    FullOrbResponse,
+    MessageResponse,
+    NodeListResponse,
+    SummaryResponse,
+)
+
+
+@pytest.fixture(scope="function")
+async def real_driver():
+    """Get a real Neo4j driver using environment variables or settings."""
+    uri = os.environ.get("NEO4J_URI", settings.neo4j_uri)
+    user = os.environ.get("NEO4J_USER", settings.neo4j_user)
+    pwd = os.environ.get("NEO4J_PASSWORD", settings.neo4j_password)
+
+    driver = AsyncGraphDatabase.driver(uri, auth=(user, pwd))
+    try:
+        # Check connection
+        async with driver.session() as s:
+            await s.run("RETURN 1")
+    except Exception as e:
+        pytest.skip(f"Real Neo4j not available at {uri}: {e}")
+
+    yield driver
+    await driver.close()
+
+
+@pytest.fixture(scope="function")
+async def test_orb(real_driver):
+    """Seed a test orb in the real database."""
+    orb_id = f"contract-test-{uuid.uuid4().hex[:8]}"
+    user_id = f"user-{orb_id}"
+
+    async with real_driver.session() as s:
+        # 1. Create Person
+        await s.run(
+            """
+            CREATE (p:Person {
+                user_id: $user_id, orb_id: $orb_id,
+                name: 'Contract Test User', headline: 'QA Engineer',
+                location: 'Integration Cloud', open_to_work: true
+            })
+        """,
+            user_id=user_id,
+            orb_id=orb_id,
+        )
+
+        # 2. Create a Skill
+        await s.run(
+            """
+            MATCH (p:Person {orb_id: $orb_id})
+            CREATE (p)-[:HAS_SKILL]->(s:Skill {name: 'Contracting', uid: $uid, proficiency: 'Expert'})
+        """,
+            orb_id=orb_id,
+            uid=f"skill-{orb_id}",
+        )
+
+        # 3. Create WorkExperience and linked Skill
+        exp_uid = f"exp-{orb_id}"
+        await s.run(
+            """
+            MATCH (p:Person {orb_id: $orb_id})
+            CREATE (p)-[:HAS_WORK_EXPERIENCE]->(e:WorkExperience {
+                company: 'TestCorp', title: 'Senior Tester', uid: $exp_uid
+            })
+            CREATE (s:Skill {name: 'SecretSkill', uid: $secret_uid})
+            CREATE (e)-[:USED_SKILL]->(s)
+        """,
+            orb_id=orb_id,
+            exp_uid=exp_uid,
+            secret_uid=f"secret-{orb_id}",
+        )
+
+    yield orb_id
+
+    # Cleanup: detach delete person and all its nodes
+    async with real_driver.session() as s:
+        await s.run(
+            """
+            MATCH (p:Person {orb_id: $orb_id})
+            OPTIONAL MATCH (p)-[*1..2]-(n)
+            DETACH DELETE n, p
+        """,
+            orb_id=orb_id,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_summary(real_driver, test_orb):
+    result = await get_orb_summary(real_driver, test_orb)
+    SummaryResponse.model_validate(result)
+    assert result["name"] == "Contract Test User"
+    assert result["node_counts"]["Skill"] >= 1
+    assert result["node_counts"]["WorkExperience"] >= 1
+    assert result["total_nodes"] >= 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_summary_filtering(real_driver, test_orb):
+    # Create a filter token that excludes "Contracting"
+    token = create_filter_token(test_orb, ["Contracting"])
+
+    result = await get_orb_summary(real_driver, test_orb, filter_token=token)
+    SummaryResponse.model_validate(result)
+
+    # "Contracting" skill should be excluded from counts
+    assert result["node_counts"].get("Skill", 0) == 0
+    assert result["total_nodes"] == 1  # Only WorkExperience left
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_full_orb(real_driver, test_orb):
+    result = await get_orb_full(real_driver, test_orb)
+    FullOrbResponse.model_validate(result)
+    assert result["person"]["name"] == "Contract Test User"
+    # Ensure nodes are there
+    uids = [n.get("uid") for n in result["nodes"]]
+    assert any(u.startswith("skill-") for u in uids if u)
+    assert any(u.startswith("exp-") for u in uids if u)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_nodes_by_type(real_driver, test_orb):
+    result = await get_nodes_by_type(real_driver, test_orb, "skill")
+    NodeListResponse.model_validate(result)
+    assert any(n["name"] == "Contracting" for n in result)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_connections(real_driver, test_orb):
+    exp_uid = f"exp-{test_orb}"
+    result = await get_connections(real_driver, test_orb, exp_uid)
+    ConnectionsResponse.model_validate(result)
+    assert result["node_uid"] == exp_uid
+    # Should have a connection to SecretSkill
+    assert any(c["node"]["name"] == "SecretSkill" for c in result["connections"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_get_skills_for_experience(real_driver, test_orb):
+    exp_uid = f"exp-{test_orb}"
+    result = await get_skills_for_experience(real_driver, test_orb, exp_uid)
+    NodeListResponse.model_validate(result)
+    assert any(s["name"] == "SecretSkill" for s in result)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_filtering_integration(real_driver, test_orb):
+    # Filter "Contracting"
+    token = create_filter_token(test_orb, ["Contracting"])
+
+    # Test Full Orb
+    full = await get_orb_full(real_driver, test_orb, filter_token=token)
+    assert not any(n.get("name") == "Contracting" for n in full["nodes"])
+
+    # Test Nodes by Type
+    skills = await get_nodes_by_type(real_driver, test_orb, "skill", filter_token=token)
+    assert not any(s["name"] == "Contracting" for s in skills)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_contract_send_message(real_driver, test_orb):
+    # We need to mock _get_driver in server.py to use our real_driver
+    from unittest.mock import AsyncMock, patch
+
+    with patch("mcp_server.server._get_driver", AsyncMock(return_value=real_driver)):
+        result = await orbis_send_message(
+            test_orb,
+            "Integration",
+            "test@example.com",
+            "Test Message",
+            "Integration body",
+        )
+
+    MessageResponse.model_validate(result)
+    msg_uid = result["uid"]
+
+    # Verify in DB
+    async with real_driver.session() as s:
+        res = await s.run("MATCH (m:Message {uid: $uid}) RETURN m", uid=msg_uid)
+        record = await res.single()
+        assert record is not None
+        assert record["m"]["subject"] == "Test Message"

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -1,0 +1,267 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server.server import orbis_send_message
+from mcp_server.tools import (
+    get_connections,
+    get_nodes_by_type,
+    get_orb_full,
+    get_orb_summary,
+    get_skills_for_experience,
+)
+from tests.fixtures.mcp_schemas import (
+    ConnectionsResponse,
+    FullOrbResponse,
+    MessageResponse,
+    NodeListResponse,
+    SummaryResponse,
+)
+
+
+@pytest.fixture
+def mock_person():
+    return {
+        "name": "Test User",
+        "headline": "Software Engineer",
+        "location": "San Francisco",
+        "orb_id": "test-orb",
+        "open_to_work": True,
+    }
+
+
+class MockNode:
+    def __init__(self, labels, properties):
+        self.labels = set(labels)
+        self._properties = properties
+
+    def __getitem__(self, key):
+        return self._properties[key]
+
+    def get(self, key, default=None):
+        return self._properties.get(key, default)
+
+    def items(self):
+        return self._properties.items()
+
+    def keys(self):
+        return self._properties.keys()
+
+
+@pytest.mark.asyncio
+async def test_get_orb_summary_success(mock_db, mock_person):
+    # Setup mock record
+    data = {
+        "p": mock_person,
+        "connections": [
+            {
+                "node": MockNode(["Skill"], {"name": "Python", "uid": "s1"}),
+                "rel": "HAS_SKILL",
+            },
+            {
+                "node": MockNode(
+                    ["Education"], {"institution": "Stanford", "uid": "e1"}
+                ),
+                "rel": "HAS_EDUCATION",
+            },
+        ],
+    }
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = data.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.single.return_value = mock_record
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    # Call tool
+    result = await get_orb_summary(mock_db, "test-orb")
+
+    # Validate against schema
+    SummaryResponse.model_validate(result)
+
+    assert result["name"] == "Test User"
+    assert result["node_counts"]["Skill"] == 1
+    assert result["node_counts"]["Education"] == 1
+    assert result["total_nodes"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_orb_summary_not_found(mock_db):
+    mock_result = AsyncMock()
+    mock_result.single.return_value = None
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    result = await get_orb_summary(mock_db, "non-existent")
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_orb_summary_filtering(mock_db, mock_person):
+    # Setup mock record
+    data = {
+        "p": mock_person,
+        "connections": [
+            {
+                "node": MockNode(["Skill"], {"name": "Python", "uid": "s1"}),
+                "rel": "HAS_SKILL",
+            },
+            {
+                "node": MockNode(["Skill"], {"name": "SecretSkill", "uid": "s2"}),
+                "rel": "HAS_SKILL",
+            },
+        ],
+    }
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = data.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.single.return_value = mock_record
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    # Mock filter token decoding
+    with patch("mcp_server.tools.decode_filter_token") as mock_decode:
+        mock_decode.return_value = {"orb_id": "test-orb", "filters": ["secret"]}
+
+        # Call tool with token
+        result = await get_orb_summary(mock_db, "test-orb", filter_token="some-token")
+
+    # SecretSkill should be filtered out because it contains "secret"
+    assert result["node_counts"]["Skill"] == 1
+    assert result["total_nodes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_orb_full_success(mock_db, mock_person):
+    data = {
+        "p": mock_person,
+        "connections": [
+            {
+                "node": MockNode(["Skill"], {"name": "Python", "uid": "s1"}),
+                "rel": "HAS_SKILL",
+            }
+        ],
+    }
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = data.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.single.return_value = mock_record
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    result = await get_orb_full(mock_db, "test-orb")
+
+    FullOrbResponse.model_validate(result)
+    assert result["person"]["name"] == "Test User"
+    assert len(result["nodes"]) == 1
+    assert result["nodes"][0]["name"] == "Python"
+    assert result["nodes"][0]["_type"] == "Skill"
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_by_type_success(mock_db):
+    mock_node = MockNode(["Skill"], {"name": "Python", "uid": "s1"})
+
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = {"n": mock_node}.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.__aiter__.return_value = [mock_record]
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    result = await get_nodes_by_type(mock_db, "test-orb", "skill")
+
+    NodeListResponse.model_validate(result)
+    assert len(result) == 1
+    assert result[0]["name"] == "Python"
+
+
+@pytest.mark.asyncio
+async def test_get_connections_success(mock_db):
+    mock_connected_node = MockNode(["Skill"], {"name": "Python", "uid": "s1"})
+
+    data = {
+        "connected": mock_connected_node,
+        "rel_type": "USED_SKILL",
+        "connected_labels": ["Skill"],
+    }
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = data.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.__aiter__.return_value = [mock_record]
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    result = await get_connections(mock_db, "test-orb", "exp-1")
+
+    ConnectionsResponse.model_validate(result)
+    assert result["node_uid"] == "exp-1"
+    assert len(result["connections"]) == 1
+    assert result["connections"][0]["relationship"] == "USED_SKILL"
+    assert result["connections"][0]["node"]["name"] == "Python"
+
+
+@pytest.mark.asyncio
+async def test_get_skills_for_experience_success(mock_db):
+    mock_skill = MockNode(["Skill"], {"name": "Python", "uid": "s1"})
+
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = {"s": mock_skill}.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.__aiter__.return_value = [mock_record]
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    result = await get_skills_for_experience(mock_db, "test-orb", "exp-1")
+
+    NodeListResponse.model_validate(result)
+    assert len(result) == 1
+    assert result[0]["name"] == "Python"
+
+
+@pytest.mark.asyncio
+async def test_get_orb_full_filtering(mock_db, mock_person):
+    data = {
+        "p": mock_person,
+        "connections": [
+            {
+                "node": MockNode(["Skill"], {"name": "Python", "uid": "s1"}),
+                "rel": "HAS_SKILL",
+            },
+            {
+                "node": MockNode(["Skill"], {"name": "Secret", "uid": "s2"}),
+                "rel": "HAS_SKILL",
+            },
+        ],
+    }
+    mock_record = MagicMock()
+    mock_record.__getitem__.side_effect = data.__getitem__
+
+    mock_result = AsyncMock()
+    mock_result.single.return_value = mock_record
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    with patch("mcp_server.tools.decode_filter_token") as mock_decode:
+        mock_decode.return_value = {"orb_id": "test-orb", "filters": ["secret"]}
+        result = await get_orb_full(mock_db, "test-orb", filter_token="token")
+
+    assert len(result["nodes"]) == 1
+    assert result["nodes"][0]["name"] == "Python"
+
+
+@pytest.mark.asyncio
+async def test_orbis_send_message_success(mock_db):
+    mock_result = AsyncMock()
+    mock_result.single.return_value = MagicMock(__getitem__=lambda _: "msg-123")
+    mock_db.session.return_value.__aenter__.return_value.run.return_value = mock_result
+
+    # We need to mock _get_driver in server.py
+    with patch("mcp_server.server._get_driver", AsyncMock(return_value=mock_db)):
+        result = await orbis_send_message(
+            "test-orb", "Alice", "alice@example.com", "Hello", "Test body"
+        )
+
+    MessageResponse.model_validate(result)
+    assert result["detail"] == "Message sent successfully"
+    assert "uid" in result

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,3 +90,18 @@ Query params: `?format=json|jsonld|pdf`, `?filter_token=`, `?filter_keyword=`, `
 | POST | `/search/semantic` | JWT | Vector similarity search across 5 Neo4j indexes |
 | POST | `/search/text` | JWT | Fuzzy text search on own orb |
 | POST | `/search/text/public` | No | Fuzzy text search on any public orb (supports `?filter_token=`) |
+
+## MCP Tools (Model Context Protocol)
+
+The Orbis MCP server exposes professional knowledge graph data to AI agents. These tools are available via the MCP protocol.
+
+| Tool Name | Description | Parameters |
+|-----------|-------------|------------|
+| `orbis_get_summary` | Get professional profile summary and node counts. | `orb_id` (str), `filter_token` (opt, str) |
+| `orbis_get_full_orb` | Get complete graph data (person + nodes). | `orb_id` (str), `filter_token` (opt, str) |
+| `orbis_get_nodes_by_type` | Get all nodes of a specific type. | `orb_id` (str), `node_type` (str), `filter_token` (opt, str) |
+| `orbis_get_connections` | Get all relationships for a specific node. | `orb_id` (str), `node_uid` (str), `filter_token` (opt, str) |
+| `orbis_get_skills_for_experience` | Get skills associated with an experience/project. | `orb_id` (str), `experience_uid` (str), `filter_token` (opt, str) |
+| `orbis_send_message` | Send a message to an orb owner. | `orb_id`, `sender_name`, `sender_email`, `subject`, `body` |
+
+Note: retrieval tools (`get_*`) support an optional `filter_token` for fine-grained privacy. If provided and valid, nodes matching the filter keywords will be excluded from the response.

--- a/docs/prds/55-mcp-endpoint-contract-tests.md
+++ b/docs/prds/55-mcp-endpoint-contract-tests.md
@@ -1,0 +1,178 @@
+# Spec: MCP Endpoint Contract Tests (Issue #55)
+
+## Objective
+The Orbis MCP (Model Context Protocol) server provides professional knowledge graph data to AI agents. To ensure the reliability of this interface and the privacy of user data, we must implement contract tests for all 6 tools. These tests will verify:
+- **Correct response schema:** Each tool must return a valid JSON structure according to its contract.
+- **Proper error handling:** Tools must handle missing orbs or invalid inputs gracefully.
+- **Access control (Filter Tokens):** If a user provides a `filter_token`, the tool must exclude matching nodes, consistent with the main API's filtering logic.
+- **Data integrity:** The data returned must accurately reflect the Neo4j graph state.
+
+### Tools to test:
+1. `orbis_get_summary`
+2. `orbis_get_full_orb`
+3. `orbis_get_nodes_by_type`
+4. `orbis_get_connections`
+5. `orbis_get_skills_for_experience`
+6. `orbis_send_message`
+
+## Tech Stack
+- **Testing:** `pytest` (async-compatible)
+- **Validation:** `pydantic` for schema enforcement
+- **Mocking:** `unittest.mock` for Neo4j driver (in unit tests)
+- **Integration:** Real Neo4j driver (for integration/contract tests)
+
+## Commands
+- **Unit Tests (Mocked DB):** `pytest backend/tests/unit/test_mcp_server.py`
+- **Integration Tests (Real DB):** `NEO4J_URI=bolt://localhost:7687 pytest backend/tests/integration/test_mcp_contract.py`
+- **Linting:** `ruff check backend/mcp_server`
+
+## Project Structure
+- `backend/mcp_server/` → Source code for the MCP server and tools.
+- `backend/tests/unit/test_mcp_server.py` → Unit tests for tool logic with mocked Neo4j.
+- `backend/tests/integration/test_mcp_contract.py` → Contract tests verifying graph state and schema.
+- `backend/tests/fixtures/mcp_schemas.py` → Pydantic models for contract validation.
+
+## Code Style
+### Example Test Pattern (Unit/Mock)
+```python
+@pytest.mark.asyncio
+async def test_orbis_get_summary_success(mock_db):
+    # Setup mock record
+    mock_record = {
+        "p": {"name": "Test User", "headline": "Dev", "location": "Moon", "orb_id": "test-orb"},
+        "connections": []
+    }
+    mock_db_single(mock_db, mock_record)
+    
+    # Call tool
+    result = await orbis_get_summary("test-orb")
+    
+    # Verify schema and data
+    assert result["name"] == "Test User"
+    assert "node_counts" in result
+```
+
+### Filtering Requirement (New)
+All retrieval tools must be updated to accept an optional `filter_token`:
+```python
+async def orbis_get_summary(orb_id: str, filter_token: str | None = None) -> dict:
+```
+The implementation must decode the token (using `app.orbs.filter_token.decode_filter_token`) and apply `node_matches_filters` to exclude matching nodes.
+
+## Testing Strategy
+1. **Schema Validation:** Define Pydantic models for each tool's response. In tests, parse the tool's return value through these models.
+2. **Error Cases:** Test with non-existent `orb_id` (should return an error dict), invalid `node_type`, and invalid `filter_token`.
+3. **Filter Token Validation:**
+    - Test with no token: all data returned.
+    - Test with valid token: matching nodes/links are excluded.
+    - Test with token for different `orb_id`: token ignored (as per API logic).
+4. **State Matching:** Use integration tests to populate a temporary Neo4j state and verify the MCP tool returns exactly what's expected.
+
+## Boundaries
+- **Always do:** Validate tool responses against Pydantic schemas in tests.
+- **Ask first:** Modifying `app.graph.queries` to support specialized MCP filtering (prefer filtering in Python for parity with `orbs/router.py`).
+- **Never do:** Commit tests that depend on a specific hardcoded Neo4j state without setup/teardown logic.
+
+## Success Criteria
+- [ ] Pydantic schemas defined for all 6 tools.
+- [ ] Unit tests covering all 6 tools (success, error, filtering).
+- [ ] Integration tests verifying state-matching for all 6 tools.
+- [ ] All retrieval tools updated to support `filter_token`.
+- [ ] `orbis_send_message` verified to correctly create nodes in Neo4j.
+
+## Task Breakdown
+
+### Phase 1: Foundation & Data Models
+
+#### Task 1: Define Pydantic Models for MCP Tool Responses
+**Description:** Create a new file `backend/tests/fixtures/mcp_schemas.py` and define Pydantic models for the response of each of the 6 MCP tools. These models will be used for contract validation in both unit and integration tests.
+
+**Acceptance criteria:**
+- [ ] Models defined for: `SummaryResponse`, `FullOrbResponse`, `NodeListResponse`, `ConnectionsResponse`, `SkillsListResponse`, `MessageResponse`.
+- [ ] Schemas include all expected fields (e.g., `node_counts` in summary, `_type` in full orb nodes).
+- [ ] Error response schema handles cases where an orb is not found.
+
+**Verification:**
+- [ ] Manual check: verify models against current `tools.py` return types.
+- [ ] Linter passes: `ruff check backend/tests/fixtures/mcp_schemas.py`.
+
+**Files likely touched:**
+- `backend/tests/fixtures/mcp_schemas.py`
+
+#### Task 2: Create Test Infrastructure
+**Description:** Set up the base files for unit and integration tests, including necessary fixtures for mocking the Neo4j driver and decoding filter tokens.
+
+**Acceptance criteria:**
+- [ ] `backend/tests/unit/test_mcp_server.py` created with `mock_db` fixture.
+- [ ] `backend/tests/integration/test_mcp_contract.py` created with real DB connection setup/teardown.
+- [ ] Common utilities for contract validation (Pydantic parsing) added to a shared test lib if needed.
+
+**Verification:**
+- [ ] `pytest backend/tests/unit/test_mcp_server.py` runs (even if empty/skipped).
+
+**Files likely touched:**
+- `backend/tests/unit/test_mcp_server.py`
+- `backend/tests/integration/test_mcp_contract.py`
+- `backend/tests/conftest.py`
+
+### Phase 2: Feature Implementation (Filtering)
+
+#### Task 3: Implement Filter Token Support in MCP Tools
+**Description:** Update all retrieval tools in `backend/mcp_server/tools.py` and their wrappers in `server.py` to accept an optional `filter_token`. Integrate `decode_filter_token` and `node_matches_filters` logic.
+
+**Acceptance criteria:**
+- [ ] `orbis_get_summary`, `orbis_get_full_orb`, `orbis_get_nodes_by_type`, `orbis_get_connections`, and `orbis_get_skills_for_experience` updated.
+- [ ] Filtering logic correctly excludes nodes based on keywords if the `orb_id` in the token matches.
+- [ ] Invalid or mismatched tokens are gracefully ignored (as per PRD).
+
+**Verification:**
+- [ ] Unit tests (from Task 4) pass for filtering scenarios.
+
+**Files likely touched:**
+- `backend/mcp_server/tools.py`
+- `backend/mcp_server/server.py`
+
+### Phase 3: Contract Testing Implementation
+
+#### Task 4: Implement Unit Tests for Each Tool (One by One)
+**Description:** Add unit tests with mocked Neo4j responses for all 6 tools, verifying both successful data retrieval and error handling.
+
+**Acceptance criteria:**
+- [ ] Tests for `get_summary`, `get_orb_full`, `get_nodes_by_type`, `get_connections`, `get_skills_for_experience`, and `send_message`.
+- [ ] Each test validates the response against its Pydantic schema.
+- [ ] Coverage for edge cases: Orb not found, invalid node type, empty graph.
+
+**Verification:**
+- [ ] `pytest backend/tests/unit/test_mcp_server.py` passes all tests.
+
+**Files likely touched:**
+- `backend/tests/unit/test_mcp_server.py`
+
+#### Task 5: Implement Integration & Contract Tests
+**Description:** Add integration tests that interact with a real (or test) Neo4j instance to verify the end-to-end contract and data integrity.
+
+**Acceptance criteria:**
+- [ ] Setup/Teardown logic populates a test orb with known data.
+- [ ] Verification that tools return exactly what is in the graph.
+- [ ] Filter token integration tested against real graph data.
+- [ ] `orbis_send_message` verified by checking Neo4j for the created `Message` node.
+
+**Verification:**
+- [ ] `NEO4J_URI=... pytest backend/tests/integration/test_mcp_contract.py` passes.
+
+**Files likely touched:**
+- `backend/tests/integration/test_mcp_contract.py`
+
+### Phase 4: Final Validation
+
+#### Task 6: Final Quality Check and Documentation
+**Description:** Perform a final audit of the implementation, ensuring consistent error messages, proper type hinting, and updated documentation.
+
+**Acceptance criteria:**
+- [ ] All tests (unit + integration) pass in CI/local.
+- [ ] `docs/api.md` or similar updated if MCP tool signatures changed.
+- [ ] Code follows all project conventions and linting rules.
+
+**Verification:**
+- [ ] `ruff check backend/mcp_server` passes.
+- [ ] `mypy backend/mcp_server` (if used) passes.


### PR DESCRIPTION
Closes #55. Added contract tests for all 6 MCP tools, implemented filter_token support for fine-grained privacy, and established Pydantic schemas for response validation.