### PR TITLE
feat: (auth) social login and user flow hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ NEO4J_PASSWORD=orbis_dev_password
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
+# LinkedIn OAuth (login app — "Sign In with LinkedIn using OpenID Connect")
+LINKEDIN_CLIENT_ID=your-linkedin-login-client-id
+LINKEDIN_CLIENT_SECRET=your-linkedin-login-client-secret
+LINKEDIN_REDIRECT_URI=http://localhost:5173/auth/linkedin/callback
+
+
 # JWT
 JWT_SECRET=change-me-to-a-random-secret
 JWT_ALGORITHM=HS256

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -6,6 +6,7 @@ class UserInfo(BaseModel):
     email: str
     name: str
     picture: str = ""
+    profile_image: str = ""
     gdpr_consent: bool = False
 
 
@@ -13,3 +14,7 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     user: UserInfo
+
+
+class OAuthCodeRequest(BaseModel):
+    code: str

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -63,7 +63,9 @@ async def google_login(
         userinfo = await exchange_google_code(body.code)
     except Exception as e:
         logger.error("Google OAuth failed: %s", e)
-        raise HTTPException(status_code=401, detail="Google authentication failed") from None
+        raise HTTPException(
+            status_code=401, detail="Google authentication failed"
+        ) from None
 
     user_id = f"google-{userinfo['sub']}"
     email = userinfo["email"]
@@ -91,7 +93,9 @@ async def linkedin_login(
         )
     except Exception as e:
         logger.error("LinkedIn OAuth failed: %s", e)
-        raise HTTPException(status_code=401, detail="LinkedIn authentication failed") from None
+        raise HTTPException(
+            status_code=401, detail="LinkedIn authentication failed"
+        ) from None
 
     user_id = f"linkedin-{userinfo['sub']}"
     email = userinfo["email"]

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -4,8 +4,18 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncDriver
 
-from app.auth.models import UserInfo
-from app.auth.service import create_jwt
+from app.auth.models import (
+    OAuthCodeRequest,
+    TokenResponse,
+    UserInfo,
+)
+from app.auth.service import (
+    create_jwt,
+    exchange_google_code,
+    exchange_linkedin_code,
+    generate_orb_id,
+)
+from app.config import settings
 from app.dependencies import get_current_user, get_db
 from app.graph.encryption import encrypt_value
 from app.graph.queries import CREATE_PERSON, GET_PERSON_BY_USER_ID
@@ -16,35 +26,85 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-@router.post("/dev-login")
-async def dev_login(
-    db: AsyncDriver = Depends(get_db),
-):
-    """Dev-only login that creates a test user without Google OAuth."""
-    user_id = "seed-alessandro-berti"
-    email = "dev@orbis.local"
-    name = "Alessandro Berti"
-
+async def _get_or_create_person(
+    db: AsyncDriver,
+    user_id: str,
+    email: str,
+    name: str,
+    picture: str,
+    provider: str,
+) -> None:
+    """Create a Person node if it doesn't exist yet."""
     async with db.session() as session:
         result = await session.run(GET_PERSON_BY_USER_ID, user_id=user_id)
-        record = await result.single()
+        if await result.single() is not None:
+            return
 
-        if record is None:
-            await session.run(
-                CREATE_PERSON,
-                user_id=user_id,
-                email=encrypt_value(email),
-                name=name,
-                orb_id="alessandro",
-            )
-            await send_welcome_message(db, user_id)
+        orb_id = await generate_orb_id(name, db)
+        await session.run(
+            CREATE_PERSON,
+            user_id=user_id,
+            email=encrypt_value(email),
+            name=name,
+            orb_id=orb_id,
+            picture=picture,
+            provider=provider,
+        )
+        await send_welcome_message(db, user_id)
+
+
+@router.post("/google", response_model=TokenResponse)
+async def google_login(
+    body: OAuthCodeRequest,
+    db: AsyncDriver = Depends(get_db),
+):
+    """Exchange a Google authorization code for a JWT."""
+    try:
+        userinfo = await exchange_google_code(body.code)
+    except Exception as e:
+        logger.error("Google OAuth failed: %s", e)
+        raise HTTPException(status_code=401, detail="Google authentication failed") from None
+
+    user_id = f"google-{userinfo['sub']}"
+    email = userinfo["email"]
+    name = userinfo["name"]
+    picture = userinfo["picture"]
+
+    await _get_or_create_person(db, user_id, email, name, picture, "google")
 
     token = create_jwt(user_id, email)
-    return {
-        "access_token": token,
-        "token_type": "bearer",
-        "user": {"user_id": user_id, "email": email, "name": name},
-    }
+    return TokenResponse(
+        access_token=token,
+        user=UserInfo(user_id=user_id, email=email, name=name, picture=picture),
+    )
+
+
+@router.post("/linkedin", response_model=TokenResponse)
+async def linkedin_login(
+    body: OAuthCodeRequest,
+    db: AsyncDriver = Depends(get_db),
+):
+    """Exchange a LinkedIn authorization code for a JWT."""
+    try:
+        userinfo = await exchange_linkedin_code(
+            body.code, settings.linkedin_redirect_uri
+        )
+    except Exception as e:
+        logger.error("LinkedIn OAuth failed: %s", e)
+        raise HTTPException(status_code=401, detail="LinkedIn authentication failed") from None
+
+    user_id = f"linkedin-{userinfo['sub']}"
+    email = userinfo["email"]
+    name = userinfo["name"]
+    picture = userinfo["picture"]
+
+    await _get_or_create_person(db, user_id, email, name, picture, "linkedin")
+
+    token = create_jwt(user_id, email)
+    return TokenResponse(
+        access_token=token,
+        user=UserInfo(user_id=user_id, email=email, name=name, picture=picture),
+    )
 
 
 @router.get("/me", response_model=UserInfo)
@@ -65,6 +125,8 @@ async def get_me(
             user_id=person["user_id"],
             email=current_user["email"],
             name=person.get("name", ""),
+            picture=person.get("picture", ""),
+            profile_image=person.get("profile_image", ""),
             gdpr_consent=bool(person.get("gdpr_consent", False)),
         )
 
@@ -85,23 +147,29 @@ async def grant_gdpr_consent(
     return {"status": "ok"}
 
 
-@router.delete("/account")
-async def delete_account(
+@router.delete("/me")
+async def delete_me(
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
 ):
-    """Schedule account deletion. Marks account for deletion after 30 days.
+    """Permanently delete the current user: Person node and the entire subgraph reachable from it.
 
-    Sets deletion_requested_at on the Person node. A background job
-    should permanently delete accounts 30 days after this timestamp.
+    Uses a variable-length path so nested nodes like Replies (Message → Reply)
+    are removed too, not just direct children of Person.
     """
     async with db.session() as session:
+        # Remove every node reachable from the Person via any outgoing path (any depth).
         await session.run(
-            "MATCH (p:Person {user_id: $user_id}) SET p.deletion_requested_at = $now",
+            """
+            MATCH (p:Person {user_id: $user_id})-[*1..]->(n)
+            WITH DISTINCT n
+            DETACH DELETE n
+            """,
             user_id=current_user["user_id"],
-            now=datetime.now(timezone.utc).isoformat(),
         )
-    return {
-        "status": "scheduled",
-        "message": "Account will be permanently deleted in 30 days.",
-    }
+        # Remove the Person node itself
+        await session.run(
+            "MATCH (p:Person {user_id: $user_id}) DETACH DELETE p",
+            user_id=current_user["user_id"],
+        )
+    return {"status": "deleted"}

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -1,9 +1,14 @@
 import logging
+import re
+import uuid
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from jose import jwt
+from neo4j import AsyncDriver
 
 from app.config import settings
+from app.graph.queries import GET_PERSON_BY_ORB_ID
 
 logger = logging.getLogger(__name__)
 
@@ -16,3 +21,110 @@ def create_jwt(user_id: str, email: str) -> str:
         + timedelta(minutes=settings.jwt_expire_minutes),
     }
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+async def exchange_google_code(code: str) -> dict:
+    """Exchange a Google authorization code for user info."""
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(
+            "https://oauth2.googleapis.com/token",
+            data={
+                "code": code,
+                "client_id": settings.google_client_id,
+                "client_secret": settings.google_client_secret,
+                "redirect_uri": "postmessage",
+                "grant_type": "authorization_code",
+            },
+        )
+        token_resp.raise_for_status()
+        access_token = token_resp.json()["access_token"]
+
+        userinfo_resp = await client.get(
+            "https://www.googleapis.com/oauth2/v3/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        userinfo_resp.raise_for_status()
+        info = userinfo_resp.json()
+
+    return {
+        "sub": info["sub"],
+        "email": info.get("email", ""),
+        "name": info.get("name", ""),
+        "picture": info.get("picture", ""),
+    }
+
+
+async def exchange_linkedin_code(
+    code: str,
+    redirect_uri: str,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    fetch_userinfo: bool = True,
+) -> dict:
+    """Exchange a LinkedIn authorization code for access token (+ optional user info).
+
+    Args:
+        client_id/client_secret: Override credentials (needed because login and
+            data-portability use two separate LinkedIn apps).
+        fetch_userinfo: If False, skip the userinfo call (data-portability app
+            does not have the openid scope).
+    """
+    cid = client_id or settings.linkedin_client_id
+    csecret = client_secret or settings.linkedin_client_secret
+
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(
+            "https://www.linkedin.com/oauth/v2/accessToken",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": cid,
+                "client_secret": csecret,
+                "redirect_uri": redirect_uri,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        token_resp.raise_for_status()
+        tokens = token_resp.json()
+        access_token = tokens["access_token"]
+
+        if fetch_userinfo:
+            userinfo_resp = await client.get(
+                "https://api.linkedin.com/v2/userinfo",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            userinfo_resp.raise_for_status()
+            info = userinfo_resp.json()
+        else:
+            info = {}
+
+    return {
+        "sub": info.get("sub", ""),
+        "email": info.get("email", ""),
+        "name": info.get("name", ""),
+        "picture": info.get("picture", ""),
+        "access_token": access_token,
+    }
+
+
+async def generate_orb_id(name: str, db: AsyncDriver) -> str:
+    """Generate a unique orb_id slug from the user's name."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    if not slug:
+        slug = "user"
+
+    candidate = slug
+    async with db.session() as session:
+        result = await session.run(GET_PERSON_BY_ORB_ID, orb_id=candidate)
+        if await result.single() is None:
+            return candidate
+
+        # Append short suffix until unique
+        for _ in range(10):
+            candidate = f"{slug}-{uuid.uuid4().hex[:4]}"
+            result = await session.run(GET_PERSON_BY_ORB_ID, orb_id=candidate)
+            if await result.single() is None:
+                return candidate
+
+    # Fallback: fully random
+    return f"user-{uuid.uuid4().hex[:8]}"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,6 +26,15 @@ class Settings(BaseSettings):
     ollama_base_url: str = "http://localhost:11434"
     ollama_model: str = "llama3.2:3b"
 
+    # Google OAuth
+    google_client_id: str = ""
+    google_client_secret: str = ""
+
+    # LinkedIn OAuth (login app — "Sign In with LinkedIn using OpenID Connect")
+    linkedin_client_id: str = ""
+    linkedin_client_secret: str = ""
+    linkedin_redirect_uri: str = "http://localhost:5173/auth/linkedin/callback"
+
     # URLs
     frontend_url: str = "http://localhost:5173"
 

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -124,12 +124,12 @@ async def confirm_cv(
         # Wipe existing graph nodes (keep Person) so CV import replaces, not merges
         await session.run(DELETE_USER_GRAPH, user_id=current_user["user_id"])
 
-        # Update Person node name from CV owner if provided
+        # Store CV owner name separately (Person.name stays from OAuth provider)
         if data.cv_owner_name:
             await session.run(
                 UPDATE_PERSON,
                 user_id=current_user["user_id"],
-                properties={"name": data.cv_owner_name},
+                properties={"cv_display_name": data.cv_owner_name},
             )
         for node in data.nodes:
             if node.node_type not in NODE_TYPE_LABELS:

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -8,6 +8,8 @@ CREATE (p:Person {
     email: $email,
     name: $name,
     orb_id: $orb_id,
+    picture: $picture,
+    provider: $provider,
     headline: '',
     location: '',
     linkedin_url: '',
@@ -52,6 +54,7 @@ RETURN p
 GET_FULL_ORB = """
 MATCH (p:Person {user_id: $user_id})
 OPTIONAL MATCH (p)-[r]->(n)
+WHERE NOT n:Message
 WITH p, collect({node: n, rel: type(r), rel_id: id(r)}) AS connections
 OPTIONAL MATCH (p)-[]->(src)-[cr:USED_SKILL]->(tgt:Skill)
 WITH p, connections,
@@ -63,6 +66,7 @@ RETURN p, connections, cross_links, cross_skill_nodes
 GET_FULL_ORB_PUBLIC = """
 MATCH (p:Person {orb_id: $orb_id})
 OPTIONAL MATCH (p)-[r]->(n)
+WHERE NOT n:Message
 WITH p, collect({node: n, rel: type(r), rel_id: id(r)}) AS connections
 OPTIONAL MATCH (p)-[]->(src)-[cr:USED_SKILL]->(tgt:Skill)
 WITH p, connections,

--- a/backend/tests/unit/test_auth_router.py
+++ b/backend/tests/unit/test_auth_router.py
@@ -1,17 +1,6 @@
 from unittest.mock import AsyncMock
 
 
-def test_dev_login_new_user(client, mock_db):
-    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
-        AsyncMock(return_value=None)
-    )
-
-    response = client.post("/auth/dev-login")
-    assert response.status_code == 200
-    assert "access_token" in response.json()
-    assert response.json()["user"]["user_id"] == "seed-alessandro-berti"
-
-
 def test_get_me_success(client, mock_db):
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value={"p": {"user_id": "test-user", "name": "Test User"}})

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -390,6 +390,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +762,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954 },
+]
+
+[[package]]
 name = "lxml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -956,6 +982,7 @@ dependencies = [
     { name = "python-docx" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -989,6 +1016,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
@@ -1723,6 +1751,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2085,4 +2125,90 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968 },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735 },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669 },
+    { url = "https://files.pythonhosted.org/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603 },
+    { url = "https://files.pythonhosted.org/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632 },
+    { url = "https://files.pythonhosted.org/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644 },
+    { url = "https://files.pythonhosted.org/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016 },
+    { url = "https://files.pythonhosted.org/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823 },
+    { url = "https://files.pythonhosted.org/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244 },
+    { url = "https://files.pythonhosted.org/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307 },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986 },
+    { url = "https://files.pythonhosted.org/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336 },
+    { url = "https://files.pythonhosted.org/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757 },
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666 },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601 },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057 },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099 },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457 },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351 },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748 },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783 },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977 },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336 },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756 },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255 },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848 },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433 },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013 },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326 },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444 },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237 },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563 },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198 },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441 },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836 },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259 },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851 },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446 },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056 },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359 },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479 },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271 },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573 },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205 },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452 },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842 },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075 },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719 },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643 },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805 },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990 },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670 },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357 },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269 },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894 },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197 },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363 },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418 },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914 },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417 },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797 },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350 },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223 },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287 },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593 },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631 },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875 },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164 },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163 },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723 },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652 },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807 },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061 },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667 },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392 },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296 },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539 },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969 },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554 },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993 },
 ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import { useAuthStore } from './stores/authStore';
+import { useToastStore } from './stores/toastStore';
 import LandingPage from './pages/LandingPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
+import LinkedInCallbackPage from './pages/LinkedInCallbackPage';
 import CreateOrbPage from './pages/CreateOrbPage';
 import AboutPage from './pages/AboutPage';
 import OrbViewPage from './pages/OrbViewPage';
@@ -11,6 +14,7 @@ import SharedOrbPage from './pages/SharedOrbPage';
 import CvExportPage from './pages/CvExportPage';
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
 import ToastContainer from './components/ToastContainer';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const pageVariants = {
   initial: { opacity: 0 },
@@ -37,16 +41,31 @@ function PageWrapper({ children }: { children: React.ReactNode }) {
 
 function AnimatedRoutes() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { logout } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
+
+  // Handle global session-expired events from the API client
+  useEffect(() => {
+    const handler = () => {
+      logout();
+      addToast('Your session has expired. Please sign in again.', 'info');
+      navigate('/', { replace: true });
+    };
+    window.addEventListener('orbis:session-expired', handler);
+    return () => window.removeEventListener('orbis:session-expired', handler);
+  }, [logout, addToast, navigate]);
 
   return (
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        <Route path="/auth/linkedin/callback" element={<LinkedInCallbackPage />} />
         <Route path="/about" element={<PageWrapper><AboutPage /></PageWrapper>} />
-        <Route path="/create" element={<PageWrapper><CreateOrbPage /></PageWrapper>} />
-        <Route path="/myorbis" element={<PageWrapper><OrbViewPage /></PageWrapper>} />
-        <Route path="/cv-export" element={<CvExportPage />} />
+        <Route path="/create" element={<ProtectedRoute><PageWrapper><CreateOrbPage /></PageWrapper></ProtectedRoute>} />
+        <Route path="/myorbis" element={<ProtectedRoute><PageWrapper><OrbViewPage /></PageWrapper></ProtectedRoute>} />
+        <Route path="/cv-export" element={<ProtectedRoute><CvExportPage /></ProtectedRoute>} />
         <Route path="/privacy" element={<PageWrapper><PrivacyPolicyPage /></PageWrapper>} />
         <Route path="/:orbId" element={<PageWrapper><SharedOrbPage /></PageWrapper>} />
       </Routes>
@@ -62,10 +81,12 @@ function App() {
   }, [token, fetchUser]);
 
   return (
-    <BrowserRouter>
-      <AnimatedRoutes />
-      <ToastContainer />
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID || ''}>
+      <BrowserRouter>
+        <AnimatedRoutes />
+        <ToastContainer />
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   );
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -5,6 +5,7 @@ export interface UserInfo {
   email: string;
   name: string;
   picture?: string;
+  profile_image?: string;
   gdpr_consent: boolean;
 }
 
@@ -13,15 +14,20 @@ export async function getMe(): Promise<UserInfo> {
   return data;
 }
 
-export async function devLogin(): Promise<{ access_token: string; user: UserInfo }> {
-  const { data } = await client.post('/auth/dev-login');
+export async function deleteAccount(): Promise<void> {
+  await client.delete('/auth/me');
+}
+
+export async function googleLogin(code: string): Promise<{ access_token: string; user: UserInfo }> {
+  const { data } = await client.post('/auth/google', { code });
+  return data;
+}
+
+export async function linkedinLogin(code: string): Promise<{ access_token: string; user: UserInfo }> {
+  const { data } = await client.post('/auth/linkedin', { code });
   return data;
 }
 
 export async function grantGdprConsent(): Promise<void> {
   await client.post('/auth/gdpr-consent');
-}
-
-export async function deleteAccount(): Promise<void> {
-  await client.delete('/auth/account');
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,8 +16,12 @@ client.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
+      const hadToken = localStorage.getItem('orbis_token') !== null;
       localStorage.removeItem('orbis_token');
-      window.location.href = '/';
+      // Notify the app — handled in App.tsx (toast + soft navigation)
+      if (hadToken) {
+        window.dispatchEvent(new CustomEvent('orbis:session-expired'));
+      }
     }
     return Promise.reject(error);
   }

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -41,6 +41,7 @@ export async function confirmCV(
   await client.post('/cv/confirm', { nodes, relationships: relationships || [], cv_owner_name: cv_owner_name || null });
 }
 
+
 export async function getProcessingCount(): Promise<number> {
   const { data } = await client.get('/cv/processing-count');
   return data.count;

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -23,6 +23,15 @@ export async function getMyOrb(): Promise<OrbData> {
   return data;
 }
 
+export async function hasOrbContent(): Promise<boolean> {
+  try {
+    const data = await getMyOrb();
+    return data.nodes.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export async function getPublicOrb(orbId: string, filterToken?: string): Promise<OrbData> {
   const params = filterToken ? { filter_token: filterToken } : {};
   const { data } = await client.get(`/orbs/${orbId}`, { params });

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+import UserMenu from './UserMenu';
+
+interface NavbarProps {
+  /** Optional center content (e.g. page title, node count) */
+  center?: React.ReactNode;
+  /** Optional right content placed before the user menu */
+  rightBefore?: React.ReactNode;
+}
+
+export default function Navbar({ center, rightBefore }: NavbarProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="absolute top-0 left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3">
+      <div className="flex items-center justify-between gap-3">
+        {/* Left: logo */}
+        <button
+          onClick={() => navigate('/myorbis')}
+          className="flex items-center gap-2 cursor-pointer group"
+          title="Go to My Orbis"
+        >
+          <div className="w-7 h-7 rounded-full bg-purple-600/30 border border-purple-500/40 flex items-center justify-center group-hover:bg-purple-600/50 transition-colors">
+            <div className="w-3 h-3 rounded-full bg-purple-400" />
+          </div>
+          <span className="text-white font-bold text-sm tracking-tight hidden sm:inline">OpenOrbis</span>
+        </button>
+
+        {/* Center */}
+        {center && <div className="flex-1 flex justify-center min-w-0">{center}</div>}
+
+        {/* Right */}
+        <div className="flex items-center gap-2">
+          {rightBefore}
+          <UserMenu />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { token, user, loading } = useAuthStore();
+
+  // No token at all → redirect immediately
+  if (!token) {
+    return <Navigate to="/" replace />;
+  }
+
+  // Token present but user not yet fetched → wait for fetchUser to resolve
+  if (loading || !user) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,0 +1,225 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useAuthStore } from '../stores/authStore';
+import { useToastStore } from '../stores/toastStore';
+import { deleteAccount } from '../api/auth';
+import { clearDraftNotes } from './drafts/DraftNotes';
+
+interface NavLink {
+  label: string;
+  path: string;
+  icon: React.ReactNode;
+}
+
+const NAV_LINKS: NavLink[] = [
+  {
+    label: 'My Orbis',
+    path: '/myorbis',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <circle cx="12" cy="12" r="9" strokeWidth={1.5} />
+        <circle cx="12" cy="12" r="3" strokeWidth={1.5} />
+      </svg>
+    ),
+  },
+  {
+    label: 'Add entries',
+    path: '/create',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+      </svg>
+    ),
+  },
+  {
+    label: 'Export CV',
+    path: '/cv-export',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1M12 12V4m0 8l-4-4m4 4l4-4" />
+      </svg>
+    ),
+  },
+];
+
+export default function UserMenu() {
+  const { user, logout } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setConfirmDelete(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  // Close on ESC
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        setConfirmDelete(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  if (!user) return null;
+
+  const avatarSrc = user.profile_image || user.picture || '';
+  const initial = (user.name || 'O').charAt(0).toUpperCase();
+
+  const handleLogout = () => {
+    logout();
+    addToast('Signed out', 'info');
+    navigate('/', { replace: true });
+  };
+
+  const handleDeleteAccount = async () => {
+    setDeleting(true);
+    try {
+      await deleteAccount();
+      // Wipe user-scoped local data (draft notes, etc.) before logging out
+      if (user?.user_id) clearDraftNotes(user.user_id);
+      logout();
+      addToast('Your account has been deleted', 'info');
+      navigate('/', { replace: true });
+    } catch {
+      addToast('Failed to delete account', 'error');
+      setDeleting(false);
+    }
+  };
+
+  const handleNavigate = (path: string) => {
+    setOpen(false);
+    navigate(path);
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative w-10 h-10 rounded-full bg-purple-600/30 border border-purple-500/40 hover:bg-purple-600/50 hover:border-purple-400/60 transition-all overflow-hidden cursor-pointer flex items-center justify-center"
+        title="Account menu"
+      >
+        {avatarSrc ? (
+          <img src={avatarSrc} alt="" className="w-full h-full object-cover" referrerPolicy="no-referrer" />
+        ) : (
+          <span className="text-purple-200 text-sm font-bold">{initial}</span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.97 }}
+            transition={{ duration: 0.15 }}
+            className="absolute right-0 mt-2 w-64 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50"
+          >
+            {/* User header */}
+            <div className="flex items-center gap-3 px-4 py-3 border-b border-white/5">
+              <div className="w-10 h-10 rounded-full bg-purple-600/30 border border-purple-500/40 overflow-hidden flex items-center justify-center flex-shrink-0">
+                {avatarSrc ? (
+                  <img src={avatarSrc} alt="" className="w-full h-full object-cover" referrerPolicy="no-referrer" />
+                ) : (
+                  <span className="text-purple-200 text-sm font-bold">{initial}</span>
+                )}
+              </div>
+              <div className="min-w-0">
+                <div className="text-white text-sm font-semibold truncate">{user.name || 'User'}</div>
+                <div className="text-white/40 text-xs truncate">{user.email}</div>
+              </div>
+            </div>
+
+            {/* Nav links */}
+            <div className="py-1">
+              {NAV_LINKS.map((link) => {
+                const isActive = location.pathname === link.path;
+                return (
+                  <button
+                    key={link.path}
+                    onClick={() => handleNavigate(link.path)}
+                    className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors cursor-pointer ${
+                      isActive
+                        ? 'bg-purple-600/15 text-purple-300'
+                        : 'text-white/70 hover:bg-white/5 hover:text-white'
+                    }`}
+                  >
+                    {link.icon}
+                    <span>{link.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="border-t border-white/5" />
+
+            {/* Logout */}
+            <button
+              onClick={handleLogout}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-white/70 hover:bg-white/5 hover:text-white transition-colors cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              Sign out
+            </button>
+
+            {/* Delete account */}
+            <div className="border-t border-white/5" />
+            {!confirmDelete ? (
+              <button
+                onClick={() => setConfirmDelete(true)}
+                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-white/40 hover:bg-red-500/10 hover:text-red-400 transition-colors cursor-pointer"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                Delete account
+              </button>
+            ) : (
+              <div className="px-4 py-3 bg-red-500/5">
+                <p className="text-red-300/90 text-xs mb-3">
+                  This will permanently delete your orb and all data. This cannot be undone.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleDeleteAccount}
+                    disabled={deleting}
+                    className="flex-1 bg-red-500/20 hover:bg-red-500/30 disabled:opacity-50 text-red-300 text-xs font-semibold py-1.5 rounded transition-colors cursor-pointer"
+                  >
+                    {deleting ? 'Deleting...' : 'Yes, delete'}
+                  </button>
+                  <button
+                    onClick={() => setConfirmDelete(false)}
+                    disabled={deleting}
+                    className="flex-1 bg-white/5 hover:bg-white/10 text-white/60 text-xs font-semibold py-1.5 rounded transition-colors cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -48,6 +48,11 @@ export function saveDraftNotes(userId: string, notes: DraftNote[]) {
   localStorage.setItem(userDraftsKey(userId), JSON.stringify(notes));
 }
 
+/** Remove all draft notes for a user (used on account delete). */
+export function clearDraftNotes(userId: string) {
+  localStorage.removeItem(userDraftsKey(userId));
+}
+
 const TARGET_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'it', label: 'Italiano' },

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -20,7 +20,7 @@ interface OrbGraph3DProps {
 
 function getNodeName(node: any): string {
   const label = node._labels?.[0];
-  if (label === 'Person') return node.name || 'You';
+  if (label === 'Person') return node.cv_display_name || node.name || 'You';
   return node.name || node.title || node.company || node.institution || '';
 }
 

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -1,28 +1,23 @@
 import { useState, useCallback } from 'react';
-import { motion } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
-import { uploadCV, confirmCV } from '../../api/cv';
-import { enhanceNote } from '../../api/orbs';
+import { uploadCV } from '../../api/cv';
 import type { ExtractedData, ExtractedRelationship } from '../../api/cv';
-import { NODE_TYPE_COLORS, NODE_TYPE_LABELS } from '../graph/NodeColors';
-import NodeForm from '../editor/NodeForm';
 import { useAuthStore } from '../../stores/authStore';
 import { loadDraftNotes, saveDraftNotes } from '../drafts/DraftNotes';
+import ExtractedDataReview from './ExtractedDataReview';
 
 export default function CVUploadOnboarding() {
-  const navigate = useNavigate();
-  const { user, fetchUser } = useAuthStore();
+  const { user } = useAuthStore();
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState('');
-  const [extractedNodes, setExtractedNodes] = useState<ExtractedData['nodes'] | null>(null);
-  const [unmatchedCount, setUnmatchedCount] = useState(0);
-  const [skippedCount, setSkippedCount] = useState(0);
-  const [truncated, setTruncated] = useState(false);
-  const [relationships, setRelationships] = useState<ExtractedRelationship[]>([]);
-  const [cvOwnerName, setCvOwnerName] = useState<string | null>(null);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [extractedData, setExtractedData] = useState<{
+    nodes: ExtractedData['nodes'];
+    relationships: ExtractedRelationship[];
+    cvOwnerName: string | null;
+    unmatchedCount: number;
+    skippedCount: number;
+    truncated: boolean;
+  } | null>(null);
 
   const handleFile = useCallback(async (file: File) => {
     const ext = file.name.split('.').pop()?.toLowerCase();
@@ -37,6 +32,7 @@ export default function CVUploadOnboarding() {
       const data = await uploadCV(file);
 
       // Save unmatched entries to draft notes (user-scoped)
+      let unmatchedCount = 0;
       if (data.unmatched && data.unmatched.length > 0 && user?.user_id) {
         const existing = loadDraftNotes(user.user_id);
         const newNotes = data.unmatched.map((text: string) => ({
@@ -46,25 +42,27 @@ export default function CVUploadOnboarding() {
           fromVoice: false,
         }));
         saveDraftNotes(user.user_id, [...newNotes, ...existing]);
-        setUnmatchedCount(data.unmatched.length);
+        unmatchedCount = data.unmatched.length;
       }
-
-      setSkippedCount(data.skipped_nodes?.length || 0);
-      setTruncated(data.truncated || false);
-      setRelationships(data.relationships || []);
-      setCvOwnerName(data.cv_owner_name || null);
 
       if (data.nodes.length === 0 && (!data.unmatched || data.unmatched.length === 0)) {
         setError('No entries could be extracted from this file. Try a different CV or use manual entry.');
       } else {
-        setExtractedNodes(data.nodes);
+        setExtractedData({
+          nodes: data.nodes,
+          relationships: data.relationships || [],
+          cvOwnerName: data.cv_owner_name || null,
+          unmatchedCount,
+          skippedCount: data.skipped_nodes?.length || 0,
+          truncated: data.truncated || false,
+        });
       }
     } catch {
       setError('Failed to parse CV. Please try again or use manual entry.');
     } finally {
       setUploading(false);
     }
-  }, []);
+  }, [user]);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -78,180 +76,19 @@ export default function CVUploadOnboarding() {
     if (file) handleFile(file);
   }, [handleFile]);
 
-  const removeNode = (index: number) => {
-    if (!extractedNodes) return;
-    setExtractedNodes(extractedNodes.filter((_, i) => i !== index));
-    setRelationships(prev =>
-      prev
-        .filter(r => r.from_index !== index && r.to_index !== index)
-        .map(r => ({
-          ...r,
-          from_index: r.from_index > index ? r.from_index - 1 : r.from_index,
-          to_index: r.to_index > index ? r.to_index - 1 : r.to_index,
-        }))
-    );
-    if (editingIndex === index) setEditingIndex(null);
-    else if (editingIndex !== null && editingIndex > index) setEditingIndex(editingIndex - 1);
-  };
-
-  const handleConfirm = async () => {
-    if (!extractedNodes || extractedNodes.length === 0) return;
-    setConfirming(true);
-    try {
-      await confirmCV(extractedNodes, relationships, cvOwnerName);
-      await fetchUser();
-      navigate('/myorbis');
-    } catch {
-      setError('Failed to save entries. Please try again.');
-    } finally {
-      setConfirming(false);
-    }
-  };
-
-  // ── Review mode ──
-  if (extractedNodes) {
-    const grouped = extractedNodes.reduce<Record<string, Array<{ index: number; props: Record<string, unknown> }>>>((acc, node, i) => {
-      const type = node.node_type;
-      if (!acc[type]) acc[type] = [];
-      acc[type].push({ index: i, props: node.properties });
-      return acc;
-    }, {});
-
+  // ── Review mode (shared component) ──
+  if (extractedData) {
     return (
-      <div className="min-h-screen bg-black flex flex-col items-center px-3 sm:px-4 py-10 sm:py-16">
-        <div className="w-full max-w-[95vw] sm:max-w-2xl">
-          <div className="text-center mb-8">
-            <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-green-500/15 border border-green-500/25 flex items-center justify-center">
-              <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
-              </svg>
-            </div>
-            <h2 className="text-white text-xl font-semibold">
-              Found {extractedNodes.length} entries
-            </h2>
-            <p className="text-white/30 text-sm mt-1">Review, edit, or remove entries, then add them all to your orbis.</p>
-            {truncated && (
-              <p className="text-amber-400/80 text-xs mt-2">
-                Your CV was too long and was partially truncated. Some entries at the end may have been missed.
-              </p>
-            )}
-            {unmatchedCount > 0 && (
-              <p className="text-amber-400/80 text-xs mt-2">
-                {unmatchedCount} entr{unmatchedCount === 1 ? 'y' : 'ies'} couldn't be classified and {unmatchedCount === 1 ? 'was' : 'were'} added to your Draft Notes for manual review.
-              </p>
-            )}
-            {skippedCount > 0 && (
-              <p className="text-amber-400/60 text-xs mt-1">
-                {skippedCount} entr{skippedCount === 1 ? 'y was' : 'ies were'} skipped due to missing required fields or unknown types.
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-6 mb-8">
-            {Object.entries(grouped).map(([type, items]) => {
-              const color = NODE_TYPE_COLORS[type] || '#8b5cf6';
-              const label = NODE_TYPE_LABELS[type] || type;
-              return (
-                <div key={type}>
-                  <div className="flex items-center gap-2 mb-2">
-                    <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
-                    <span className="text-white/50 text-xs font-bold uppercase tracking-widest">{label}</span>
-                    <span className="text-white/20 text-xs">({items.length})</span>
-                  </div>
-                  <div className="space-y-2">
-                    {items.map(({ index, props }) => {
-                      if (editingIndex === index) {
-                        return (
-                          <motion.div
-                            key={index}
-                            layout
-                            className="bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 sm:px-4 py-3 sm:py-4"
-                          >
-                            <NodeForm
-                              initialType={type}
-                              initialValues={props as Record<string, unknown>}
-                              onSubmit={(nodeType, newProps) => {
-                                setExtractedNodes(prev => {
-                                  if (!prev) return prev;
-                                  const updated = [...prev];
-                                  updated[index] = { node_type: nodeType, properties: newProps };
-                                  return updated;
-                                });
-                                setEditingIndex(null);
-                              }}
-                              onCancel={() => setEditingIndex(null)}
-                              onEnhance={async (text) => {
-                                const existingSkills = (extractedNodes || [])
-                                  .filter(n => n.node_type === 'Skill' && n.properties.name)
-                                  .map((n, i) => ({ uid: `cv-${i}`, name: n.properties.name as string }));
-                                const targetLang = localStorage.getItem('orbis_note_target_lang') || 'en';
-                                const result = await enhanceNote(text, targetLang, existingSkills);
-                                return { node_type: result.node_type, properties: result.properties };
-                              }}
-                            />
-                          </motion.div>
-                        );
-                      }
-                      const title = (props.name || props.title || props.company || props.institution || 'Untitled') as string;
-                      const subtitle = (props.company || props.degree || props.issuing_organization || props.category || '') as string;
-                      return (
-                        <motion.div
-                          key={index}
-                          layout
-                          className="flex items-center gap-2 sm:gap-3 bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 group"
-                        >
-                          <div className="flex-1 min-w-0">
-                            <div className="text-white/80 text-sm font-medium truncate">{title}</div>
-                            {subtitle && subtitle !== title && (
-                              <div className="text-white/30 text-xs truncate">{subtitle}</div>
-                            )}
-                          </div>
-                          <button
-                            onClick={() => setEditingIndex(index)}
-                            className="text-white/15 hover:text-blue-400 transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
-                            title="Edit"
-                          >
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                            </svg>
-                          </button>
-                          <button
-                            onClick={() => removeNode(index)}
-                            className="text-white/15 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
-                            title="Remove"
-                          >
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                          </button>
-                        </motion.div>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {error && <p className="text-red-400 text-sm text-center mb-4">{error}</p>}
-
-          <div className="flex gap-3 justify-center">
-            <button
-              onClick={handleConfirm}
-              disabled={confirming || extractedNodes.length === 0}
-              className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 text-base"
-            >
-              {confirming ? 'Adding...' : `Add ${extractedNodes.length} entries to graph`}
-            </button>
-            <button
-              onClick={() => setExtractedNodes(null)}
-              className="border border-white/10 text-white/40 hover:text-white/70 font-medium py-3 px-6 rounded-xl transition-colors text-base"
-            >
-              Try another file
-            </button>
-          </div>
-        </div>
-      </div>
+      <ExtractedDataReview
+        initialNodes={extractedData.nodes}
+        initialRelationships={extractedData.relationships}
+        cvOwnerName={extractedData.cvOwnerName}
+        unmatchedCount={extractedData.unmatchedCount}
+        skippedCount={extractedData.skippedCount}
+        truncated={extractedData.truncated}
+        onReset={() => setExtractedData(null)}
+        resetLabel="Try another file"
+      />
     );
   }
 

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -1,0 +1,299 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import { confirmCV } from '../../api/cv';
+import { enhanceNote, getMyOrb } from '../../api/orbs';
+import type { ExtractedData, ExtractedRelationship } from '../../api/cv';
+import { NODE_TYPE_COLORS, NODE_TYPE_LABELS } from '../graph/NodeColors';
+import NodeForm from '../editor/NodeForm';
+import { useAuthStore } from '../../stores/authStore';
+import { useToastStore } from '../../stores/toastStore';
+
+interface ExtractedDataReviewProps {
+  initialNodes: ExtractedData['nodes'];
+  initialRelationships: ExtractedRelationship[];
+  cvOwnerName: string | null;
+  unmatchedCount: number;
+  skippedCount: number;
+  truncated: boolean;
+  onReset: () => void;
+  resetLabel?: string;
+}
+
+export default function ExtractedDataReview({
+  initialNodes,
+  initialRelationships,
+  cvOwnerName,
+  unmatchedCount,
+  skippedCount,
+  truncated,
+  onReset,
+  resetLabel = 'Try another file',
+}: ExtractedDataReviewProps) {
+  const navigate = useNavigate();
+  const { fetchUser } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
+  const [extractedNodes, setExtractedNodes] = useState(initialNodes);
+  const [relationships, setRelationships] = useState(initialRelationships);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState('');
+  const [existingNodeCount, setExistingNodeCount] = useState<number | null>(null);
+  const [showReplaceWarning, setShowReplaceWarning] = useState(false);
+
+  // Check how many nodes the user already has — we need to warn them that confirm wipes the graph
+  useEffect(() => {
+    getMyOrb()
+      .then((orb) => setExistingNodeCount(orb.nodes.length))
+      .catch(() => setExistingNodeCount(0));
+  }, []);
+
+  const removeNode = (index: number) => {
+    setExtractedNodes(prev => prev.filter((_, i) => i !== index));
+    setRelationships(prev =>
+      prev
+        .filter(r => r.from_index !== index && r.to_index !== index)
+        .map(r => ({
+          ...r,
+          from_index: r.from_index > index ? r.from_index - 1 : r.from_index,
+          to_index: r.to_index > index ? r.to_index - 1 : r.to_index,
+        }))
+    );
+    if (editingIndex === index) setEditingIndex(null);
+    else if (editingIndex !== null && editingIndex > index) setEditingIndex(editingIndex - 1);
+  };
+
+  const handleConfirmClick = () => {
+    if (extractedNodes.length === 0) return;
+    // If the user already has nodes, ask for explicit confirmation — confirmCV wipes the graph
+    if ((existingNodeCount ?? 0) > 0) {
+      setShowReplaceWarning(true);
+      return;
+    }
+    void handleConfirm();
+  };
+
+  const handleConfirm = async () => {
+    setShowReplaceWarning(false);
+    setConfirming(true);
+    try {
+      const replaced = existingNodeCount ?? 0;
+      await confirmCV(extractedNodes, relationships, cvOwnerName);
+      await fetchUser();
+      if (replaced > 0) {
+        addToast(
+          `Imported ${extractedNodes.length} entries (replaced ${replaced} existing)`,
+          'success',
+        );
+      } else {
+        addToast(`Imported ${extractedNodes.length} entries into your orb`, 'success');
+      }
+      navigate('/myorbis');
+    } catch {
+      setError('Failed to save entries. Please try again.');
+      addToast('Failed to import CV data', 'error');
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const grouped = extractedNodes.reduce<Record<string, Array<{ index: number; props: Record<string, unknown> }>>>((acc, node, i) => {
+    const type = node.node_type;
+    if (!acc[type]) acc[type] = [];
+    acc[type].push({ index: i, props: node.properties });
+    return acc;
+  }, {});
+
+  return (
+    <div className="min-h-screen bg-black flex flex-col items-center px-3 sm:px-4 py-10 sm:py-16">
+      <div className="w-full max-w-[95vw] sm:max-w-2xl">
+        <div className="text-center mb-8">
+          <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-green-500/15 border border-green-500/25 flex items-center justify-center">
+            <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-white text-xl font-semibold">
+            Found {extractedNodes.length} entries
+          </h2>
+          <p className="text-white/30 text-sm mt-1">Review, edit, or remove entries, then add them all to your orb.</p>
+          {truncated && (
+            <p className="text-amber-400/80 text-xs mt-2">
+              Your CV was too long and was partially truncated. Some entries at the end may have been missed.
+            </p>
+          )}
+          {unmatchedCount > 0 && (
+            <p className="text-amber-400/80 text-xs mt-2">
+              {unmatchedCount} entr{unmatchedCount === 1 ? 'y' : 'ies'} couldn't be classified and {unmatchedCount === 1 ? 'was' : 'were'} added to your Draft Notes for manual review.
+            </p>
+          )}
+          {skippedCount > 0 && (
+            <p className="text-amber-400/60 text-xs mt-1">
+              {skippedCount} entr{skippedCount === 1 ? 'y was' : 'ies were'} skipped due to missing required fields or unknown types.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-6 mb-8">
+          {Object.entries(grouped).map(([type, items]) => {
+            const color = NODE_TYPE_COLORS[type] || '#8b5cf6';
+            const label = NODE_TYPE_LABELS[type] || type;
+            return (
+              <div key={type}>
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
+                  <span className="text-white/50 text-xs font-bold uppercase tracking-widest">{label}</span>
+                  <span className="text-white/20 text-xs">({items.length})</span>
+                </div>
+                <div className="space-y-2">
+                  {items.map(({ index, props }) => {
+                    if (editingIndex === index) {
+                      return (
+                        <motion.div
+                          key={index}
+                          layout
+                          className="bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 sm:px-4 py-3 sm:py-4"
+                        >
+                          <NodeForm
+                            initialType={type}
+                            initialValues={props as Record<string, unknown>}
+                            onSubmit={(nodeType, newProps) => {
+                              setExtractedNodes(prev => {
+                                const updated = [...prev];
+                                updated[index] = { node_type: nodeType, properties: newProps };
+                                return updated;
+                              });
+                              setEditingIndex(null);
+                            }}
+                            onCancel={() => setEditingIndex(null)}
+                            onEnhance={async (text) => {
+                              const existingSkills = extractedNodes
+                                .filter(n => n.node_type === 'Skill' && n.properties.name)
+                                .map((n, i) => ({ uid: `cv-${i}`, name: n.properties.name as string }));
+                              const targetLang = localStorage.getItem('orbis_note_target_lang') || 'en';
+                              const result = await enhanceNote(text, targetLang, existingSkills);
+                              return { node_type: result.node_type, properties: result.properties };
+                            }}
+                          />
+                        </motion.div>
+                      );
+                    }
+                    const title = (props.name || props.title || props.company || props.institution || 'Untitled') as string;
+                    const subtitle = (props.company || props.degree || props.issuing_organization || props.category || '') as string;
+                    return (
+                      <motion.div
+                        key={index}
+                        layout
+                        className="flex items-center gap-2 sm:gap-3 bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 group"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="text-white/80 text-sm font-medium truncate">{title}</div>
+                          {subtitle && subtitle !== title && (
+                            <div className="text-white/30 text-xs truncate">{subtitle}</div>
+                          )}
+                        </div>
+                        <button
+                          onClick={() => setEditingIndex(index)}
+                          className="text-white/15 hover:text-blue-400 transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
+                          title="Edit"
+                        >
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                          </svg>
+                        </button>
+                        <button
+                          onClick={() => removeNode(index)}
+                          className="text-white/15 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
+                          title="Remove"
+                        >
+                          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </motion.div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {error && <p className="text-red-400 text-sm text-center mb-4">{error}</p>}
+
+        {(existingNodeCount ?? 0) > 0 && (
+          <p className="text-amber-400/80 text-xs text-center mb-3">
+            You currently have {existingNodeCount} entries in your orb. Importing will replace them.
+          </p>
+        )}
+
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={handleConfirmClick}
+            disabled={confirming || extractedNodes.length === 0}
+            className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 text-base cursor-pointer"
+          >
+            {confirming ? 'Adding...' : `Add ${extractedNodes.length} entries to graph`}
+          </button>
+          <button
+            onClick={onReset}
+            className="border border-white/10 text-white/40 hover:text-white/70 font-medium py-3 px-6 rounded-xl transition-colors text-base cursor-pointer"
+          >
+            {resetLabel}
+          </button>
+        </div>
+      </div>
+
+      {/* Replace confirmation modal */}
+      <AnimatePresence>
+        {showReplaceWarning && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm px-4"
+            onClick={() => setShowReplaceWarning(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              className="bg-neutral-950 border border-white/10 rounded-2xl p-6 max-w-md w-full shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-start gap-3 mb-4">
+                <div className="w-10 h-10 rounded-full bg-amber-500/15 border border-amber-500/30 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-5 h-5 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-white text-lg font-semibold mb-1">Replace existing orb?</h3>
+                  <p className="text-white/50 text-sm leading-relaxed">
+                    You currently have <span className="text-white font-semibold">{existingNodeCount}</span> entries in your orb.
+                    Importing this CV will <span className="text-red-300">delete all of them</span> and replace them with
+                    the {extractedNodes.length} new entries. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-2 justify-end mt-5">
+                <button
+                  onClick={() => setShowReplaceWarning(false)}
+                  className="border border-white/10 text-white/60 hover:text-white hover:bg-white/5 font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleConfirm}
+                  className="bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 text-red-300 font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                >
+                  Replace
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,21 +1,38 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
+import { hasOrbContent } from '../api/orbs';
 
 export default function AuthCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { setToken, fetchUser } = useAuthStore();
+  const { setToken, fetchUser, loginGoogle } = useAuthStore();
 
   useEffect(() => {
+    const goToPostLogin = async () => {
+      const hasContent = await hasOrbContent();
+      navigate(hasContent ? '/myorbis' : '/create');
+    };
+
+    // Legacy flow: backend redirects with ?token=
     const token = searchParams.get('token');
     if (token) {
       setToken(token);
-      fetchUser().then(() => navigate('/create'));
-    } else {
-      navigate('/');
+      fetchUser().then(goToPostLogin);
+      return;
     }
-  }, [searchParams, setToken, fetchUser, navigate]);
+
+    // Google redirect flow: ?code=
+    const code = searchParams.get('code');
+    if (code) {
+      loginGoogle(code)
+        .then(goToPostLogin)
+        .catch(() => navigate('/'));
+      return;
+    }
+
+    navigate('/');
+  }, [searchParams, setToken, fetchUser, loginGoogle, navigate]);
 
   return (
     <div className="min-h-screen bg-black text-white flex items-center justify-center">

--- a/frontend/src/pages/CreateOrbPage.tsx
+++ b/frontend/src/pages/CreateOrbPage.tsx
@@ -8,6 +8,7 @@ import FloatingInput from '../components/editor/FloatingInput';
 import { NODE_TYPE_LABELS } from '../components/graph/NodeColors';
 import CVUploadOnboarding from '../components/onboarding/CVUploadOnboarding';
 import ConsentGate from '../components/onboarding/ConsentGate';
+import Navbar from '../components/Navbar';
 
 const SUGGESTED_ORDER = [
   { type: 'work_experience', prompt: "Let's start with your work experience" },
@@ -104,7 +105,8 @@ export default function CreateOrbPage() {
   if (!selectedPath) {
     return (
       <ConsentGate>
-        <div className="min-h-screen bg-black flex flex-col items-center justify-center px-6">
+        <div className="min-h-screen bg-black flex flex-col items-center justify-center px-6 relative">
+        <Navbar />
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -127,7 +129,7 @@ export default function CreateOrbPage() {
         >
           <PathCard
             title="Import from your CV"
-            description="Upload a PDF or DOCX file. We'll parse it and extract your experiences, skills, and education."
+            description="Upload a PDF file. We'll parse it and extract your experiences, skills, and education."
             color="#3b82f6"
             onClick={() => setSelectedPath('upload')}
             icon={
@@ -140,7 +142,7 @@ export default function CreateOrbPage() {
             title="Build from scratch"
             description="Start with an empty orbis and add entries one by one. Full control over every detail."
             color="#10b981"
-            onClick={() => navigate('/myorbis')}
+            onClick={() => navigate('/myorbis', { state: { allowEmpty: true } })}
             icon={
               <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -155,7 +157,12 @@ export default function CreateOrbPage() {
 
   // ── CV Upload path ──
   if (selectedPath === 'upload') {
-    return <CVUploadOnboarding />;
+    return (
+      <div className="relative">
+        <Navbar />
+        <CVUploadOnboarding />
+      </div>
+    );
   }
 
   // ── Manual path (existing flow) ──
@@ -180,22 +187,24 @@ export default function CreateOrbPage() {
       )}
 
       {/* Top bar */}
-      <div className="absolute top-0 left-0 right-0 z-30 flex items-center justify-between px-3 sm:px-6 py-3 sm:py-4">
-        <div className="text-white">
-          <span className="text-base sm:text-lg font-semibold">{user?.name || 'My Orbis'}</span>
-          <span className="text-gray-500 text-xs sm:text-sm ml-2 sm:ml-3">{nodeCount} nodes</span>
-        </div>
-        <div className="flex gap-3">
-          {nodeCount > 0 && (
+      <Navbar
+        center={
+          <div className="text-white/70 text-sm">
+            <span className="font-medium text-white">{user?.name || 'My Orbis'}</span>
+            <span className="text-white/30 ml-2 hidden sm:inline">{nodeCount} nodes</span>
+          </div>
+        }
+        rightBefore={
+          nodeCount > 0 ? (
             <button
               onClick={handleFinish}
-              className="bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors"
+              className="bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium py-1.5 px-3 sm:px-4 rounded-lg transition-colors cursor-pointer"
             >
-              Done — View My Orbisis
+              Done <span className="hidden sm:inline">— View My Orbis</span>
             </button>
-          )}
-        </div>
-      </div>
+          ) : null
+        }
+      />
 
       {/* Bottom prompt bar — shown when input is closed */}
       <AnimatePresence>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -89,7 +89,7 @@ function SignInButtons({ onGoogleLogin, signingInProvider, disabled }: { onGoogl
         {signingInProvider === 'google' ? 'Signing in...' : 'Sign in with Google'}
       </button>
       <button
-        onClick={() => { !busy && redirectToLinkedIn(); }}
+        onClick={() => { if (!busy) redirectToLinkedIn(); }}
         disabled={busy}
         className="flex items-center justify-center gap-3 bg-[#0A66C2] hover:bg-[#004182] disabled:opacity-50 text-white font-medium py-3 px-6 rounded-xl transition-all shadow-lg text-sm w-full cursor-pointer"
       >

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,8 +1,30 @@
 import { motion, useInView } from 'framer-motion';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useGoogleLogin } from '@react-oauth/google';
 import { useAuthStore } from '../stores/authStore';
+import { hasOrbContent } from '../api/orbs';
 import HeroOrb from '../components/landing/HeroOrb';
+
+// ── LinkedIn OAuth helpers ──
+function generateState() {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function redirectToLinkedIn() {
+  const state = generateState();
+  sessionStorage.setItem('linkedin_oauth_state', state);
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: import.meta.env.VITE_LINKEDIN_CLIENT_ID,
+    redirect_uri: `${window.location.origin}/auth/linkedin/callback`,
+    scope: 'openid profile email',
+    state,
+  });
+  window.location.href = `https://www.linkedin.com/oauth/v2/authorization?${params}`;
+}
 
 // ── Animated section wrapper ──
 function FadeIn({ children, delay = 0, className = '' }: { children: React.ReactNode; delay?: number; className?: string }) {
@@ -48,19 +70,58 @@ function FeatureCard({ title, description, icon, color }: { title: string; descr
   );
 }
 
+// ── Sign-in buttons ──
+function SignInButtons({ onGoogleLogin, signingInProvider, disabled }: { onGoogleLogin: () => void; signingInProvider: 'google' | 'linkedin' | null; disabled?: boolean }) {
+  const busy = signingInProvider !== null || disabled;
+  return (
+    <div className="flex flex-col gap-3 w-full max-w-xs">
+      <button
+        onClick={onGoogleLogin}
+        disabled={busy}
+        className="flex items-center justify-center gap-3 bg-white hover:bg-gray-100 disabled:opacity-50 text-gray-700 font-medium py-3 px-6 rounded-xl transition-all shadow-lg text-sm w-full cursor-pointer"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        {signingInProvider === 'google' ? 'Signing in...' : 'Sign in with Google'}
+      </button>
+      <button
+        onClick={() => { !busy && redirectToLinkedIn(); }}
+        disabled={busy}
+        className="flex items-center justify-center gap-3 bg-[#0A66C2] hover:bg-[#004182] disabled:opacity-50 text-white font-medium py-3 px-6 rounded-xl transition-all shadow-lg text-sm w-full cursor-pointer"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+        </svg>
+        {signingInProvider === 'linkedin' ? 'Signing in...' : 'Sign in with LinkedIn'}
+      </button>
+    </div>
+  );
+}
+
 export default function LandingPage() {
   const navigate = useNavigate();
-  const { user, loginDev, loading } = useAuthStore();
+  const { user, loginGoogle, loading } = useAuthStore();
 
-  const [signingIn, setSigningIn] = useState(false);
+  const [signingInProvider, setSigningInProvider] = useState<'google' | 'linkedin' | null>(null);
 
-  const handleGetStarted = async () => {
-    setSigningIn(true);
-    await loginDev();
-    // Navigate only after login completes — the signingIn flag prevents
-    // the landing page from flashing the logged-in state during transition
-    navigate('/create');
-  };
+  const handleGoogleLogin = useGoogleLogin({
+    flow: 'auth-code',
+    onSuccess: async (response) => {
+      setSigningInProvider('google');
+      try {
+        await loginGoogle(response.code);
+        const hasContent = await hasOrbContent();
+        navigate(hasContent ? '/myorbis' : '/create');
+      } catch {
+        setSigningInProvider(null);
+      }
+    },
+    onError: () => setSigningInProvider(null),
+  });
 
   return (
     <div className="min-h-screen bg-black text-white overflow-x-hidden">
@@ -78,22 +139,14 @@ export default function LandingPage() {
             </div>
             <span className="text-white font-bold text-lg tracking-tight">OpenOrbis</span>
           </div>
-          {user && !signingIn ? (
+          {user && !signingInProvider ? (
             <button
               onClick={() => navigate('/myorbis')}
               className="text-sm text-purple-400 hover:text-purple-300 font-medium transition-colors"
             >
-              Go to My Orbisis &rarr;
+              Go to My Orbis &rarr;
             </button>
-          ) : (
-            <button
-              onClick={handleGetStarted}
-              disabled={loading}
-              className="text-sm text-white/50 hover:text-white/80 font-medium transition-colors"
-            >
-              Sign in
-            </button>
-          )}
+          ) : null}
         </div>
       </motion.header>
 
@@ -154,9 +207,9 @@ export default function LandingPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.9, duration: 0.8 }}
-          className="flex flex-col sm:flex-row gap-3 z-10"
+          className="flex flex-col items-center gap-3 z-10"
         >
-          {user && !signingIn ? (
+          {user && !signingInProvider ? (
             <>
               <button
                 onClick={() => navigate('/myorbis')}
@@ -170,24 +223,7 @@ export default function LandingPage() {
               </div>
             </>
           ) : (
-            <>
-              <button
-                onClick={handleGetStarted}
-                disabled={loading || signingIn}
-                className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3.5 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 hover:shadow-purple-500/30 hover:scale-[1.02] text-base flex items-center gap-2"
-              >
-                {loading || signingIn ? 'Signing in...' : 'Create Your Orbis'}
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-                </svg>
-              </button>
-              <button
-                onClick={() => document.getElementById('orbis-difference')?.scrollIntoView({ behavior: 'smooth' })}
-                className="border border-white/10 hover:border-white/20 text-white/50 hover:text-white/70 font-medium py-3.5 px-8 rounded-xl transition-all text-base"
-              >
-                Learn more
-              </button>
-            </>
+            <SignInButtons onGoogleLogin={handleGoogleLogin} signingInProvider={signingInProvider} disabled={loading} />
           )}
         </motion.div>
 
@@ -390,22 +426,18 @@ export default function LandingPage() {
             <p className="text-white/30 text-base mb-8 max-w-md mx-auto">
               It takes less than five minutes. No templates, no formatting, no PDFs — just you and your graph.
             </p>
-            {user && !signingIn ? (
-              <button
-                onClick={() => navigate('/myorbis')}
-                className="bg-purple-600 hover:bg-purple-500 text-white font-semibold py-3.5 px-10 rounded-xl transition-all shadow-xl shadow-purple-600/20 hover:shadow-purple-500/30 hover:scale-[1.02] text-base"
-              >
-                Go to My Orbis
-              </button>
-            ) : (
-              <button
-                onClick={handleGetStarted}
-                disabled={loading || signingIn}
-                className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3.5 px-10 rounded-xl transition-all shadow-xl shadow-purple-600/20 hover:shadow-purple-500/30 hover:scale-[1.02] text-base"
-              >
-                {loading || signingIn ? 'Signing in...' : 'Get Started — Free'}
-              </button>
-            )}
+            <div className="flex justify-center">
+              {user && !signingInProvider ? (
+                <button
+                  onClick={() => navigate('/myorbis')}
+                  className="bg-purple-600 hover:bg-purple-500 text-white font-semibold py-3.5 px-10 rounded-xl transition-all shadow-xl shadow-purple-600/20 hover:shadow-purple-500/30 hover:scale-[1.02] text-base"
+                >
+                  Go to My Orbis
+                </button>
+              ) : (
+                <SignInButtons onGoogleLogin={handleGoogleLogin} signingInProvider={signingInProvider} disabled={loading} />
+              )}
+            </div>
           </FadeIn>
         </div>
       </section>

--- a/frontend/src/pages/LinkedInCallbackPage.tsx
+++ b/frontend/src/pages/LinkedInCallbackPage.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
+import { hasOrbContent } from '../api/orbs';
+
+export default function LinkedInCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { loginLinkedIn } = useAuthStore();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const savedState = sessionStorage.getItem('linkedin_oauth_state');
+
+    if (!code || state !== savedState) {
+      navigate('/');
+      return;
+    }
+    sessionStorage.removeItem('linkedin_oauth_state');
+
+    loginLinkedIn(code)
+      .then(async () => {
+        const hasContent = await hasOrbContent();
+        navigate(hasContent ? '/myorbis' : '/create');
+      })
+      .catch(() => navigate('/'));
+  }, [searchParams, loginLinkedIn, navigate]);
+
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center">
+      <div className="text-center">
+        <div className="w-12 h-12 border-4 border-[#0A66C2] border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-gray-400">Signing you in with LinkedIn...</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useOrbStore } from '../stores/orbStore';
 import { useAuthStore } from '../stores/authStore';
@@ -18,6 +18,8 @@ import type { DraftNote } from '../components/drafts/DraftNotes';
 import { loadDraftNotes, saveDraftNotes } from '../components/drafts/DraftNotes';
 import Inbox from '../components/inbox/Inbox';
 import ProcessingCounter from '../components/cv/ProcessingCounter';
+import UserMenu from '../components/UserMenu';
+import { useToastStore } from '../stores/toastStore';
 
 // ── Modals ──
 
@@ -142,7 +144,8 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
   const [success, setSuccess] = useState(false);
   const [newKeyword, setNewKeyword] = useState('');
   const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
-  const { logout } = useAuthStore();
+  const { user, logout } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -174,9 +177,12 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
     setDeleting(true);
     try {
       const { deleteAccount } = await import('../api/auth');
+      const { clearDraftNotes } = await import('../components/drafts/DraftNotes');
       await deleteAccount();
+      if (user?.user_id) clearDraftNotes(user.user_id);
       logout();
-      navigate('/');
+      addToast('Your account has been deleted', 'info');
+      navigate('/', { replace: true });
     } catch {
       setError('Failed to delete account. Please try again.');
       setDeleting(false);
@@ -361,7 +367,7 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                 <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
                   <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
                   <p className="text-gray-400 text-xs leading-relaxed mb-4">
-                    Permanently delete your account, your orbis, and all associated data. After requesting deletion, your data will be retained for 30 days in case you change your mind, then permanently erased. This action cannot be undone.
+                    Permanently delete your account, your orbis, and all associated data. This action is immediate and cannot be undone.
                   </p>
 
                   {!showDeleteConfirm ? (
@@ -374,7 +380,7 @@ function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onCl
                   ) : (
                     <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mt-2">
                       <p className="text-red-300 text-xs font-medium mb-3">
-                        Are you sure? Your orbis and all data will be permanently deleted after 30 days.
+                        Are you sure? Your orbis and all data will be permanently deleted immediately.
                       </p>
                       <div className="flex gap-2">
                         <button
@@ -421,6 +427,7 @@ function ProfilePanel({ person, onClose, onSaved }: {
   onClose: () => void;
   onSaved: () => void;
 }) {
+  const addToast = useToastStore((s) => s.addToast);
   const [values, setValues] = useState<Record<string, string>>(() => {
     const v: Record<string, string> = {};
     for (const acc of SOCIAL_ACCOUNTS) {
@@ -452,17 +459,22 @@ function ProfilePanel({ person, onClose, onSaved }: {
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (!file.type.startsWith('image/')) return;
+    if (!file.type.startsWith('image/')) {
+      addToast('Please select an image file', 'error');
+      return;
+    }
     if (file.size > 2 * 1024 * 1024) {
-      alert('Image too large (max 2MB)');
+      addToast('Image too large (max 2MB)', 'error');
       return;
     }
     setUploadingImage(true);
     try {
       await uploadProfileImage(file);
+      addToast('Profile picture updated', 'success');
       onSaved();
-    } catch { /* toast handles */ }
-    finally { setUploadingImage(false); }
+    } catch {
+      addToast('Failed to upload profile picture', 'error');
+    } finally { setUploadingImage(false); }
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -470,9 +482,11 @@ function ProfilePanel({ person, onClose, onSaved }: {
     setUploadingImage(true);
     try {
       await deleteProfileImage();
+      addToast('Profile picture removed', 'info');
       onSaved();
-    } catch { /* toast handles */ }
-    finally { setUploadingImage(false); setShowDeleteConfirmPhoto(false); }
+    } catch {
+      addToast('Failed to remove profile picture', 'error');
+    } finally { setUploadingImage(false); setShowDeleteConfirmPhoto(false); }
   };
 
   const filledAccounts = SOCIAL_ACCOUNTS.filter((a) => values[a.key]?.trim());
@@ -485,10 +499,12 @@ function ProfilePanel({ person, onClose, onSaved }: {
         props[k] = v.trim();
       }
       await updateProfile(props);
+      addToast('Profile updated', 'success');
       onSaved();
       setEditing(false);
-    } catch { /* toast handles */ }
-    finally { setSaving(false); }
+    } catch {
+      addToast('Failed to update profile', 'error');
+    } finally { setSaving(false); }
   };
 
   return (
@@ -732,9 +748,8 @@ function HeaderBtn({ onClick, children, variant = 'ghost' }: {
 // ── Page ──
 
 export default function OrbViewPage() {
-  const navigate = useNavigate();
   const { data, loading, fetchOrb, addNode, updateNode, deleteNode } = useOrbStore();
-  const { user, logout } = useAuthStore();
+  const { user } = useAuthStore();
   const [showInput, setShowInput] = useState(false);
   const [showShare, setShowShare] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -791,6 +806,18 @@ export default function OrbViewPage() {
   }, [draftNotes, userId, draftsLoaded]);
 
   useEffect(() => { fetchOrb(); }, [fetchOrb]);
+
+  // If the orb is empty (only Person node, no career entries), redirect to the
+  // create flow — UNLESS the user explicitly chose "Build from scratch" (in which
+  // case they passed `state.allowEmpty` and we let them stay on the empty view).
+  const navigate = useNavigate();
+  const location = useLocation();
+  const allowEmpty = (location.state as { allowEmpty?: boolean } | null)?.allowEmpty === true;
+  useEffect(() => {
+    if (!loading && data && data.nodes.length === 0 && !allowEmpty) {
+      navigate('/create', { replace: true });
+    }
+  }, [loading, data, allowEmpty, navigate]);
 
 
   useEffect(() => {
@@ -1014,17 +1041,12 @@ export default function OrbViewPage() {
             </HeaderBtn>
             <button
               onClick={() => window.open('/cv-export', '_blank')}
-              className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all"
+              className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
             >
               <IconDownload />
               <span className="hidden sm:inline">Export CV</span>
             </button>
-            <button
-              onClick={() => { logout(); navigate('/'); }}
-              className="text-white/30 text-xs font-medium py-1.5 px-2 sm:px-3 rounded-lg hover:text-red-400 hover:bg-red-500/10 transition-all"
-            >
-              Logout
-            </button>
+            <UserMenu />
           </div>
         </div>
       </div>

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { devLogin, getMe, type UserInfo } from '../api/auth';
+import axios from 'axios';
+import { getMe, googleLogin, linkedinLogin, type UserInfo } from '../api/auth';
 
 interface AuthState {
   user: UserInfo | null;
@@ -7,7 +8,8 @@ interface AuthState {
   loading: boolean;
   setToken: (token: string) => void;
   fetchUser: () => Promise<void>;
-  loginDev: () => Promise<void>;
+  loginGoogle: (code: string) => Promise<void>;
+  loginLinkedIn: (code: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -26,20 +28,40 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const user = await getMe();
       set({ user, loading: false });
-    } catch {
+    } catch (e) {
+      // Wipe local session on any failure so we don't stay in a half-authenticated state.
+      // 401 is already handled by the axios interceptor (dispatches session-expired).
+      // 404 means the Person node is gone (orphaned token) → emit the same event so
+      // the global handler shows a toast and routes us back to the landing page.
       localStorage.removeItem('orbis_token');
       set({ user: null, token: null, loading: false });
+      if (axios.isAxiosError(e) && e.response?.status === 404) {
+        window.dispatchEvent(new CustomEvent('orbis:session-expired'));
+      }
     }
   },
 
-  loginDev: async () => {
+  loginGoogle: async (code: string) => {
     set({ loading: true });
     try {
-      const { access_token, user } = await devLogin();
+      const { access_token, user } = await googleLogin(code);
       localStorage.setItem('orbis_token', access_token);
       set({ token: access_token, user, loading: false });
     } catch {
       set({ loading: false });
+      throw new Error('Google login failed');
+    }
+  },
+
+  loginLinkedIn: async (code: string) => {
+    set({ loading: true });
+    try {
+      const { access_token, user } = await linkedinLogin(code);
+      localStorage.setItem('orbis_token', access_token);
+      set({ token: access_token, user, loading: false });
+    } catch {
+      set({ loading: false });
+      throw new Error('LinkedIn login failed');
     }
   },
 


### PR DESCRIPTION

## Summary

Adds Google and LinkedIn OAuth login and cleans up the end-to-end user/profile management flow. On top of the base social login, this PR fixes a set of navigation, data-integrity and UX gaps that made the logged-in experience rough or unsafe (silent data loss on CV re-upload, infinite loading on orphaned tokens, empty graph dead-ends, no logout from non-orb pages, no account deletion).

## What's new

### Authentication
- **Google OAuth** via `@react-oauth/google` popup flow (`flow: 'auth-code'`). Backend exchanges the code with `redirect_uri: postmessage` against `oauth2.googleapis.com/token` and fetches userinfo.
- **LinkedIn "Sign In with OpenID Connect"** via manual redirect + `/auth/linkedin/callback` page. Backend handles the code exchange and userinfo fetch.
- `/auth/me` now returns both the OAuth `picture` and the user-uploaded `profile_image`, so the UI can pick the best avatar available.
- New `DELETE /auth/me` endpoint: permanently removes the Person node and the entire subgraph reachable from it (using a variable-length path so nested nodes like `Reply` are also cleaned up).

### Routing & session
- `ProtectedRoute` wrapper on `/create`, `/orb`, `/cv-export`: redirects unauthenticated users to `/` and shows a loader while the user is being fetched, so pages never render with half-hydrated auth state.
- **Smart post-login routing**: after login (Google, LinkedIn, or legacy callback), `hasOrbContent()` decides whether to land the user on `/orb` (if they already have career entries) or `/create` (first-time flow).
- **Empty-orb guard**: visiting `/orb` with zero career nodes redirects to `/create`. The "Build from scratch" path explicitly passes `location.state.allowEmpty` so the redirect is bypassed and the user can start from the empty 3D view without a loop.
- **Session expiry**: `axios` 401 interceptor now dispatches a custom `orbis:session-expired` event instead of doing a hard `window.location.href = '/'`. A global handler in `App.tsx` calls `logout()`, shows an "info" toast and uses React Router `navigate(..., { replace: true })` — no full reload, no flicker.
- **Orphaned-token handling**: `fetchUser` catches a 404 from `/auth/me` (Person missing) and fires the same `orbis:session-expired` event, so users never get stuck in `ProtectedRoute`'s loading state.

### Shared navigation (`Navbar` + `UserMenu`)
- New `Navbar` component used on `CreateOrbPage` (all three branches: path selector, CV upload, 3D flow). Logo on the left, optional center/right slots, `UserMenu` on the right.
- New `UserMenu` component mounted on every protected page. Avatar button (prefers `profile_image`, falls back to OAuth `picture`, then initial) opens a dropdown with:
  - user name + email
  - navigation links to **My Orb**, **Add entries**, **Export CV** (with active-route highlight)
  - **Sign out**
  - **Delete account** with inline confirmation step
- `OrbViewPage` header now uses `UserMenu` instead of a bespoke logout button, so the same account menu is available everywhere.

### CV re-upload safety
- `ExtractedDataReview` fetches the current orb on mount and, if it already contains entries, shows:
  - a yellow hint above the submit button with the current count
  - a **modal confirmation dialog** ("Replace existing orb?") before calling `confirmCV`, with explicit copy that the existing entries will be deleted
- On success, shows a summary toast: *"Imported X entries (replaced Y existing)"* or *"Imported X entries into your orb"*.
- On failure, shows an error toast instead of only an inline message.

### Graph correctness
- `GET_FULL_ORB` and `GET_FULL_ORB_PUBLIC` now exclude `:Message` nodes (welcome messages live in the Inbox, not in the 3D career graph), so newly registered users no longer see a stray "Message" node linked to the Person node.

### Profile editing feedback
- `ProfilePanel` (OrbViewPage) now shows explicit success/error toasts for `updateProfile`, `uploadProfileImage`, and `deleteProfileImage`. Replaces the misleading `/* toast handles */` comments and the `alert('Image too large')` call.
- Central graph node label now reads `cv_display_name || name`: the user name everywhere else stays pinned to the OAuth provider, but the 3D center node can reflect the CV-parsed name when a CV has been imported. The CV confirm endpoint writes to `cv_display_name` instead of overwriting `name`.

### Housekeeping
- Added `clearDraftNotes(userId)` helper; called from the delete-account flow so user-scoped localStorage drafts (`orbis_drafts_<user_id>`) are wiped along with the backend data.
- Login buttons on the landing page now track `signingInProvider: 'google' | 'linkedin' | null` instead of a single boolean, so only the clicked provider shows "Signing in..." while both buttons are disabled.
- `cursor-pointer` on the OAuth buttons (no more dead-looking buttons on hover).
