### PR TITLE
feat: improve CV extraction prompt and extract person profile

### DIFF
--- a/backend/app/cv/models.py
+++ b/backend/app/cv/models.py
@@ -19,6 +19,20 @@ class ExtractedRelationship(BaseModel):
     type: str = "USED_SKILL"
 
 
+class ExtractedProfile(BaseModel):
+    """Person-level fields extracted from the CV."""
+
+    headline: str | None = None
+    location: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    linkedin_url: str | None = None
+    github_url: str | None = None
+    website_url: str | None = None
+    scholar_url: str | None = None
+    orcid_url: str | None = None
+
+
 class ExtractedData(BaseModel):
     nodes: list[ExtractedNode]
     unmatched: list[str] = []
@@ -26,9 +40,11 @@ class ExtractedData(BaseModel):
     relationships: list[ExtractedRelationship] = []
     truncated: bool = False
     cv_owner_name: str | None = None
+    profile: ExtractedProfile | None = None
 
 
 class ConfirmRequest(BaseModel):
     nodes: list[ExtractedNode]
     relationships: list[ExtractedRelationship] = []
     cv_owner_name: str | None = None
+    profile: ExtractedProfile | None = None

--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -17,7 +17,26 @@ from app.graph.queries import NODE_TYPE_LABELS
 logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """You are a CV/resume parsing assistant. Given raw text extracted from a CV document,
-identify and classify every entry into structured nodes.
+extract the person's profile information AND classify every entry into structured nodes.
+
+## Person Profile
+
+Extract the following about the CV owner (all optional, include only if found):
+- cv_owner_name: full name
+- headline: professional title or tagline (e.g. "Senior ML Engineer", "PhD Researcher in Quantum Computing")
+- location: city, country (e.g. "Pisa, Italy", "San Francisco, CA")
+- email: email address
+- phone: phone number
+- linkedin_url: LinkedIn profile URL
+- github_url: GitHub profile URL
+- website_url: personal website URL
+- scholar_url: Google Scholar URL
+- orcid_url: ORCID URL (https://orcid.org/...)
+
+For the headline: if no explicit tagline is given, infer it from the most recent job title
+and company (e.g. "Postdoc Researcher @ University of Pisa").
+
+## Node Types
 
 Each node must have a "node_type" and a "properties" object.
 
@@ -32,7 +51,8 @@ Valid node_types and their expected properties:
     start_date (string), end_date (string or null), description (string), location (string)
 
 - skill:
-    name (string), category (one of: "Programming", "Framework", "Tool", "Methodology", "Soft Skill", "Other"),
+    name (string), category (one of: "Programming", "Framework", "Tool", "Methodology",
+    "Research Area", "Domain Knowledge", "Soft Skill", "Other"),
     proficiency (one of: "Expert", "Advanced", "Intermediate", "Beginner" or null)
 
 - language:
@@ -45,6 +65,8 @@ Valid node_types and their expected properties:
 - publication:
     title (string), venue (string), date (string), doi (string or null),
     url (string or null), abstract (string or null)
+    NOTE: Publications often appear as numbered lists or multi-line entries with authors, title,
+    venue/journal, and year. Extract each publication as a separate node. Include ALL publications.
 
 - project:
     name (string), role (string), description (string),
@@ -66,20 +88,37 @@ Valid node_types and their expected properties:
     role (string, e.g. "Speaker", "Organizer", "Panelist"),
     url (string or null)
 
-Rules:
+## Rules
+
 - Use ISO date format when possible (YYYY-MM-DD, YYYY-MM, or YYYY)
 - If end_date is "Present", "Current", or ongoing, set it to null
-- Extract ALL entries you can find — do not skip any
-- For skills, extract individual skills (not groups)
-- If something does not clearly fit any node_type, put the raw text in the "unmatched" array
+- Extract ALL entries — do not skip any. Completeness is critical.
+- For skills, extract individual skills (not groups). Normalize names (e.g. "JS" → "JavaScript").
+- Do not create duplicate skill nodes — if the same skill appears multiple times, create it once.
+- Education: only extract actual degrees (BSc, MSc, PhD, etc.), not workshops or short courses.
+- If something does not clearly fit any node_type, put the raw text in the "unmatched" array.
 
-For each skill that is mentioned in the context of a work_experience, project, education,
-publication, award, or outreach entry, include a relationship entry linking the experience
-node (by its index in the nodes array) to the skill node (by its index). Use type "USED_SKILL".
+## Relationships
+
+For each skill mentioned in the context of a work_experience, project, education,
+publication, patent, award, or outreach entry, include a relationship entry linking
+the source node (by its index in the nodes array) to the skill node (by its index).
+Use type "USED_SKILL".
+
+## Output Format
 
 You MUST return valid JSON in exactly this format:
 {
-  "cv_owner_name": "Full Name of the person whose CV this is",
+  "cv_owner_name": "Full Name",
+  "headline": "Professional Title @ Company",
+  "location": "City, Country",
+  "email": "user@example.com",
+  "phone": "+1234567890",
+  "linkedin_url": "https://linkedin.com/in/...",
+  "github_url": "https://github.com/...",
+  "website_url": "https://...",
+  "scholar_url": "https://scholar.google.com/...",
+  "orcid_url": "https://orcid.org/...",
   "nodes": [
     {"node_type": "work_experience", "properties": {"company": "...", "title": "...", ...}},
     {"node_type": "skill", "properties": {"name": "Python", "category": "Programming"}},
@@ -95,6 +134,7 @@ You MUST return valid JSON in exactly this format:
   ]
 }
 
+Omit profile fields that are not found in the CV (do not include null values for missing fields).
 Return ONLY valid JSON. No markdown, no explanation, no code blocks."""
 
 
@@ -179,6 +219,7 @@ class ClassificationResult:
     relationships: list[ExtractedRelationship] = field(default_factory=list)
     truncated: bool = False
     cv_owner_name: str | None = None
+    profile: dict | None = None
 
 
 MAX_RETRIES = 2
@@ -362,6 +403,21 @@ def _parse_result(raw_response: str) -> ClassificationResult:  # noqa: C901
     unmatched = parsed.get("unmatched", [])
     raw_rels = parsed.get("relationships", [])
 
+    # Extract person profile fields
+    profile_keys = [
+        "headline",
+        "location",
+        "email",
+        "phone",
+        "linkedin_url",
+        "github_url",
+        "website_url",
+        "scholar_url",
+        "orcid_url",
+    ]
+    profile = {k: parsed[k] for k in profile_keys if parsed.get(k)}
+    profile = profile if profile else None
+
     # Validate nodes — track original-to-filtered index mapping for relationships
     nodes: list[ExtractedNode] = []
     skipped: list[SkippedNode] = []
@@ -444,4 +500,5 @@ def _parse_result(raw_response: str) -> ClassificationResult:  # noqa: C901
         skipped=skipped,
         relationships=relationships,
         cv_owner_name=cv_owner_name,
+        profile=profile,
     )

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -13,7 +13,7 @@ from app.cv.models import ConfirmRequest, ExtractedData
 from app.cv.ollama_classifier import classify_entries
 from app.cv.progress import CVStep
 from app.dependencies import get_current_user, get_db
-from app.graph.encryption import encrypt_properties
+from app.graph.encryption import encrypt_properties, encrypt_value
 from app.graph.queries import (
     ADD_NODE,
     DELETE_USER_GRAPH,
@@ -109,6 +109,12 @@ async def upload_cv(
 
         progress.set_progress(user_id, CVStep.DONE)
 
+        from app.cv.models import ExtractedProfile
+
+        extracted_profile = None
+        if result.profile:
+            extracted_profile = ExtractedProfile(**result.profile)
+
         return ExtractedData(
             nodes=result.nodes,
             unmatched=result.unmatched,
@@ -116,6 +122,7 @@ async def upload_cv(
             relationships=result.relationships,
             truncated=result.truncated,
             cv_owner_name=result.cv_owner_name,
+            profile=extracted_profile,
         )
 
     except HTTPException:
@@ -179,6 +186,20 @@ async def get_cv_progress(
     }
 
 
+def _build_person_updates(data: ConfirmRequest) -> dict:
+    """Build Person node property updates from CV extraction results."""
+    updates: dict[str, str] = {}
+    if data.cv_owner_name:
+        updates["cv_display_name"] = data.cv_owner_name
+    if data.profile:
+        profile_dict = data.profile.model_dump(exclude_none=True)
+        for pii_field in ("email", "phone"):
+            if pii_field in profile_dict:
+                profile_dict[pii_field] = encrypt_value(profile_dict[pii_field])
+        updates.update(profile_dict)
+    return updates
+
+
 @router.post("/confirm")
 async def confirm_cv(
     data: ConfirmRequest,
@@ -193,12 +214,13 @@ async def confirm_cv(
         # Wipe existing graph nodes (keep Person) so CV import replaces, not merges
         await session.run(DELETE_USER_GRAPH, user_id=current_user["user_id"])
 
-        # Store CV owner name separately (Person.name stays from OAuth provider)
-        if data.cv_owner_name:
+        # Store CV owner name and extracted profile on the Person node
+        person_updates = _build_person_updates(data)
+        if person_updates:
             await session.run(
                 UPDATE_PERSON,
                 user_id=current_user["user_id"],
-                properties={"cv_display_name": data.cv_owner_name},
+                properties=person_updates,
             )
         for node in data.nodes:
             if node.node_type not in NODE_TYPE_LABELS:


### PR DESCRIPTION
## Summary

Overhaul the CV extraction LLM prompt to improve entity classification quality and extract person-level profile information (headline, location, social accounts) that was previously left empty.

## Problem

The existing prompt had several gaps (documented in #147):
- **Person profile fields ignored** — headline, location, email, social URLs were never extracted from the CV text, leaving the profile empty
- **Publications often missed** — no guidance for common publication formats (numbered lists, multi-line)
- **Skills over/under-extracted** — no dedup instruction, limited categories (missing "Research Area", "Domain Knowledge")
- **Education over-extracted** — workshops and courses counted as degrees
- **USED_SKILL incomplete** — patents not covered

## Changes

### Prompt improvements (`ollama_classifier.py`)
- **Person profile extraction** — LLM now extracts: headline, location, email, phone, linkedin_url, github_url, website_url, scholar_url, orcid_url
- **Headline inference** — if no explicit tagline, infer from most recent job title + company
- **Publication guidance** — explicit note about numbered lists, multi-line entries, "extract ALL"
- **Skill categories expanded** — added "Research Area" and "Domain Knowledge"
- **Deduplication instruction** — "do not create duplicate skill nodes"
- **Education scoping** — "only extract actual degrees, not workshops or short courses"
- **USED_SKILL expanded** — now covers patents too
- **Completeness emphasis** — "Completeness is critical" added to rules

### New model (`models.py`)
- `ExtractedProfile` — pydantic model for person-level fields
- Added `profile` field to `ExtractedData` and `ConfirmRequest`

### Profile persistence (`router.py`)
- Parse profile fields from LLM JSON response
- On CV confirm, persist profile fields to Person node
- Encrypt email and phone with Fernet before storage
- Extracted `_build_person_updates()` helper to keep complexity under limit

## Test plan

- [ ] Upload a CV with contact info → headline, location, social URLs populated on Person node
- [ ] Upload a CV without contact info → profile fields remain unchanged
- [ ] Publications are extracted (especially numbered lists)
- [ ] Skills are not duplicated
- [ ] Education only includes degrees
- [ ] USED_SKILL links cover all node types including patents
- [ ] All 334 existing tests pass (83% coverage)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)