### PR TITLE
feat: save draft note

### DIFF
--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -1,10 +1,43 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { NODE_TYPE_LABELS, NODE_TYPE_COLORS } from '../graph/NodeColors';
+
+// Per node type, the field that best summarizes the entry as a heading.
+const HEADING_FIELDS: Record<string, string[]> = {
+  work_experience: ['title', 'company'],
+  education: ['degree', 'institution', 'field_of_study'],
+  project: ['name', 'role'],
+  certification: ['name', 'issuing_organization'],
+  publication: ['title', 'venue'],
+  patent: ['title', 'patent_number'],
+  award: ['name', 'issuing_organization'],
+  outreach: ['title', 'venue'],
+  skill: ['name', 'category'],
+  language: ['name', 'proficiency'],
+};
+
+function pickHeading(nodeType: string, properties: Record<string, unknown>): string {
+  const fields = HEADING_FIELDS[nodeType] || [];
+  const parts: string[] = [];
+  for (const f of fields) {
+    const v = properties[f];
+    if (typeof v === 'string' && v.trim()) parts.push(v.trim());
+  }
+  return parts.join(' · ');
+}
+
+export interface EnhancedDraftState {
+  nodeType: string;
+  properties: Record<string, unknown>;
+  suggestedSkillUids: string[];
+  updatedAt: number;
+}
 
 export interface DraftNote {
   id: string;
   text: string;
   createdAt: number;
+  enhanced?: EnhancedDraftState;
 }
 
 // ── Shared localStorage helpers (user-scoped, with migration) ──
@@ -365,7 +398,41 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                 ) : (
                   /* ── Normal display ── */
                   <>
-                    <p className="text-white/80 text-sm leading-relaxed">{note.text}</p>
+                    {note.enhanced ? (
+                      (() => {
+                        const typeColor = NODE_TYPE_COLORS[note.enhanced.nodeType] || '#8b5cf6';
+                        const typeLabel = NODE_TYPE_LABELS[note.enhanced.nodeType] || note.enhanced.nodeType;
+                        const heading = pickHeading(note.enhanced.nodeType, note.enhanced.properties);
+                        return (
+                          <div>
+                            <div className="flex items-center gap-1.5 mb-1.5">
+                              <span
+                                className="text-[10px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded border"
+                                style={{
+                                  color: typeColor,
+                                  borderColor: `${typeColor}40`,
+                                  backgroundColor: `${typeColor}15`,
+                                }}
+                              >
+                                {typeLabel}
+                              </span>
+                              <span className="text-[10px] text-purple-300/70 flex items-center gap-0.5">
+                                <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                                </svg>
+                                Enhanced
+                              </span>
+                            </div>
+                            {heading && (
+                              <p className="text-white/90 text-sm font-medium leading-snug">{heading}</p>
+                            )}
+                            <p className="text-white/40 text-xs leading-relaxed mt-1 line-clamp-2">{note.text}</p>
+                          </div>
+                        );
+                      })()
+                    ) : (
+                      <p className="text-white/80 text-sm leading-relaxed">{note.text}</p>
+                    )}
                     <div className="flex items-center justify-between mt-2">
                       <div className="flex items-center gap-2">
                         <span className="text-white/20 text-[10px]">{formatTime(note.createdAt)}</span>
@@ -403,7 +470,7 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                                 <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
                                 </svg>
-                                Enhance
+                                {note.enhanced ? 'Refine' : 'Enhance'}
                               </>
                             )}
                           </button>

--- a/frontend/src/components/editor/FloatingInput.tsx
+++ b/frontend/src/components/editor/FloatingInput.tsx
@@ -10,9 +10,10 @@ interface FloatingInputProps {
   onCancel: () => void;
   onDelete?: (uid: string) => void;
   onEnhance?: (text: string) => Promise<{ node_type: string; properties: Record<string, string> } | null>;
+  onSaveDraft?: (nodeType: string, properties: Record<string, unknown>) => void;
 }
 
-export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDelete, onEnhance }: FloatingInputProps) {
+export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDelete, onEnhance, onSaveDraft }: FloatingInputProps) {
   const [currentType, setCurrentType] = useState(editNode?.type || 'skill');
   const color = NODE_TYPE_COLORS[currentType] || '#8b5cf6';
   const isEditing = !!editNode?.values?.uid;
@@ -73,6 +74,7 @@ export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDe
                   onTypeChange={handleTypeChange}
                   onDelete={onDelete && editNode?.values?.uid ? () => onDelete(editNode.values.uid as string) : undefined}
                   onEnhance={onEnhance}
+                  onSaveDraft={onSaveDraft}
                 />
               </div>
             </div>

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -17,6 +17,7 @@ interface NodeFormProps {
   onTypeChange?: (nodeType: string) => void;
   onDelete?: () => void;
   onEnhance?: (text: string) => Promise<EnhanceResult | null>;
+  onSaveDraft?: (nodeType: string, properties: Record<string, unknown>) => void;
 }
 
 // Layout config per type: which fields go where
@@ -129,7 +130,7 @@ function FieldInput({
   );
 }
 
-export default function NodeForm({ initialType, initialValues, onSubmit, onCancel, onTypeChange, onDelete, onEnhance }: NodeFormProps) {
+export default function NodeForm({ initialType, initialValues, onSubmit, onCancel, onTypeChange, onDelete, onEnhance, onSaveDraft }: NodeFormProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [nodeType, setNodeType] = useState(initialType || 'skill');
   const [enhancing, setEnhancing] = useState(false);
@@ -161,6 +162,18 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
       delete filtered.expiry_date;
     }
     onSubmit(nodeType, filtered);
+  };
+
+  const handleSaveDraftClick = () => {
+    if (!onSaveDraft) return;
+    const filtered = Object.fromEntries(
+      Object.entries(values).filter(([, v]) => v !== '')
+    );
+    if (isCurrent) {
+      delete filtered.end_date;
+      delete filtered.expiry_date;
+    }
+    onSaveDraft(nodeType, filtered);
   };
 
   const handleEnhanceClick = async () => {
@@ -226,6 +239,24 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
               Enhance
             </>
           )}
+        </button>
+      )}
+      {onSaveDraft && !initialValues?.uid && (
+        <button
+          type="button"
+          onClick={handleSaveDraftClick}
+          disabled={!hasAnyText}
+          className={`flex items-center gap-1.5 font-medium py-2.5 px-4 rounded-lg transition-all text-sm border ${
+            hasAnyText
+              ? 'border-purple-500/30 text-purple-300 hover:border-purple-500/50 hover:bg-purple-500/10'
+              : 'border-white/5 text-white/15 cursor-not-allowed'
+          }`}
+          title="Save as draft to keep refining later"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+          </svg>
+          Save Draft
         </button>
       )}
       <button

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -485,6 +485,7 @@ export default function OrbViewPage() {
   const [draftsLoaded, setDraftsLoaded] = useState(false);
   const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
   const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
+  const [pendingDraftRawText, setPendingDraftRawText] = useState<string>('');
   const [hiddenNodeTypes, setHiddenNodeTypes] = useState<Set<string>>(new Set());
 
   // ESC key closes any open panel/modal
@@ -578,12 +579,23 @@ export default function OrbViewPage() {
       setDraftNotes((prev) => prev.filter((n) => n.id !== pendingDraftNoteId));
       setPendingDraftNoteId(null);
     }
+    setPendingDraftRawText('');
     setPendingSkillLinks([]);
     setShowInput(false);
     setEditNode(null);
   };
 
   const handleDraftToGraph = (note: DraftNote) => {
+    setPendingDraftNoteId(note.id);
+    // If the draft has been enhanced, jump straight into the form with the
+    // enhanced state so the user only has to confirm before creating the node.
+    if (note.enhanced) {
+      setPendingSkillLinks(note.enhanced.suggestedSkillUids);
+      setEditNode({ type: note.enhanced.nodeType, values: note.enhanced.properties });
+      setShowInput(true);
+      setShowDrafts(false);
+      return;
+    }
     const text = note.text.toLowerCase();
     const detect: [RegExp, string][] = [
       [/\b(python|javascript|typescript|react|angular|vue|java|c\+\+|node\.?js|sql|docker|kubernetes|aws|git|html|css|figma|photoshop|agile|scrum|machine learning|data science|deep learning|tensorflow|pytorch)\b/i, 'skill'],
@@ -598,13 +610,24 @@ export default function OrbViewPage() {
     for (const [regex, nodeType] of detect) {
       if (regex.test(text)) { type = nodeType; break; }
     }
-    setPendingDraftNoteId(note.id);
     setEditNode({ type, values: { description: note.text } });
     setShowInput(true);
     setShowDrafts(false);
   };
 
   const handleDraftEnhance = async (note: DraftNote, targetLang: string) => {
+    // Already enhanced: re-open the form with the saved structured data so
+    // the user can keep refining without spending another LLM call.
+    if (note.enhanced) {
+      setPendingDraftNoteId(note.id);
+      setPendingDraftRawText(note.text);
+      setPendingSkillLinks(note.enhanced.suggestedSkillUids);
+      setEditNode({ type: note.enhanced.nodeType, values: note.enhanced.properties });
+      setShowInput(true);
+      setShowDrafts(false);
+      return;
+    }
+
     const existingSkills = (data?.nodes || [])
       .filter((n) => n._labels?.[0] === 'Skill' && n.name)
       .map((n) => ({ uid: n.uid, name: n.name as string }));
@@ -612,10 +635,44 @@ export default function OrbViewPage() {
     const result = await enhanceNote(note.text, targetLang, existingSkills);
 
     setPendingDraftNoteId(note.id);
+    setPendingDraftRawText(note.text);
     setPendingSkillLinks(result.suggested_skill_uids);
     setEditNode({ type: result.node_type, values: result.properties });
     setShowInput(true);
     setShowDrafts(false);
+  };
+
+  const handleSaveDraftEnhanced = (nodeType: string, properties: Record<string, unknown>) => {
+    if (!pendingDraftNoteId) return;
+    const draftId = pendingDraftNoteId;
+    const rawText = pendingDraftRawText;
+    const skillUids = pendingSkillLinks;
+    setDraftNotes((prev) => {
+      const existing = prev.find((n) => n.id === draftId);
+      if (existing) {
+        return prev.map((n) =>
+          n.id === draftId
+            ? { ...n, enhanced: { nodeType, properties, suggestedSkillUids: skillUids, updatedAt: Date.now() } }
+            : n,
+        );
+      }
+      // The draft was created on the fly from the input field — persist it now.
+      return [
+        {
+          id: draftId,
+          text: rawText,
+          createdAt: Date.now(),
+          enhanced: { nodeType, properties, suggestedSkillUids: skillUids, updatedAt: Date.now() },
+        },
+        ...prev,
+      ];
+    });
+    setPendingDraftNoteId(null);
+    setPendingDraftRawText('');
+    setPendingSkillLinks([]);
+    setShowInput(false);
+    setEditNode(null);
+    setShowDrafts(true);
   };
 
   const orbId = (data?.person?.orb_id as string) || '';
@@ -784,7 +841,7 @@ export default function OrbViewPage() {
         open={showInput}
         editNode={editNode}
         onSubmit={handleSubmit}
-        onCancel={() => { setShowInput(false); setEditNode(null); setPendingSkillLinks([]); setPendingDraftNoteId(null); }}
+        onCancel={() => { setShowInput(false); setEditNode(null); setPendingSkillLinks([]); setPendingDraftNoteId(null); setPendingDraftRawText(''); }}
         onDelete={async (uid) => {
           await deleteNode(uid);
           setShowInput(false);
@@ -799,6 +856,7 @@ export default function OrbViewPage() {
           setPendingSkillLinks(result.suggested_skill_uids);
           return { node_type: result.node_type, properties: result.properties };
         }}
+        onSaveDraft={pendingDraftNoteId ? handleSaveDraftEnhanced : undefined}
       />
 
       {/* ── Chat Box ── */}


### PR DESCRIPTION
## Summary

- Allow users to save the **enhanced** version of a draft note and keep refining it across sessions before turning it into a graph node
- Previously, clicking *Enhance* on a draft only opened the form modal — the user had to either commit the result as a node or lose all enhancement work on cancel
- Now the form exposes a new **Save Draft** action that persists the structured (LLM-enhanced) state back into the draft, so the user can iterate over multiple sessions and only convert to a node when ready

Closes #136 