### PR TITLE
fix(UI): consolidate duplicate user menus on orb view page

### DIFF
--- a/backend/app/cv/claude_classifier.py
+++ b/backend/app/cv/claude_classifier.py
@@ -41,7 +41,7 @@ async def call_claude(
     except asyncio.TimeoutError:
         process.kill()
         logger.error("Claude CLI timed out after 30 minutes")
-        raise RuntimeError("Claude CLI timed out after 30 minutes")
+        raise RuntimeError("Claude CLI timed out after 30 minutes") from None
 
     if process.returncode != 0:
         error_msg = stderr.decode("utf-8", errors="replace").strip()

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -70,7 +70,11 @@ async def upload_cv(
             )
 
         # Step 2: Classify entries via LLM
-        logger.info("Classifying entries with %s (%d chars)", settings.llm_provider, len(raw_text))
+        logger.info(
+            "Classifying entries with %s (%d chars)",
+            settings.llm_provider,
+            len(raw_text),
+        )
         result = await classify_entries(raw_text)
 
         if not result.nodes and not result.unmatched:

--- a/backend/tests/unit/test_classify_entries.py
+++ b/backend/tests/unit/test_classify_entries.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 from httpx import Response
 
-from app.cv.ollama_classifier import TEXT_LIMIT_OLLAMA_OLLAMA, classify_entries
+from app.cv.ollama_classifier import TEXT_LIMIT_OLLAMA, classify_entries
 
 # A valid LLM JSON response
 GOOD_LLM_RESPONSE = json.dumps(

--- a/backend/tests/unit/test_classify_entries.py
+++ b/backend/tests/unit/test_classify_entries.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 from httpx import Response
 
-from app.cv.ollama_classifier import TEXT_LIMIT, classify_entries
+from app.cv.ollama_classifier import TEXT_LIMIT_OLLAMA_OLLAMA, classify_entries
 
 # A valid LLM JSON response
 GOOD_LLM_RESPONSE = json.dumps(
@@ -121,35 +121,41 @@ class TestSuccessfulClassification:
 
 class TestTruncation:
     async def test_short_text_not_truncated(self):
-        with patch(
-            "app.cv.ollama_classifier._call_ollama",
-            new_callable=AsyncMock,
-            return_value=GOOD_LLM_RESPONSE,
-        ):
-            result = await classify_entries("Short CV")
-            assert result.truncated is False
+        with patch("app.cv.ollama_classifier.settings") as mock_settings:
+            mock_settings.llm_provider = "ollama"
+            with patch(
+                "app.cv.ollama_classifier._call_ollama",
+                new_callable=AsyncMock,
+                return_value=GOOD_LLM_RESPONSE,
+            ):
+                result = await classify_entries("Short CV")
+                assert result.truncated is False
 
     async def test_long_text_truncated(self):
-        long_text = "x" * (TEXT_LIMIT + 3000)
-        with patch(
-            "app.cv.ollama_classifier._call_ollama",
-            new_callable=AsyncMock,
-            return_value=GOOD_LLM_RESPONSE,
-        ):
-            result = await classify_entries(long_text)
-            assert result.truncated is True
+        long_text = "x" * (TEXT_LIMIT_OLLAMA + 3000)
+        with patch("app.cv.ollama_classifier.settings") as mock_settings:
+            mock_settings.llm_provider = "ollama"
+            with patch(
+                "app.cv.ollama_classifier._call_ollama",
+                new_callable=AsyncMock,
+                return_value=GOOD_LLM_RESPONSE,
+            ):
+                result = await classify_entries(long_text)
+                assert result.truncated is True
 
     async def test_long_text_sends_truncated_content_to_llm(self):
-        # Use a unique marker that only appears after TEXT_LIMIT
-        long_text = "a" * TEXT_LIMIT + "UNIQUE_TAIL_MARKER"
-        with patch(
-            "app.cv.ollama_classifier._call_ollama",
-            new_callable=AsyncMock,
-            return_value=GOOD_LLM_RESPONSE,
-        ) as mock_ollama:
-            await classify_entries(long_text)
-            call_args = mock_ollama.call_args[0][0]
-            assert "UNIQUE_TAIL_MARKER" not in call_args
+        # Use a unique marker that only appears after TEXT_LIMIT_OLLAMA
+        long_text = "a" * TEXT_LIMIT_OLLAMA + "UNIQUE_TAIL_MARKER"
+        with patch("app.cv.ollama_classifier.settings") as mock_settings:
+            mock_settings.llm_provider = "ollama"
+            with patch(
+                "app.cv.ollama_classifier._call_ollama",
+                new_callable=AsyncMock,
+                return_value=GOOD_LLM_RESPONSE,
+            ) as mock_ollama:
+                await classify_entries(long_text)
+                call_args = mock_ollama.call_args[0][0]
+                assert "UNIQUE_TAIL_MARKER" not in call_args
 
 
 # ── Retry logic ──
@@ -228,14 +234,16 @@ class TestRuleBasedFallback:
             assert result.cv_owner_name == "John Smith"
 
     async def test_fallback_sets_truncated_flag(self):
-        long_text = SAMPLE_CV_TEXT + "x" * (TEXT_LIMIT + 1000)
-        with patch(
-            "app.cv.ollama_classifier._call_ollama",
-            new_callable=AsyncMock,
-            side_effect=ConnectionError("always fails"),
-        ):
-            result = await classify_entries(long_text)
-            assert result.truncated is True
+        long_text = SAMPLE_CV_TEXT + "x" * (TEXT_LIMIT_OLLAMA + 1000)
+        with patch("app.cv.ollama_classifier.settings") as mock_settings:
+            mock_settings.llm_provider = "ollama"
+            with patch(
+                "app.cv.ollama_classifier._call_ollama",
+                new_callable=AsyncMock,
+                side_effect=ConnectionError("always fails"),
+            ):
+                result = await classify_entries(long_text)
+                assert result.truncated is True
 
     async def test_fallback_skips_invalid_nodes(self):
         """Rule-based fallback validates nodes the same way _parse_result does."""

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,56 +1,25 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
+import { claimOrbId } from '../api/orbs';
 import { clearDraftNotes } from './drafts/DraftNotes';
 
-interface NavLink {
-  label: string;
-  path: string;
-  icon: React.ReactNode;
+interface UserMenuProps {
+  orbId?: string;
+  onOrbIdChanged?: () => void;
+  /** Display name next to avatar — makes the whole thing a clickable pill */
+  label?: string;
 }
 
-const NAV_LINKS: NavLink[] = [
-  {
-    label: 'My Orbis',
-    path: '/myorbis',
-    icon: (
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <circle cx="12" cy="12" r="9" strokeWidth={1.5} />
-        <circle cx="12" cy="12" r="3" strokeWidth={1.5} />
-      </svg>
-    ),
-  },
-  {
-    label: 'Add entries',
-    path: '/create',
-    icon: (
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
-      </svg>
-    ),
-  },
-  {
-    label: 'Export CV',
-    path: '/cv-export',
-    icon: (
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1M12 12V4m0 8l-4-4m4 4l4-4" />
-      </svg>
-    ),
-  },
-];
-
-export default function UserMenu() {
+export default function UserMenu({ orbId, onOrbIdChanged, label }: UserMenuProps) {
   const { user, logout } = useAuthStore();
   const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
-  const location = useLocation();
   const [open, setOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [showAccountSettings, setShowAccountSettings] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // Close on outside click
@@ -59,7 +28,6 @@ export default function UserMenu() {
     const onClick = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);
-        setConfirmDelete(false);
       }
     };
     document.addEventListener('mousedown', onClick);
@@ -70,10 +38,7 @@ export default function UserMenu() {
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-        setConfirmDelete(false);
-      }
+      if (e.key === 'Escape') setOpen(false);
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
@@ -90,38 +55,25 @@ export default function UserMenu() {
     navigate('/', { replace: true });
   };
 
-  const handleDeleteAccount = async () => {
-    setDeleting(true);
-    try {
-      await deleteAccount();
-      // Wipe user-scoped local data (draft notes, etc.) before logging out
-      if (user?.user_id) clearDraftNotes(user.user_id);
-      logout();
-      addToast('Your account has been deleted', 'info');
-      navigate('/', { replace: true });
-    } catch {
-      addToast('Failed to delete account', 'error');
-      setDeleting(false);
-    }
-  };
-
-  const handleNavigate = (path: string) => {
-    setOpen(false);
-    navigate(path);
-  };
-
   return (
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="relative w-10 h-10 rounded-full bg-purple-600/30 border border-purple-500/40 hover:bg-purple-600/50 hover:border-purple-400/60 transition-all overflow-hidden cursor-pointer flex items-center justify-center"
+        className={
+          label
+            ? 'flex items-center gap-2 bg-white/5 border border-white/10 rounded-full pl-3 pr-1 py-1 hover:bg-white/10 hover:border-white/15 transition-all cursor-pointer'
+            : 'relative w-10 h-10 rounded-full bg-purple-600/30 border border-purple-500/40 hover:bg-purple-600/50 hover:border-purple-400/60 transition-all overflow-hidden cursor-pointer flex items-center justify-center'
+        }
         title="Account menu"
       >
-        {avatarSrc ? (
-          <img src={avatarSrc} alt="" className="w-full h-full object-cover" referrerPolicy="no-referrer" />
-        ) : (
-          <span className="text-purple-200 text-sm font-bold">{initial}</span>
-        )}
+        {label && <span className="text-white/80 text-xs font-medium">{label}</span>}
+        <div className={`rounded-full bg-purple-600/30 border border-purple-500/40 overflow-hidden flex items-center justify-center flex-shrink-0 ${label ? 'w-8 h-8' : 'w-10 h-10'}`}>
+          {avatarSrc ? (
+            <img src={avatarSrc} alt="" className="w-full h-full object-cover" referrerPolicy="no-referrer" />
+          ) : (
+            <span className="text-purple-200 text-sm font-bold">{initial}</span>
+          )}
+        </div>
       </button>
 
       <AnimatePresence>
@@ -148,26 +100,17 @@ export default function UserMenu() {
               </div>
             </div>
 
-            {/* Nav links */}
-            <div className="py-1">
-              {NAV_LINKS.map((link) => {
-                const isActive = location.pathname === link.path;
-                return (
-                  <button
-                    key={link.path}
-                    onClick={() => handleNavigate(link.path)}
-                    className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors cursor-pointer ${
-                      isActive
-                        ? 'bg-purple-600/15 text-purple-300'
-                        : 'text-white/70 hover:bg-white/5 hover:text-white'
-                    }`}
-                  >
-                    {link.icon}
-                    <span>{link.label}</span>
-                  </button>
-                );
-              })}
-            </div>
+            {/* Account settings */}
+            <button
+              onClick={() => { setOpen(false); setShowAccountSettings(true); }}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-white/70 hover:bg-white/5 hover:text-white transition-colors cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Account settings
+            </button>
 
             <div className="border-t border-white/5" />
 
@@ -181,45 +124,223 @@ export default function UserMenu() {
               </svg>
               Sign out
             </button>
-
-            {/* Delete account */}
-            <div className="border-t border-white/5" />
-            {!confirmDelete ? (
-              <button
-                onClick={() => setConfirmDelete(true)}
-                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-white/40 hover:bg-red-500/10 hover:text-red-400 transition-colors cursor-pointer"
-              >
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-                Delete account
-              </button>
-            ) : (
-              <div className="px-4 py-3 bg-red-500/5">
-                <p className="text-red-300/90 text-xs mb-3">
-                  This will permanently delete your orb and all data. This cannot be undone.
-                </p>
-                <div className="flex gap-2">
-                  <button
-                    onClick={handleDeleteAccount}
-                    disabled={deleting}
-                    className="flex-1 bg-red-500/20 hover:bg-red-500/30 disabled:opacity-50 text-red-300 text-xs font-semibold py-1.5 rounded transition-colors cursor-pointer"
-                  >
-                    {deleting ? 'Deleting...' : 'Yes, delete'}
-                  </button>
-                  <button
-                    onClick={() => setConfirmDelete(false)}
-                    disabled={deleting}
-                    className="flex-1 bg-white/5 hover:bg-white/10 text-white/60 text-xs font-semibold py-1.5 rounded transition-colors cursor-pointer"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            )}
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Account Settings Modal */}
+      <AnimatePresence>
+        {showAccountSettings && (
+          <AccountSettingsModal
+            orbId={orbId}
+            onOrbIdChanged={onOrbIdChanged}
+            onClose={() => setShowAccountSettings(false)}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Account Settings Modal ──
+
+function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
+  orbId?: string;
+  onOrbIdChanged?: () => void;
+  onClose: () => void;
+}) {
+  const [activeTab, setActiveTab] = useState<'orb-id' | 'account'>('orb-id');
+  const { user, logout } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
+  const navigate = useNavigate();
+
+  // Orbis ID state
+  const [customId, setCustomId] = useState(orbId || '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  // Delete account state
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleSaveOrbId = async () => {
+    const trimmed = customId.trim().toLowerCase();
+    if (!trimmed) return;
+    if (trimmed === orbId) { onClose(); return; }
+    if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(trimmed)) { setError('Only lowercase letters, numbers, and hyphens allowed.'); return; }
+    if (trimmed.length < 3) { setError('Must be at least 3 characters.'); return; }
+    setSaving(true); setError('');
+    try {
+      await claimOrbId(trimmed);
+      setSuccess(true);
+      onOrbIdChanged?.();
+      setTimeout(() => onClose(), 1200);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to claim this ID. It may already be taken.');
+    } finally { setSaving(false); }
+  };
+
+  const handleDeleteAccount = async () => {
+    setDeleting(true);
+    try {
+      await deleteAccount();
+      if (user?.user_id) clearDraftNotes(user.user_id);
+      logout();
+      addToast('Your account has been deleted', 'info');
+      navigate('/', { replace: true });
+    } catch {
+      setError('Failed to delete account. Please try again.');
+      setDeleting(false);
+    }
+  };
+
+  const TABS = [
+    { id: 'orb-id' as const, label: 'Orbis ID', icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.172 13.828a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.102 1.101" />
+      </svg>
+    )},
+    { id: 'account' as const, label: 'Account', icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+      </svg>
+    )},
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.92, y: 24 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.92, y: 24 }}
+        transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl h-[420px] max-h-[90vh] overflow-hidden flex flex-col"
+      >
+        <div className="p-4 sm:p-6 pb-0">
+          <h2 className="text-white text-lg font-semibold mb-1">Account Settings</h2>
+          <p className="text-gray-400 text-sm mb-4">Manage your orbis identity and account.</p>
+        </div>
+
+        <div className="flex flex-1 min-h-0">
+          {/* Tabs sidebar */}
+          <div className="w-36 sm:w-44 border-r border-gray-700 p-2 flex flex-col gap-0.5">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => { setActiveTab(tab.id); setError(''); setSuccess(false); setShowDeleteConfirm(false); }}
+                className={`flex items-center gap-2.5 text-left px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer ${
+                  activeTab === tab.id
+                    ? 'bg-gray-800 text-white font-medium'
+                    : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+                }`}
+              >
+                {tab.icon}
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Tab content */}
+          <div className="flex-1 p-4 sm:p-6 overflow-hidden flex flex-col min-h-0">
+            <AnimatePresence mode="wait">
+              {/* ── Orbis ID tab ── */}
+              {activeTab === 'orb-id' && (
+                <motion.div
+                  key="orb-id"
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -8 }}
+                  transition={{ duration: 0.15, ease: 'easeInOut' }}
+                  className="flex flex-col justify-between h-full"
+                >
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orbis ID</label>
+                    <p className="text-[11px] text-gray-500 mt-1 mb-5">Choose a memorable ID for your orbis. This will be your public URL and MCP identifier.</p>
+                    <div className="flex items-center gap-2">
+                      <span className="text-gray-500 text-sm">{window.location.origin}/</span>
+                      <input
+                        value={customId}
+                        onChange={(e) => { setCustomId(e.target.value); setError(''); setSuccess(false); }}
+                        placeholder="your-name"
+                        className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                      />
+                    </div>
+                    {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                    {success && <p className="text-green-400 text-xs mt-2">Orbis ID updated!</p>}
+                  </div>
+
+                  <div className="flex gap-3">
+                    <button onClick={handleSaveOrbId} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm cursor-pointer">{saving ? 'Saving...' : 'Save'}</button>
+                    <button onClick={onClose} className="flex-1 border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm cursor-pointer">Cancel</button>
+                  </div>
+                </motion.div>
+              )}
+
+              {/* ── Account tab ── */}
+              {activeTab === 'account' && (
+                <motion.div
+                  key="account"
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -8 }}
+                  transition={{ duration: 0.15, ease: 'easeInOut' }}
+                >
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Account</label>
+                  <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Manage your account and data.</p>
+
+                  <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
+                    <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
+                    <p className="text-gray-400 text-xs leading-relaxed mb-4">
+                      Permanently delete your account, your orbis, and all associated data. This action is immediate and cannot be undone.
+                    </p>
+
+                    {!showDeleteConfirm ? (
+                      <button
+                        onClick={() => setShowDeleteConfirm(true)}
+                        className="bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-500/30 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                      >
+                        Delete my account
+                      </button>
+                    ) : (
+                      <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mt-2">
+                        <p className="text-red-300 text-xs font-medium mb-3">
+                          Are you sure? Your orbis and all data will be permanently deleted immediately.
+                        </p>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => setShowDeleteConfirm(false)}
+                            className="border border-gray-600 text-gray-300 hover:bg-gray-800 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            onClick={handleDeleteAccount}
+                            disabled={deleting}
+                            className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                          >
+                            {deleting ? 'Deleting...' : 'Yes, delete my account'}
+                          </button>
+                        </div>
+                        {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                      </div>
+                    )}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </motion.div>
     </div>
   );
 }

--- a/frontend/src/components/cv/KeywordFilterDropdown.tsx
+++ b/frontend/src/components/cv/KeywordFilterDropdown.tsx
@@ -1,0 +1,153 @@
+import { useState, useRef, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useFilterStore } from '../../stores/filterStore';
+
+export default function KeywordFilterDropdown() {
+  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
+  const [open, setOpen] = useState(false);
+  const [newKeyword, setNewKeyword] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  // Close on ESC
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  const handleAdd = () => {
+    const trimmed = newKeyword.trim();
+    if (!trimmed) return;
+    addKeyword(trimmed);
+    setNewKeyword('');
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg transition-all cursor-pointer ${
+          activeKeywords.length > 0
+            ? 'text-amber-400 bg-amber-500/10'
+            : 'text-white/40 hover:text-white hover:bg-white/5'
+        }`}
+        title="Keyword filters"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+        </svg>
+        <span className="hidden sm:inline">Filters</span>
+        {activeKeywords.length > 0 && (
+          <span className="bg-amber-500 text-white text-[10px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
+            {activeKeywords.length}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.97 }}
+            transition={{ duration: 0.15 }}
+            className="absolute right-0 mt-2 w-72 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50"
+          >
+            <div className="px-4 py-3 border-b border-white/5">
+              <h3 className="text-white text-sm font-semibold">Keyword Filters</h3>
+              <p className="text-white/40 text-[11px] mt-0.5">
+                Nodes matching active filters become transparent and are excluded from shares and exports.
+              </p>
+            </div>
+
+            <div className="px-4 py-3">
+              <div className="flex items-center gap-2 mb-3">
+                <input
+                  value={newKeyword}
+                  onChange={(e) => setNewKeyword(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+                  placeholder="e.g. confidential, private..."
+                  className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-white text-xs focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                />
+                <button
+                  onClick={handleAdd}
+                  className="bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium py-1.5 px-3 rounded-lg transition-colors whitespace-nowrap cursor-pointer"
+                >
+                  Add
+                </button>
+              </div>
+
+              {keywords.length === 0 ? (
+                <p className="text-white/20 text-xs italic">No filter keywords configured.</p>
+              ) : (
+                <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                  {keywords.map((kw) => {
+                    const isActive = activeKeywords.includes(kw);
+                    return (
+                      <div
+                        key={kw}
+                        className={`flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border transition-all ${
+                          isActive
+                            ? 'bg-amber-600/15 border-amber-500/40'
+                            : 'bg-white/5 border-white/5 hover:border-white/10'
+                        }`}
+                      >
+                        <span className="text-white text-xs font-mono truncate">{kw}</span>
+                        <div className="flex items-center gap-1.5 flex-shrink-0">
+                          <button
+                            onClick={() => toggleKeyword(kw)}
+                            className={`text-[10px] font-medium px-2 py-0.5 rounded transition-colors cursor-pointer ${
+                              isActive
+                                ? 'bg-amber-500 text-white'
+                                : 'bg-white/10 text-white/40 hover:text-white hover:bg-white/20'
+                            }`}
+                          >
+                            {isActive ? 'Active' : 'Activate'}
+                          </button>
+                          <button
+                            onClick={() => removeKeyword(kw)}
+                            className="text-white/20 hover:text-red-400 transition-colors cursor-pointer"
+                            title="Remove"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {activeKeywords.length > 0 && (
+                <p className="text-amber-400/70 text-[11px] mt-2">
+                  {activeKeywords.length === 1 ? 'Filter' : 'Filters'}{' '}
+                  {activeKeywords.map((kw, i) => (
+                    <span key={kw}>
+                      {i > 0 && ', '}"<span className="font-semibold">{kw}</span>"
+                    </span>
+                  ))}{' '}
+                  active.
+                </p>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '../stores/authStore';
 import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
 import DateRangeSlider from '../components/graph/DateRangeSlider';
 import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
-import { claimOrbId, updateProfile, uploadProfileImage, deleteProfileImage, createFilterToken, enhanceNote, linkSkill } from '../api/orbs';
+import { updateProfile, uploadProfileImage, deleteProfileImage, createFilterToken, enhanceNote, linkSkill } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
@@ -18,6 +18,7 @@ import type { DraftNote } from '../components/drafts/DraftNotes';
 import { loadDraftNotes, saveDraftNotes } from '../components/drafts/DraftNotes';
 import Inbox from '../components/inbox/Inbox';
 import ProcessingCounter from '../components/cv/ProcessingCounter';
+import KeywordFilterDropdown from '../components/cv/KeywordFilterDropdown';
 import UserMenu from '../components/UserMenu';
 import { useToastStore } from '../stores/toastStore';
 
@@ -131,281 +132,6 @@ function SharePanel({ orbId, onClose }: { orbId: string; onClose: () => void }) 
         </div>
 
         <button onClick={onClose} className="w-full border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Close</button>
-      </motion.div>
-    </div>
-  );
-}
-
-function SettingsPanel({ orbId, onClose, onOrbIdChanged }: { orbId: string; onClose: () => void; onOrbIdChanged: () => void }) {
-  const [activeTab, setActiveTab] = useState<'orb-id' | 'filters' | 'account'>('orb-id');
-  const [customId, setCustomId] = useState(orbId);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState(false);
-  const [newKeyword, setNewKeyword] = useState('');
-  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
-  const { user, logout } = useAuthStore();
-  const addToast = useToastStore((s) => s.addToast);
-  const navigate = useNavigate();
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-
-  const handleSave = async () => {
-    const trimmed = customId.trim().toLowerCase();
-    if (!trimmed) return;
-    if (trimmed === orbId) { onClose(); return; }
-    if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(trimmed)) { setError('Only lowercase letters, numbers, and hyphens allowed.'); return; }
-    if (trimmed.length < 3) { setError('Must be at least 3 characters.'); return; }
-    setSaving(true); setError('');
-    try {
-      await claimOrbId(trimmed);
-      setSuccess(true); onOrbIdChanged();
-      setTimeout(() => onClose(), 1200);
-    } catch (err: any) {
-      setError(err?.response?.data?.detail || 'Failed to claim this ID. It may already be taken.');
-    } finally { setSaving(false); }
-  };
-
-  const handleAddKeyword = () => {
-    const trimmed = newKeyword.trim();
-    if (!trimmed) return;
-    addKeyword(trimmed);
-    setNewKeyword('');
-  };
-
-  const handleDeleteAccount = async () => {
-    setDeleting(true);
-    try {
-      const { deleteAccount } = await import('../api/auth');
-      const { clearDraftNotes } = await import('../components/drafts/DraftNotes');
-      await deleteAccount();
-      if (user?.user_id) clearDraftNotes(user.user_id);
-      logout();
-      addToast('Your account has been deleted', 'info');
-      navigate('/', { replace: true });
-    } catch {
-      setError('Failed to delete account. Please try again.');
-      setDeleting(false);
-    }
-  };
-
-  const TABS = [
-    { id: 'orb-id' as const, label: 'Orbis ID' },
-    { id: 'filters' as const, label: 'Filters' },
-    { id: 'account' as const, label: 'Account' },
-  ];
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.2 }}
-        className="absolute inset-0 bg-black/50"
-        onClick={onClose}
-      />
-      <motion.div
-        initial={{ opacity: 0, scale: 0.92, y: 24 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.92, y: 24 }}
-        transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl h-[520px] max-h-[90vh] overflow-hidden flex flex-col"
-      >
-        <div className="p-4 sm:p-6 pb-0">
-          <h2 className="text-white text-lg font-semibold mb-1">Settings</h2>
-          <p className="text-gray-400 text-sm mb-4">Customize your orbis identity and visibility.</p>
-        </div>
-
-        <div className="flex flex-1 min-h-0">
-          {/* Tabs sidebar */}
-          <div className="w-32 sm:w-40 border-r border-gray-700 p-2 flex flex-col gap-0.5">
-            {TABS.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => { setActiveTab(tab.id); setError(''); setSuccess(false); }}
-                className={`text-left px-3 py-2 rounded-lg text-sm transition-colors ${
-                  activeTab === tab.id
-                    ? 'bg-gray-800 text-white font-medium'
-                    : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Tab content */}
-          <div className="flex-1 p-4 sm:p-6 overflow-hidden flex flex-col min-h-0">
-            <AnimatePresence mode="wait">
-            {/* ── Orb ID tab ── */}
-            {activeTab === 'orb-id' && (
-              <motion.div
-                key="orb-id"
-                initial={{ opacity: 0, x: 8 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -8 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
-                className="flex flex-col justify-between h-full"
-              >
-                <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Custom Orbis ID</label>
-                  <p className="text-[11px] text-gray-500 mt-1 mb-5">Choose a memorable ID for your orbis. This will be your public URL and MCP identifier.</p>
-                  <div className="flex items-center gap-2">
-                    <span className="text-gray-500 text-sm">{window.location.origin}/</span>
-                    <input value={customId} onChange={(e) => { setCustomId(e.target.value); setError(''); setSuccess(false); }} placeholder="your-name" className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent" />
-                  </div>
-                  {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
-                  {success && <p className="text-green-400 text-xs mt-2">Orbis ID updated!</p>}
-                </div>
-
-                <div className="flex gap-3">
-                  <button onClick={handleSave} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm">{saving ? 'Saving...' : 'Save'}</button>
-                  <button onClick={onClose} className="flex-1 border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Cancel</button>
-                </div>
-              </motion.div>
-            )}
-
-            {/* ── Filters tab ── */}
-            {activeTab === 'filters' && (
-              <motion.div
-                key="filters"
-                initial={{ opacity: 0, x: 8 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -8 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
-                className="flex flex-col h-full"
-              >
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility Filters</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">
-                  Add keywords to filter nodes. When a filter is active, nodes containing that keyword become transparent. Filtered nodes are excluded from shared links and CV exports.
-                </p>
-
-                <div className="flex items-center gap-2 mb-3 flex-shrink-0">
-                  <input
-                    value={newKeyword}
-                    onChange={(e) => setNewKeyword(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && handleAddKeyword()}
-                    placeholder="e.g. confidential, private, salary..."
-                    className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
-                  />
-                  <button
-                    onClick={handleAddKeyword}
-                    className="bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
-                  >
-                    Add
-                  </button>
-                </div>
-
-                <div className="flex-1 min-h-0 overflow-y-auto">
-                  {keywords.length === 0 ? (
-                    <p className="text-gray-600 text-xs italic">No filter keywords configured yet.</p>
-                  ) : (
-                    <div className="space-y-1.5">
-                      {keywords.map((kw) => {
-                        const isActive = activeKeywords.includes(kw);
-                        return (
-                          <div
-                            key={kw}
-                            className={`flex items-center justify-between gap-2 px-3 py-2 rounded-lg border transition-all ${
-                              isActive
-                                ? 'bg-amber-600/15 border-amber-500/40'
-                                : 'bg-gray-800/50 border-gray-700/50 hover:border-gray-600'
-                            }`}
-                          >
-                            <span className="text-white text-sm font-mono truncate">{kw}</span>
-                            <div className="flex items-center gap-1.5 flex-shrink-0">
-                              <button
-                                onClick={() => toggleKeyword(kw)}
-                                className={`text-[10px] font-medium px-2 py-1 rounded transition-colors ${
-                                  isActive
-                                    ? 'bg-amber-500 text-white'
-                                    : 'bg-gray-700 text-gray-400 hover:text-white hover:bg-gray-600'
-                                }`}
-                              >
-                                {isActive ? 'Active' : 'Activate'}
-                              </button>
-                              <button
-                                onClick={() => removeKeyword(kw)}
-                                className="text-gray-500 hover:text-red-400 transition-colors"
-                                title="Remove"
-                              >
-                                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {activeKeywords.length > 0 && (
-                  <p className="text-amber-400/70 text-[11px] mt-2 flex-shrink-0">
-                    {activeKeywords.length === 1 ? 'Filter' : 'Filters'} {activeKeywords.map((kw, i) => (
-                      <span key={kw}>{i > 0 && ', '}"<span className="font-semibold">{kw}</span>"</span>
-                    ))} active. Matching nodes are transparent.
-                  </p>
-                )}
-              </motion.div>
-            )}
-
-            {/* ── Account tab ── */}
-            {activeTab === 'account' && (
-              <motion.div
-                key="account"
-                initial={{ opacity: 0, x: 8 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -8 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
-              >
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Account</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Manage your account and data.</p>
-
-                <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
-                  <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
-                  <p className="text-gray-400 text-xs leading-relaxed mb-4">
-                    Permanently delete your account, your orbis, and all associated data. This action is immediate and cannot be undone.
-                  </p>
-
-                  {!showDeleteConfirm ? (
-                    <button
-                      onClick={() => setShowDeleteConfirm(true)}
-                      className="bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-500/30 text-xs font-medium py-2 px-4 rounded-lg transition-colors"
-                    >
-                      Delete my account
-                    </button>
-                  ) : (
-                    <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mt-2">
-                      <p className="text-red-300 text-xs font-medium mb-3">
-                        Are you sure? Your orbis and all data will be permanently deleted immediately.
-                      </p>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={() => setShowDeleteConfirm(false)}
-                          className="border border-gray-600 text-gray-300 hover:bg-gray-800 text-xs font-medium py-2 px-4 rounded-lg transition-colors"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          onClick={handleDeleteAccount}
-                          disabled={deleting}
-                          className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors"
-                        >
-                          {deleting ? 'Deleting...' : 'Yes, delete my account'}
-                        </button>
-                      </div>
-                      {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
-                    </div>
-                  )}
-                </div>
-              </motion.div>
-            )}
-            </AnimatePresence>
-          </div>
-        </div>
       </motion.div>
     </div>
   );
@@ -696,15 +422,6 @@ function ProfilePanel({ person, onClose, onSaved }: {
 
 // ── Icon components ──
 
-function IconSettings() {
-  return (
-    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    </svg>
-  );
-}
-
 function IconNotes() {
   return (
     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -752,7 +469,6 @@ export default function OrbViewPage() {
   const { user } = useAuthStore();
   const [showInput, setShowInput] = useState(false);
   const [showShare, setShowShare] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showDrafts, setShowDrafts] = useState(false);
   const [showInbox, setShowInbox] = useState(false);
@@ -774,14 +490,13 @@ export default function OrbViewPage() {
       if (e.key !== 'Escape') return;
       if (showInput) { setShowInput(false); setEditNode(null); return; }
       if (showProfile) { setShowProfile(false); return; }
-      if (showSettings) { setShowSettings(false); return; }
       if (showShare) { setShowShare(false); return; }
       if (showDrafts) { setShowDrafts(false); return; }
       if (showInbox) { setShowInbox(false); return; }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [showInput, showProfile, showSettings, showShare, showDrafts, showInbox]);
+  }, [showInput, showProfile, showShare, showDrafts, showInbox]);
 
   // Load drafts when userId becomes available (async auth)
   useEffect(() => {
@@ -972,55 +687,40 @@ export default function OrbViewPage() {
       {/* ── Header ── */}
       <div className="absolute top-0 left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3">
         <div className="flex items-center justify-between">
-          {/* Left: identity — click avatar to open settings */}
+          {/* Left: identity + view/filter/export */}
           <div className="flex items-center gap-2 sm:gap-3">
-            <button
-              onClick={() => setShowSettings(true)}
-              className="relative w-12 h-12 rounded-full bg-purple-600/30 border border-purple-500/40 flex items-center justify-center hover:bg-purple-600/50 hover:border-purple-400/60 transition-all group overflow-hidden"
-              title="Settings"
-            >
-              {(data.person.profile_image as string) ? (
-                <>
-                  <img src={data.person.profile_image as string} alt="" className="w-full h-full object-cover rounded-full group-hover:opacity-30 transition-opacity" />
-                  <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                    <IconSettings />
-                  </span>
-                </>
-              ) : (
-                <>
-                  <span className="text-purple-300 text-xs font-bold group-hover:opacity-0 transition-opacity">
-                    {((data.person.name as string) || user?.name || 'O').charAt(0).toUpperCase()}
-                  </span>
-                  <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                    <IconSettings />
-                  </span>
-                </>
-              )}
-            </button>
+            <div className="flex items-center gap-2">
+              <div className="w-7 h-7 rounded-full bg-purple-600/30 border border-purple-500/40 flex items-center justify-center">
+                <div className="w-3 h-3 rounded-full bg-purple-400" />
+              </div>
+              <span className="text-white font-bold text-sm tracking-tight hidden sm:inline">OpenOrbis</span>
+            </div>
+            <div className="hidden sm:block w-px h-5 bg-white/10" />
             <div>
-              <span className="text-white text-xs sm:text-sm font-semibold">{(data.person.name as string) || user?.name || 'My Orbis'}</span>
-              <span className="text-white/20 text-xs ml-2 hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
-              {activeKeywords.length > 0 && (
-                <span className="text-amber-400/70 text-[10px] ml-2 hidden sm:inline-flex items-center gap-1">
-                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-                  </svg>
-                  {activeKeywords.join(', ')}
-                </span>
-              )}
+              <span className="text-white/20 text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
+            </div>
+            <div className="hidden sm:block w-px h-5 bg-white/10" />
+            <div className="flex items-center gap-1">
+              <NodeTypeFilter
+                hiddenTypes={hiddenNodeTypes}
+                onToggleType={handleToggleNodeType}
+                onShowAll={handleShowAllNodeTypes}
+                onHideAll={handleHideAllNodeTypes}
+              />
+              <KeywordFilterDropdown />
+              <button
+                onClick={() => window.open('/cv-export', '_blank')}
+                className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
+              >
+                <IconDownload />
+                <span className="hidden sm:inline">Export CV</span>
+              </button>
             </div>
           </div>
 
-          {/* Right: secondary actions */}
+          {/* Right: inbox, notes, user menu */}
           <div className="flex items-center gap-1">
             <ProcessingCounter />
-            <NodeTypeFilter
-              hiddenTypes={hiddenNodeTypes}
-              onToggleType={handleToggleNodeType}
-              onShowAll={handleShowAllNodeTypes}
-              onHideAll={handleHideAllNodeTypes}
-            />
-            <div className="w-px h-5 bg-white/10 mx-1" />
             <HeaderBtn onClick={() => setShowInbox(true)} variant="outline">
               <IconInbox />
               <span className="hidden sm:inline">Inbox</span>
@@ -1039,14 +739,8 @@ export default function OrbViewPage() {
                 </span>
               )}
             </HeaderBtn>
-            <button
-              onClick={() => window.open('/cv-export', '_blank')}
-              className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
-            >
-              <IconDownload />
-              <span className="hidden sm:inline">Export CV</span>
-            </button>
-            <UserMenu />
+            <div className="w-px h-5 bg-white/10 mx-1" />
+            <UserMenu orbId={data.person.orb_id as string} onOrbIdChanged={fetchOrb} label={(data.person.name as string) || user?.name || 'My Orbis'} />
           </div>
         </div>
       </div>
@@ -1150,9 +844,6 @@ export default function OrbViewPage() {
       {/* ── Animated Panels ── */}
       <AnimatePresence>
         {showShare && <SharePanel key="share" orbId={orbId} onClose={() => setShowShare(false)} />}
-      </AnimatePresence>
-      <AnimatePresence>
-        {showSettings && <SettingsPanel key="settings" orbId={orbId} onClose={() => setShowSettings(false)} onOrbIdChanged={fetchOrb} />}
       </AnimatePresence>
       <AnimatePresence>
         {showProfile && <ProfilePanel key="profile" person={data.person} onClose={() => setShowProfile(false)} onSaved={fetchOrb} />}


### PR DESCRIPTION
## Summary

- Consolidate the two overlapping menus on `/myorbis` into a single unified layout
- Left side: logo, metadata, view/filter/export controls
- Right side: inbox, notes, user pill (name + avatar) with dropdown menu
- Account settings (Orbis ID + Delete account) accessible via modal from the dropdown

## Changes

- **Removed** left-side clickable avatar that opened Settings modal
- **Removed** SettingsPanel component entirely (Orbis ID + Delete moved to UserMenu's Account Settings modal)
- **Removed** NAV_LINKS from UserMenu (My Orbis, Add entries, Export CV were redundant)
- **Added** `KeywordFilterDropdown` — standalone toolbar dropdown extracted from SettingsPanel
- **Added** `AccountSettingsModal` inside UserMenu — two-tab modal (Orbis ID, Account)
- **Added** `label` prop to UserMenu for the name+avatar pill layout
- **Moved** NodeTypeFilter, KeywordFilterDropdown, Export CV to the left toolbar
- **Moved** user name to the right, next to avatar, as a unified clickable pill

## Test plan

- [ ] Verify single avatar/menu on `/myorbis` — no duplicate menus
- [ ] Click the pill (name + avatar) → dropdown opens with Account settings + Sign out
- [ ] Account settings → modal with Orbis ID tab (save/cancel) and Account tab (delete)
- [ ] Keyword filters dropdown works from toolbar (add, toggle, remove keywords)
- [ ] NodeTypeFilter, Export CV accessible from left side
- [ ] Inbox and Notes buttons work from right side
- [ ] UserMenu on other pages (CreateOrbPage via Navbar) still works as avatar-only
- [ ] ESC closes dropdown and modal
- [ ] Outside click closes dropdown

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)