### PR TITLE
chore: align About page and README with landing page messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p align="center">
-  <em>Your professional identity as a knowledge graph.<br>Shareable, queryable, and always up to date.</em>
+  <em>Beyond the CV.<br>Your career as a knowledge graph — queryable, shareable, portable.</em>
 </p>
 
 <p align="center">
@@ -20,7 +20,7 @@
 
 ## What is OpenOrbis?
 
-OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Instead of a static PDF, your professional identity — skills, experience, education, projects, publications, and more — becomes a queryable data structure that both humans and AI agents can explore.
+OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Instead of a static PDF, your professional identity — skills, experience, education, projects, publications, awards, outreach, and more — becomes a queryable data structure that both humans and AI agents can explore.
 
 🌐 **Share it** — every orbis gets a unique URL and QR code, ready to send to recruiters or embed in your portfolio
 
@@ -41,7 +41,6 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 - Export to PDF with page-break preview
 - Shareable URL with QR code
 - Draft notes with LLM enhancement
-- Inbox for recruiters & AI agents
 - Date range slider for temporal filtering
 - Privacy-aware sharing via filter tokens
 - Fuzzy + semantic vector search
@@ -57,7 +56,6 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 - `orbis_get_nodes_by_type`
 - `orbis_get_connections`
 - `orbis_get_skills_for_experience`
-- `orbis_send_message`
 - Structured JSON responses
 - Filter token access control
 
@@ -85,7 +83,7 @@ OpenOrbis turns your CV into a **living, interactive 3D knowledge graph**. Inste
 <tr><td><strong>Backend</strong></td><td>FastAPI · Python 3.10+ · Uvicorn</td></tr>
 <tr><td><strong>Database</strong></td><td>Neo4j 5 (graph database with vector indexes)</td></tr>
 <tr><td><strong>AI / LLM</strong></td><td>Anthropic Claude (via CLI) · Ollama (llama3.2:3b local fallback)</td></tr>
-<tr><td><strong>Auth</strong></td><td>JWT (HS256) · Google OAuth (scaffolded)</td></tr>
+<tr><td><strong>Auth</strong></td><td>JWT (HS256) · Google OAuth · LinkedIn OAuth</td></tr>
 <tr><td><strong>Encryption</strong></td><td>Fernet (cryptography)</td></tr>
 <tr><td><strong>Agent Protocol</strong></td><td>MCP (Model Context Protocol)</td></tr>
 <tr><td><strong>PDF</strong></td><td>PyMuPDF (extraction) · fpdf2 (generation)</td></tr>
@@ -102,18 +100,17 @@ orb_project/
 ├── frontend/                  # React + TypeScript app
 │   └── src/
 │       ├── pages/             # Landing, Create, View, Shared, Export, About, Privacy
-│       ├── components/        # Graph, Editor, Chat, Inbox, CV, Drafts, Onboarding
+│       ├── components/        # Graph, Editor, Chat, CV, Drafts, Onboarding, Landing
 │       ├── stores/            # Zustand (auth, orb, filter, dateFilter, toast)
 │       └── api/               # Axios clients
 ├── backend/                   # FastAPI app
 │   ├── app/
-│   │   ├── auth/              # JWT auth, dev-login, GDPR, account lifecycle
+│   │   ├── auth/              # JWT auth, Google/LinkedIn OAuth, GDPR, account lifecycle
 │   │   ├── cv/                # PDF parsing, LLM classification, rule-based fallback
 │   │   ├── graph/             # Neo4j client, Cypher queries, encryption, embeddings
 │   │   ├── orbs/              # Graph CRUD, profile, filter tokens
 │   │   ├── export/            # PDF / JSON / JSON-LD export
 │   │   ├── search/            # Semantic vector + fuzzy text search
-│   │   ├── messages/          # Inbox & messaging
 │   │   ├── notes/             # Draft notes with LLM enhancement
 │   │   └── main.py            # App entry, middleware, CORS
 │   ├── mcp_server/            # MCP tools for AI agents
@@ -122,7 +119,6 @@ orb_project/
 ├── infra/                     # Neo4j init scripts (constraints, indexes)
 ├── docker-compose.yml         # Neo4j + Ollama services
 ├── .env.example               # Environment variable template
-├── ontology.md                # Knowledge graph schema reference
 ├── CLAUDE.md                  # AI session project guide
 └── LICENSE                    # GNU AGPL v3
 ```
@@ -180,7 +176,7 @@ docker exec orbis-ollama ollama pull llama3.2:3b
 
 ### 6. Open the app
 
-Navigate to http://localhost:5173, click login (dev mode), and choose **"Upload CV"** or **"Manual Entry"** to build your orb.
+Navigate to http://localhost:5173 and sign in with Google or LinkedIn to start building your orbis.
 
 ---
 
@@ -197,11 +193,12 @@ Navigate to http://localhost:5173, click login (dev mode), and choose **"Upload 
 | `BACKEND_URL` | Backend URL | Yes |
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID | Prod |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | Prod |
+| `LINKEDIN_CLIENT_ID` | LinkedIn OAuth client ID | Prod |
+| `LINKEDIN_CLIENT_SECRET` | LinkedIn OAuth client secret | Prod |
 | `ANTHROPIC_API_KEY` | Claude API key | — |
 | `OLLAMA_BASE_URL` | Ollama endpoint (default: `http://localhost:11434`) | — |
 | `OLLAMA_MODEL` | Ollama model name (default: `llama3.2:3b`) | — |
-| `JWT_ALGORITHM` | JWT signing algorithm (default: `HS256`) | — |
-| `JWT_EXPIRE_MINUTES` | JWT token TTL in minutes (default: `1440`) | — |
+| `LLM_PROVIDER` | LLM provider: `claude` or `ollama` (default: `claude`) | — |
 
 > See [`.env.example`](.env.example) for the full template.
 
@@ -238,7 +235,6 @@ OpenOrbis includes an MCP server that exposes your knowledge graph to AI agents:
 | `orbis_get_nodes_by_type` | Filter nodes by type (education, skill, etc.) |
 | `orbis_get_connections` | All relationships of a specific node |
 | `orbis_get_skills_for_experience` | Skills linked to a work experience or project |
-| `orbis_send_message` | Send a message to the orb owner |
 
 ```bash
 cd backend
@@ -260,12 +256,13 @@ Person ──HAS_EDUCATION──────────► Education
        ──HAS_PUBLICATION───────► Publication
        ──HAS_PROJECT───────────► Project
        ──HAS_PATENT────────────► Patent
-       ──COLLABORATED_WITH─────► Collaborator
+       ──HAS_AWARD─────────────► Award
+       ──HAS_OUTREACH──────────► Outreach
 ```
 
 The key graph feature is **`USED_SKILL`** — a cross-link between experience nodes and Skill nodes, enabling queries like *"which skills were used at company X?"*
 
-> See [`ontology.md`](ontology.md) for the full schema and [`docs/database.md`](docs/database.md) for query patterns and indexes.
+> See [`docs/database.md`](docs/database.md) for query patterns and indexes.
 
 ---
 

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -4,23 +4,19 @@ import { useNavigate } from 'react-router-dom';
 const FEATURES = [
   {
     title: 'One graph, zero templates',
-    description: 'Stop wasting time choosing CV templates and rewriting your resume. Create your knowledge graph once — it works everywhere.',
+    description: 'Stop choosing templates and reformatting for every application. Build your knowledge graph once — export it as a PDF, embed it in your website, or just share the link. It adapts to every context.',
   },
   {
     title: 'Portable & machine-readable',
-    description: 'Your orbis has a unique link (e.g. orbis.io/alessandro-berti). Pass it to any LLM, agent, or tool and it gets perfectly structured data.',
+    description: 'Your orbis has a unique URL and QR code. Pass it to any LLM, embed it in your portfolio, or add it to your email signature. Humans see a 3D graph — AI agents get structured data via MCP.',
   },
   {
     title: 'Always up to date',
-    description: 'Update your orbis in one place. Generated CVs, websites, and profiles update downstream. Single source of truth.',
+    description: 'Update your orbis in one place. Every generated CV, shared link, and agent query reflects the latest version instantly. No more outdated PDFs floating around.',
   },
   {
     title: 'You control access',
-    description: 'Granular permissions let you decide what each agent or recruiter can see. Your data, encrypted by default.',
-  },
-  {
-    title: 'Connected network',
-    description: 'When collaborators join OpenOrbis, your orbis link together — forming a professional knowledge graph that recruiters can explore.',
+    description: 'Your data is encrypted end-to-end. Decide what each recruiter or AI agent can see with keyword-based filters. Your professional identity, your rules.',
   },
 ];
 
@@ -45,7 +41,7 @@ export default function AboutPage() {
           transition={{ duration: 0.6 }}
           className="text-5xl font-bold mb-4"
         >
-          What is an Orbis?
+          Beyond the CV.
         </motion.h1>
 
         <motion.p
@@ -54,9 +50,9 @@ export default function AboutPage() {
           transition={{ delay: 0.15, duration: 0.6 }}
           className="text-gray-400 text-lg mb-16"
         >
-          An orbis is a portable, structured knowledge graph of your professional identity.
-          It replaces your CV, your landing page, and your LinkedIn profile — with something
-          that both humans and machines can understand.
+          An orbis is your career as a knowledge graph — queryable, shareable, portable.
+          It replaces static CVs and disconnected profiles with a living, interactive
+          representation that both humans and AI agents can understand.
         </motion.p>
 
         <div className="space-y-10">
@@ -81,7 +77,7 @@ export default function AboutPage() {
         >
           <button
             onClick={() => navigate('/')}
-            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 px-8 rounded-lg transition-colors shadow-lg shadow-purple-600/25"
+            className="bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 px-8 rounded-lg transition-colors shadow-lg shadow-purple-600/25 cursor-pointer"
           >
             Create Your Orbis
           </button>


### PR DESCRIPTION
## Summary

Update About page and README to match the current "Beyond the CV" positioning and remove references to deleted features.

## Changes

### About page
- Title: "What is an Orbis?" → "Beyond the CV."
- Intro: updated to "queryable, shareable, portable" messaging
- Removed "Connected network" feature (Collaborator entity was removed in #146)
- Feature descriptions now match the landing page's 4 pillars

### README
- Tagline: → "Beyond the CV. Your career as a knowledge graph — queryable, shareable, portable."
- Removed: Inbox from user features, `orbis_send_message` from MCP tools, Collaborator from schema, `messages/` from project structure, `ontology.md` reference
- Added: Award + Outreach to schema, LinkedIn OAuth to auth/env vars, `LLM_PROVIDER` env var
- Updated: getting started instructions, auth description

## Test plan

- [ ] About page renders correctly with updated content
- [ ] README renders correctly on GitHub
- [ ] No broken links in README

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)