### PR TITLE
feat: granular CV progress feedback with step tracking

### DIFF
--- a/backend/app/cv/progress.py
+++ b/backend/app/cv/progress.py
@@ -1,0 +1,103 @@
+"""Per-user CV processing progress tracker."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CVStep(str, Enum):
+    READING_PDF = "reading_pdf"
+    EXTRACTING_TEXT = "extracting_text"
+    CLASSIFYING = "classifying"
+    PARSING_RESPONSE = "parsing_response"
+    DONE = "done"
+    FAILED = "failed"
+
+
+STEP_PERCENT: dict[CVStep, int] = {
+    CVStep.READING_PDF: 5,
+    CVStep.EXTRACTING_TEXT: 15,
+    CVStep.CLASSIFYING: 25,
+    CVStep.PARSING_RESPONSE: 90,
+    CVStep.DONE: 100,
+    CVStep.FAILED: 0,
+}
+
+STEP_MESSAGE: dict[CVStep, str] = {
+    CVStep.READING_PDF: "Reading your PDF...",
+    CVStep.EXTRACTING_TEXT: "Extracting text...",
+    CVStep.CLASSIFYING: "Classifying entries...",
+    CVStep.PARSING_RESPONSE: "Building your knowledge graph...",
+    CVStep.DONE: "Done!",
+    CVStep.FAILED: "Processing failed.",
+}
+
+
+@dataclass
+class CVProgress:
+    step: CVStep
+    percent: int
+    message: str
+    detail: str = ""
+    started_at: float = field(default_factory=time.time)
+
+
+_lock = threading.Lock()
+_progress: dict[str, CVProgress] = {}
+
+
+def set_progress(
+    user_id: str,
+    step: CVStep,
+    detail: str = "",
+) -> None:
+    with _lock:
+        existing = _progress.get(user_id)
+        started_at = existing.started_at if existing else time.time()
+        _progress[user_id] = CVProgress(
+            step=step,
+            percent=STEP_PERCENT[step],
+            message=STEP_MESSAGE[step],
+            detail=detail,
+            started_at=started_at,
+        )
+
+
+def get_progress(user_id: str) -> CVProgress | None:
+    with _lock:
+        p = _progress.get(user_id)
+        if p is None:
+            return None
+        # Simulate progress during classification (the long step)
+        if p.step == CVStep.CLASSIFYING:
+            elapsed = time.time() - p.started_at
+            # Gradually increase from 25% to 85% over ~5 minutes
+            fraction = min(elapsed / 300, 0.95)
+            simulated = 25 + int(60 * fraction)
+            # Rotate through processing descriptions
+            substeps = [
+                "Identifying work experiences...",
+                "Extracting education entries...",
+                "Recognizing skills and technologies...",
+                "Parsing publications and projects...",
+                "Detecting certifications and awards...",
+                "Mapping skill relationships...",
+                "Validating extracted entries...",
+            ]
+            detail = substeps[int(elapsed / 12) % len(substeps)]
+            return CVProgress(
+                step=p.step,
+                percent=simulated,
+                message=p.message,
+                detail=detail,
+                started_at=p.started_at,
+            )
+        return p
+
+
+def clear_progress(user_id: str) -> None:
+    with _lock:
+        _progress.pop(user_id, None)

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -7,10 +7,11 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from neo4j import AsyncDriver
 
 from app.config import settings
-from app.cv import counter
+from app.cv import counter, progress
 from app.cv.docling_extractor import extract_text as pdf_extract
 from app.cv.models import ConfirmRequest, ExtractedData
 from app.cv.ollama_classifier import classify_entries
+from app.cv.progress import CVStep
 from app.dependencies import get_current_user, get_db
 from app.graph.encryption import encrypt_properties
 from app.graph.queries import (
@@ -58,18 +59,33 @@ async def upload_cv(
     if len(pdf_bytes) > 10 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="File too large (max 10MB)")
 
+    user_id = current_user.get("user_id", "")
     counter.increment()
     try:
-        # Step 1: Extract text via Docling (local, free)
-        logger.info("Starting PDF extraction for user %s", current_user.get("user_id"))
+        # Step 1: Read PDF
+        progress.set_progress(user_id, CVStep.READING_PDF)
+        logger.info("Starting PDF extraction for user %s", user_id)
+
+        # Step 2: Extract text
+        progress.set_progress(
+            user_id,
+            CVStep.EXTRACTING_TEXT,
+            f"{len(pdf_bytes) // 1024}KB document",
+        )
         raw_text = await pdf_extract(pdf_bytes)
 
         if not raw_text.strip():
+            progress.set_progress(user_id, CVStep.FAILED, "No text found")
             raise HTTPException(
                 status_code=400, detail="Could not extract text from PDF"
             )
 
-        # Step 2: Classify entries via LLM
+        # Step 3: Classify entries via LLM
+        progress.set_progress(
+            user_id,
+            CVStep.CLASSIFYING,
+            f"Analyzing {len(raw_text):,} characters",
+        )
         logger.info(
             "Classifying entries with %s (%d chars)",
             settings.llm_provider,
@@ -77,11 +93,21 @@ async def upload_cv(
         )
         result = await classify_entries(raw_text)
 
+        # Step 4: Parse response
+        progress.set_progress(
+            user_id,
+            CVStep.PARSING_RESPONSE,
+            f"Found {len(result.nodes)} entries",
+        )
+
         if not result.nodes and not result.unmatched:
+            progress.set_progress(user_id, CVStep.FAILED, "No entries extracted")
             raise HTTPException(
                 status_code=400,
                 detail="No entries could be extracted. Try a different CV.",
             )
+
+        progress.set_progress(user_id, CVStep.DONE)
 
         return ExtractedData(
             nodes=result.nodes,
@@ -96,23 +122,61 @@ async def upload_cv(
         raise
     except TimeoutError as e:
         logger.error("PDF extraction timeout: %s", e)
+        progress.set_progress(user_id, CVStep.FAILED, "Timed out")
         raise HTTPException(
             status_code=504, detail="PDF processing timed out. Please try again."
         ) from None
     except Exception as e:
         logger.error("CV upload pipeline error: %s", e, exc_info=True)
+        progress.set_progress(user_id, CVStep.FAILED, str(e))
         raise HTTPException(
             status_code=500,
             detail=f"Failed to process CV: {str(e)}",
         ) from None
     finally:
         counter.decrement()
+        # Clean up progress after a delay so the frontend can show "Done"
+        import asyncio
+
+        async def _cleanup():
+            await asyncio.sleep(5)
+            progress.clear_progress(user_id)
+
+        asyncio.create_task(_cleanup())
 
 
 @router.get("/processing-count")
 async def get_processing_count():
     """Return the number of PDFs currently being processed."""
     return {"count": counter.get_count()}
+
+
+@router.get("/progress")
+async def get_cv_progress(
+    current_user: dict = Depends(get_current_user),
+):
+    """Return granular progress for the current user's CV processing."""
+    user_id = current_user["user_id"]
+    p = progress.get_progress(user_id)
+    if p is None:
+        return {
+            "active": False,
+            "step": None,
+            "percent": 0,
+            "message": None,
+            "detail": None,
+            "elapsed_seconds": 0,
+        }
+    import time
+
+    return {
+        "active": p.step not in ("done", "failed"),
+        "step": p.step,
+        "percent": p.percent,
+        "message": p.message,
+        "detail": p.detail,
+        "elapsed_seconds": round(time.time() - p.started_at),
+    }
 
 
 @router.post("/confirm")

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -46,3 +46,17 @@ export async function getProcessingCount(): Promise<number> {
   const { data } = await client.get('/cv/processing-count');
   return data.count;
 }
+
+export interface CVProgressData {
+  active: boolean;
+  step: string | null;
+  percent: number;
+  message: string | null;
+  detail: string | null;
+  elapsed_seconds: number;
+}
+
+export async function getCVProgress(): Promise<CVProgressData> {
+  const { data } = await client.get('/cv/progress');
+  return data;
+}

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from 'react';
-import { uploadCV } from '../../api/cv';
-import type { ExtractedData, ExtractedRelationship } from '../../api/cv';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { uploadCV, getCVProgress } from '../../api/cv';
+import type { ExtractedData, ExtractedRelationship, CVProgressData } from '../../api/cv';
 import { useAuthStore } from '../../stores/authStore';
 import { loadDraftNotes, saveDraftNotes } from '../drafts/DraftNotes';
 import ExtractedDataReview from './ExtractedDataReview';
@@ -10,6 +10,25 @@ export default function CVUploadOnboarding() {
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState('');
+  const [progressData, setProgressData] = useState<CVProgressData | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Poll progress while uploading
+  useEffect(() => {
+    if (!uploading) {
+      if (pollRef.current) clearInterval(pollRef.current);
+      return;
+    }
+    const poll = async () => {
+      try {
+        const data = await getCVProgress();
+        setProgressData(data);
+      } catch { /* ignore */ }
+    };
+    poll();
+    pollRef.current = setInterval(poll, 2000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [uploading]);
   const [extractedData, setExtractedData] = useState<{
     nodes: ExtractedData['nodes'];
     relationships: ExtractedRelationship[];
@@ -118,10 +137,7 @@ export default function CVUploadOnboarding() {
           }`}
         >
           {uploading ? (
-            <div className="flex flex-col items-center gap-3">
-              <div className="w-10 h-10 border-3 border-purple-500 border-t-transparent rounded-full animate-spin" />
-              <p className="text-white/50 text-sm">Parsing your CV...</p>
-            </div>
+            <ProgressSteps progress={progressData} />
           ) : (
             <>
               <svg className="w-10 h-10 mx-auto text-white/15 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -152,6 +168,91 @@ export default function CVUploadOnboarding() {
 
         {error && <p className="text-red-400 text-sm text-center mt-4">{error}</p>}
       </div>
+    </div>
+  );
+}
+
+// ── Progress steps display ──
+
+const STEPS = [
+  { key: 'reading_pdf', label: 'Reading PDF' },
+  { key: 'extracting_text', label: 'Extracting text' },
+  { key: 'classifying', label: 'Classifying entries' },
+  { key: 'parsing_response', label: 'Building graph' },
+];
+
+function ProgressSteps({ progress }: { progress: CVProgressData | null }) {
+  const currentStep = progress?.step || 'reading_pdf';
+  const percent = progress?.percent || 5;
+  const detail = progress?.detail || '';
+  const elapsed = progress?.elapsed_seconds || 0;
+
+  const currentIdx = STEPS.findIndex((s) => s.key === currentStep);
+
+  const formatTime = (secs: number) => {
+    if (secs < 60) return `${secs}s`;
+    return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-2">
+      {/* Steps */}
+      <div className="w-full max-w-xs space-y-2">
+        {STEPS.map((step, i) => {
+          const isDone = i < currentIdx || currentStep === 'done';
+          const isCurrent = i === currentIdx && currentStep !== 'done';
+          const isPending = i > currentIdx && currentStep !== 'done';
+
+          return (
+            <div key={step.key} className="flex items-center gap-3">
+              {/* Icon */}
+              <div className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
+                {isDone ? (
+                  <svg className="w-4 h-4 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : isCurrent ? (
+                  <div className="w-4 h-4 border-2 border-purple-400 border-t-transparent rounded-full animate-spin" />
+                ) : isPending ? (
+                  <div className="w-3 h-3 rounded-full bg-white/10" />
+                ) : null}
+              </div>
+              {/* Label */}
+              <span className={`text-sm ${
+                isDone ? 'text-white/40' :
+                isCurrent ? 'text-white font-medium' :
+                'text-white/20'
+              }`}>
+                {step.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full max-w-xs">
+        <div className="h-1.5 bg-white/5 rounded-full overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-1000 ease-out"
+            style={{
+              width: `${percent}%`,
+              background: percent >= 90
+                ? 'linear-gradient(to right, #a855f6, #22c55e)'
+                : 'linear-gradient(to right, #7c3aed, #a855f6)',
+            }}
+          />
+        </div>
+        <div className="flex justify-between mt-1.5">
+          <span className="text-white/20 text-[10px]">{percent}%</span>
+          <span className="text-white/20 text-[10px]">{formatTime(elapsed)}</span>
+        </div>
+      </div>
+
+      {/* Detail */}
+      {detail && (
+        <p className="text-white/30 text-xs text-center">{detail}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -102,17 +102,17 @@ function SignInButtons({ onGoogleLogin, signingInProvider, disabled }: { onGoogl
   const busy = signingInProvider !== null || disabled;
   return (
     <div className="flex flex-col items-center gap-4">
-      <p className="text-white/30 text-xs uppercase tracking-widest">Sign in with</p>
+      <p className="text-white text-xs uppercase tracking-widest">Sign in with</p>
       <div className="flex items-center gap-3">
         {/* Google */}
         <div className="group relative flex flex-col items-center">
           <button
             onClick={onGoogleLogin}
             disabled={busy}
-            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/[0.12] hover:bg-white/[0.12] disabled:opacity-40 transition-all duration-300 flex items-center justify-center cursor-pointer"
+            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/40 hover:bg-white/[0.12] disabled:opacity-40 transition-all duration-300 flex items-center justify-center cursor-pointer"
             style={{ boxShadow: 'none' }}
             onMouseEnter={(e) => { e.currentTarget.style.boxShadow = '0 0 20px rgba(66,133,244,0.3)'; e.currentTarget.style.borderColor = 'rgba(66,133,244,0.4)'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.4)'; }}
           >
             {signingInProvider === 'google' ? (
               <div className="w-4 h-4 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
@@ -135,10 +135,10 @@ function SignInButtons({ onGoogleLogin, signingInProvider, disabled }: { onGoogl
           <button
             onClick={() => { if (!busy) redirectToLinkedIn(); }}
             disabled={busy}
-            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/[0.12] hover:bg-white/[0.12] disabled:opacity-40 transition-all duration-300 flex items-center justify-center cursor-pointer"
+            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/40 hover:bg-white/[0.12] disabled:opacity-40 transition-all duration-300 flex items-center justify-center cursor-pointer"
             style={{ boxShadow: 'none' }}
             onMouseEnter={(e) => { e.currentTarget.style.boxShadow = '0 0 20px rgba(10,102,194,0.3)'; e.currentTarget.style.borderColor = 'rgba(10,102,194,0.4)'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.12)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.4)'; }}
           >
             {signingInProvider === 'linkedin' ? (
               <div className="w-4 h-4 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
@@ -157,7 +157,7 @@ function SignInButtons({ onGoogleLogin, signingInProvider, disabled }: { onGoogl
         <div className="group relative flex flex-col items-center">
           <button
             disabled={true}
-            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/[0.12] opacity-30 transition-all duration-300 flex items-center justify-center cursor-not-allowed"
+            className="w-14 h-14 rounded-full bg-white/[0.07] border border-white/40 opacity-30 transition-all duration-300 flex items-center justify-center cursor-not-allowed"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24" fill="white">
               <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
@@ -340,8 +340,8 @@ export default function LandingPage() {
             transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
             className="text-amber-400/60"
           >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+            <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
             </svg>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
## Summary

Replace the generic "Parsing your CV..." spinner with a **multi-step progress display** showing exactly what the system is doing during CV processing.

## What the user sees now

```
✅ Reading PDF
✅ Extracting text
🔄 Classifying entries          ← spinner on current step
   "Recognizing skills and technologies..."
○  Building graph               ← pending

████████████████░░░░░░░░░░  42%     1m 23s
```

## Backend changes

### New: `backend/app/cv/progress.py`
- Per-user progress tracker with `CVStep` enum (reading_pdf → extracting_text → classifying → parsing_response → done → failed)
- Simulated progress during classification: 25% → 85% over ~5 minutes
- Rotating detail messages every ~12s: "Identifying work experiences...", "Extracting education entries...", "Recognizing skills and technologies...", etc.
- Thread-safe with auto-cleanup after 5 seconds

### Updated: `backend/app/cv/router.py`
- `GET /cv/progress` endpoint — returns step, percent, message, detail, elapsed_seconds
- Progress set at each pipeline step (reading, extracting, classifying, parsing, done/failed)
- Error states update progress before raising

## Frontend changes

### Updated: `CVUploadOnboarding.tsx`
- Polls `GET /cv/progress` every 2 seconds during upload
- Multi-step display with checkmarks (done), spinner (current), dots (pending)
- Animated progress bar with purple→green gradient
- Percentage and elapsed time counter

### Updated: `cv.ts`
- New `getCVProgress()` API function and `CVProgressData` type

## Also included

- Landing page: white "Sign in with" text, white borders on login buttons, larger scroll arrow

## Test plan

- [ ] Upload a CV — progress steps appear instead of generic spinner
- [ ] Steps transition: Reading → Extracting → Classifying → Building → Done
- [ ] Progress bar moves smoothly during classification
- [ ] Detail messages rotate during classification
- [ ] Elapsed time counter works
- [ ] Failed upload shows error state
- [ ] Progress cleans up after completion

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)