### PR TITLE
feat: 30-day soft-delete with account recovery and degraded UI

### DIFF
--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -8,6 +8,8 @@ class UserInfo(BaseModel):
     picture: str = ""
     profile_image: str = ""
     gdpr_consent: bool = False
+    deletion_requested_at: str | None = None
+    deletion_days_remaining: int | None = None
 
 
 class TokenResponse(BaseModel):

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -123,6 +123,8 @@ async def get_me(
             raise HTTPException(status_code=404, detail="User not found")
 
         person = dict(record["p"])
+        deletion_at = person.get("deletion_requested_at")
+        days_left = _days_remaining(str(deletion_at)) if deletion_at else None
         return UserInfo(
             user_id=person["user_id"],
             email=current_user["email"],
@@ -130,6 +132,8 @@ async def get_me(
             picture=person.get("picture", ""),
             profile_image=person.get("profile_image", ""),
             gdpr_consent=bool(person.get("gdpr_consent", False)),
+            deletion_requested_at=str(deletion_at) if deletion_at else None,
+            deletion_days_remaining=days_left,
         )
 
 
@@ -149,29 +153,58 @@ async def grant_gdpr_consent(
     return {"status": "ok"}
 
 
+GRACE_PERIOD_DAYS = 30
+
+
+def _days_remaining(deletion_requested_at: str) -> int:
+    """Calculate days remaining before permanent deletion."""
+    requested = datetime.fromisoformat(deletion_requested_at)
+    if requested.tzinfo is None:
+        requested = requested.replace(tzinfo=timezone.utc)
+    deadline = requested + __import__("datetime").timedelta(days=GRACE_PERIOD_DAYS)
+    remaining = (deadline - datetime.now(timezone.utc)).days
+    return max(0, remaining)
+
+
 @router.delete("/me")
 async def delete_me(
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
 ):
-    """Permanently delete the current user: Person node and the entire subgraph reachable from it.
-
-    Uses a variable-length path so nested nodes like Replies (Message → Reply)
-    are removed too, not just direct children of Person.
-    """
+    """Schedule account for deletion. Data is permanently removed after 30 days."""
+    now = datetime.now(timezone.utc).isoformat()
     async with db.session() as session:
-        # Remove every node reachable from the Person via any outgoing path (any depth).
         await session.run(
-            """
-            MATCH (p:Person {user_id: $user_id})-[*1..]->(n)
-            WITH DISTINCT n
-            DETACH DELETE n
-            """,
+            "MATCH (p:Person {user_id: $user_id}) SET p.deletion_requested_at = $now",
+            user_id=current_user["user_id"],
+            now=now,
+        )
+    return {
+        "status": "scheduled",
+        "message": f"Account scheduled for deletion. You have {GRACE_PERIOD_DAYS} days to recover it.",
+    }
+
+
+@router.post("/me/recover")
+async def recover_account(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Cancel a pending account deletion and restore the account."""
+    async with db.session() as session:
+        result = await session.run(
+            GET_PERSON_BY_USER_ID, user_id=current_user["user_id"]
+        )
+        record = await result.single()
+        if record is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        person = dict(record["p"])
+        if not person.get("deletion_requested_at"):
+            return {"status": "ok", "message": "Account is not scheduled for deletion."}
+
+        await session.run(
+            "MATCH (p:Person {user_id: $user_id}) REMOVE p.deletion_requested_at",
             user_id=current_user["user_id"],
         )
-        # Remove the Person node itself
-        await session.run(
-            "MATCH (p:Person {user_id: $user_id}) DETACH DELETE p",
-            user_id=current_user["user_id"],
-        )
-    return {"status": "deleted"}
+    return {"status": "recovered", "message": "Account restored successfully."}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,12 +21,48 @@ from app.search.router import router as search_router
 logging.basicConfig(level=logging.INFO)
 
 
+async def _cleanup_expired_accounts(driver):
+    """Permanently delete accounts past the 30-day grace period."""
+    async with driver.session() as session:
+        # Find expired accounts
+        result = await session.run(
+            """
+            MATCH (p:Person)
+            WHERE p.deletion_requested_at IS NOT NULL
+            AND datetime(p.deletion_requested_at) < datetime() - duration('P30D')
+            RETURN p.user_id AS user_id
+            """
+        )
+        expired = [record["user_id"] async for record in result]
+
+        for user_id in expired:
+            await session.run(
+                "MATCH (p:Person {user_id: $uid})-[*1..]->(n) "
+                "WITH DISTINCT n DETACH DELETE n",
+                uid=user_id,
+            )
+            await session.run(
+                "MATCH (p:Person {user_id: $uid}) DETACH DELETE p",
+                uid=user_id,
+            )
+            logging.getLogger(__name__).info(
+                "Permanently deleted expired account: %s", user_id
+            )
+
+    if expired:
+        logging.getLogger(__name__).info(
+            "Cleaned up %d expired account(s)", len(expired)
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup: verify Neo4j connection
     driver = await get_driver()
     async with driver.session() as session:
         await session.run("RETURN 1")
+    # Clean up expired accounts on startup
+    await _cleanup_expired_accounts(driver)
     yield
     # Shutdown
     await close_driver()

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -364,6 +364,11 @@ async def get_public_orb(
             )
             raise HTTPException(status_code=404, detail="Orb not found")
 
+    # Block access to accounts pending deletion
+    person = dict(record["p"])
+    if person.get("deletion_requested_at"):
+        raise HTTPException(status_code=404, detail="Orb not found")
+
     orb_data = _serialize_orb(record)
 
     # Apply filter if a valid filter token is provided

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -7,6 +7,8 @@ export interface UserInfo {
   picture?: string;
   profile_image?: string;
   gdpr_consent: boolean;
+  deletion_requested_at?: string | null;
+  deletion_days_remaining?: number | null;
 }
 
 export async function getMe(): Promise<UserInfo> {
@@ -30,4 +32,8 @@ export async function linkedinLogin(code: string): Promise<{ access_token: strin
 
 export async function grantGdprConsent(): Promise<void> {
   await client.post('/auth/gdpr-consent');
+}
+
+export async function recoverAccount(): Promise<void> {
+  await client.post('/auth/me/recover');
 }

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -5,7 +5,6 @@ import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
 import { claimOrbId } from '../api/orbs';
-import { clearDraftNotes } from './drafts/DraftNotes';
 
 interface UserMenuProps {
   orbId?: string;
@@ -181,17 +180,32 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
     } finally { setSaving(false); }
   };
 
+  const [recovering, setRecovering] = useState(false);
+
   const handleDeleteAccount = async () => {
     setDeleting(true);
     try {
       await deleteAccount();
-      if (user?.user_id) clearDraftNotes(user.user_id);
       logout();
-      addToast('Your account has been deleted', 'info');
+      addToast('Account scheduled for deletion. You have 30 days to recover it.', 'info');
       navigate('/', { replace: true });
     } catch {
       setError('Failed to delete account. Please try again.');
       setDeleting(false);
+    }
+  };
+
+  const handleRecoverAccount = async () => {
+    setRecovering(true);
+    try {
+      const { recoverAccount } = await import('../api/auth');
+      await recoverAccount();
+      addToast('Account restored successfully!', 'success');
+      onClose();
+      window.location.reload();
+    } catch {
+      setError('Failed to recover account. Please try again.');
+      setRecovering(false);
     }
   };
 
@@ -298,43 +312,68 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                   <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Account</label>
                   <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Manage your account and data.</p>
 
-                  <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
-                    <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
-                    <p className="text-gray-400 text-xs leading-relaxed mb-4">
-                      Permanently delete your account, your orbis, and all associated data. This action is immediate and cannot be undone.
-                    </p>
-
-                    {!showDeleteConfirm ? (
-                      <button
-                        onClick={() => setShowDeleteConfirm(true)}
-                        className="bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-500/30 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
-                      >
-                        Delete my account
-                      </button>
-                    ) : (
-                      <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mt-2">
-                        <p className="text-red-300 text-xs font-medium mb-3">
-                          Are you sure? Your orbis and all data will be permanently deleted immediately.
-                        </p>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => setShowDeleteConfirm(false)}
-                            className="border border-gray-600 text-gray-300 hover:bg-gray-800 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            onClick={handleDeleteAccount}
-                            disabled={deleting}
-                            className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
-                          >
-                            {deleting ? 'Deleting...' : 'Yes, delete my account'}
-                          </button>
-                        </div>
-                        {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                  {user?.deletion_days_remaining != null ? (
+                    /* ── Account pending deletion — show recovery ── */
+                    <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-4">
+                      <h3 className="text-amber-400 text-sm font-semibold mb-2">Account Scheduled for Deletion</h3>
+                      <p className="text-gray-400 text-xs leading-relaxed mb-2">
+                        Your account will be permanently deleted in{' '}
+                        <span className="text-amber-300 font-semibold">{user.deletion_days_remaining} day{user.deletion_days_remaining !== 1 ? 's' : ''}</span>.
+                      </p>
+                      <p className="text-gray-500 text-xs leading-relaxed mb-4">
+                        All your data, orbis, and profile will be removed. You can recover your account before then.
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleRecoverAccount}
+                          disabled={recovering}
+                          className="bg-green-600/20 hover:bg-green-600/30 text-green-400 border border-green-500/30 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                        >
+                          {recovering ? 'Recovering...' : 'Recover my account'}
+                        </button>
                       </div>
-                    )}
-                  </div>
+                      {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                    </div>
+                  ) : (
+                    /* ── Normal state — show delete option ── */
+                    <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
+                      <h3 className="text-red-400 text-sm font-semibold mb-2">Delete Account</h3>
+                      <p className="text-gray-400 text-xs leading-relaxed mb-4">
+                        Your account will be scheduled for deletion. You have 30 days to recover it before all data is permanently removed.
+                      </p>
+
+                      {!showDeleteConfirm ? (
+                        <button
+                          onClick={() => setShowDeleteConfirm(true)}
+                          className="bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-500/30 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                        >
+                          Delete my account
+                        </button>
+                      ) : (
+                        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mt-2">
+                          <p className="text-red-300 text-xs font-medium mb-3">
+                            Are you sure? You'll have 30 days to recover your account before permanent deletion.
+                          </p>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => setShowDeleteConfirm(false)}
+                              className="border border-gray-600 text-gray-300 hover:bg-gray-800 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              onClick={handleDeleteAccount}
+                              disabled={deleting}
+                              className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                            >
+                              {deleting ? 'Scheduling...' : 'Yes, delete my account'}
+                            </button>
+                          </div>
+                          {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </motion.div>
               )}
             </AnimatePresence>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -476,6 +476,7 @@ const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'L
 export default function OrbViewPage() {
   const { data, loading, fetchOrb, addNode, updateNode, deleteNode } = useOrbStore();
   const { user } = useAuthStore();
+  const isPendingDeletion = user?.deletion_days_remaining != null;
   const [showInput, setShowInput] = useState(false);
   const [showShare, setShowShare] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
@@ -745,8 +746,17 @@ export default function OrbViewPage() {
 
   return (
     <div className="min-h-screen bg-black relative">
+      {/* ── Deletion countdown banner ── */}
+      {isPendingDeletion && (
+        <div className="absolute top-0 left-0 right-0 z-40 bg-amber-600/90 text-white text-center py-1.5 px-4 text-xs font-medium">
+          Your account is scheduled for deletion in{' '}
+          <span className="font-bold">{user.deletion_days_remaining} day{user.deletion_days_remaining !== 1 ? 's' : ''}</span>.
+          Go to Account Settings to recover it.
+        </div>
+      )}
+
       {/* ── Header ── */}
-      <div className="absolute top-0 left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3">
+      <div className={`absolute left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3 ${isPendingDeletion ? 'top-8' : 'top-0'}`}>
         <div className="flex items-center justify-between">
           {/* Left: identity + view/filter/export */}
           <div className="flex items-center gap-2 sm:gap-3">
@@ -761,22 +771,24 @@ export default function OrbViewPage() {
               <span className="text-white/20 text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
             </div>
             <div className="hidden sm:block w-px h-5 bg-white/10" />
-            <div className="flex items-center gap-1">
-              <NodeTypeFilter
-                hiddenTypes={hiddenNodeTypes}
-                onShowAll={handleShowAllNodeTypes}
-                onHideAll={handleHideAllNodeTypes}
-                onSetVisible={handleSetVisibleNodeTypes}
-              />
-              <KeywordFilterDropdown />
-              <button
-                onClick={() => window.open('/cv-export', '_blank')}
-                className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
-              >
-                <IconDownload />
-                <span className="hidden sm:inline">Export CV</span>
-              </button>
-            </div>
+            {!isPendingDeletion && (
+              <div className="flex items-center gap-1">
+                <NodeTypeFilter
+                  hiddenTypes={hiddenNodeTypes}
+                  onShowAll={handleShowAllNodeTypes}
+                  onHideAll={handleHideAllNodeTypes}
+                  onSetVisible={handleSetVisibleNodeTypes}
+                />
+                <KeywordFilterDropdown />
+                <button
+                  onClick={() => window.open('/cv-export', '_blank')}
+                  className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
+                >
+                  <IconDownload />
+                  <span className="hidden sm:inline">Export CV</span>
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Right: inbox, notes, user menu */}
@@ -821,31 +833,33 @@ export default function OrbViewPage() {
       )}
 
       {/* ── Date Range Slider ── */}
-      {dateBounds && (
+      {dateBounds && !isPendingDeletion && (
         <DateRangeSlider minDate={dateBounds.min} maxDate={dateBounds.max} />
       )}
 
       {/* ── 3D Graph ── */}
-      <OrbGraph3D
-        data={data}
-        onNodeClick={handleNodeClick}
-        onBackgroundClick={() => {
-          if (chatMessages.length > 0) {
-            setChatMessages([]);
-            setHighlightedNodeIds(new Set());
-          }
-        }}
-        highlightedNodeIds={highlightedNodeIds}
-        filteredNodeIds={filteredNodeIds}
-        hiddenNodeTypes={hiddenNodeTypes}
-        width={dimensions.width}
-        height={dimensions.height}
-      />
+      <div className={isPendingDeletion ? 'opacity-60 grayscale pointer-events-none' : ''}>
+        <OrbGraph3D
+          data={data}
+          onNodeClick={isPendingDeletion ? undefined : handleNodeClick}
+          onBackgroundClick={isPendingDeletion ? undefined : () => {
+            if (chatMessages.length > 0) {
+              setChatMessages([]);
+              setHighlightedNodeIds(new Set());
+            }
+          }}
+          highlightedNodeIds={highlightedNodeIds}
+          filteredNodeIds={filteredNodeIds}
+          hiddenNodeTypes={hiddenNodeTypes}
+          width={dimensions.width}
+          height={dimensions.height}
+        />
+      </div>
 
       {/* NodeTypeFilter moved to header bar */}
 
       {/* ── Floating Input ── */}
-      <FloatingInput
+      {!isPendingDeletion && <FloatingInput
         open={showInput}
         editNode={editNode}
         onSubmit={handleSubmit}
@@ -865,17 +879,17 @@ export default function OrbViewPage() {
           return { node_type: result.node_type, properties: result.properties };
         }}
         onSaveDraft={pendingDraftNoteId ? handleSaveDraftEnhanced : undefined}
-      />
+      />}
 
       {/* ── Chat Box ── */}
-      <ChatBox
+      {!isPendingDeletion && <ChatBox
         onHighlight={setHighlightedNodeIds}
         messages={chatMessages}
         onMessagesChange={setChatMessages}
         onAdd={() => { setEditNode(null); setShowInput(true); }}
         onShare={() => setShowShare(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
-      />
+      />}
 
       {/* ── Draft Notes ── */}
       <DraftNotes


### PR DESCRIPTION
## Summary

Replace immediate account deletion with a 30-day grace period. Users can recover their account within the window. During the grace period, the orbis is visible but non-interactive.

## Backend

| Endpoint | Change |
|----------|--------|
| `DELETE /auth/me` | Sets `deletion_requested_at` instead of wiping data |
| `POST /auth/me/recover` | Clears the flag, restores full access |
| `GET /auth/me` | Returns `deletion_days_remaining` when pending |
| `GET /orbs/{orb_id}` (public) | Returns 404 for pending-deletion accounts |
| Startup | Permanently deletes accounts past 30 days |

## Frontend — Degraded state during grace period

When an account is pending deletion, the orb view shows:

- **Amber banner** at top with countdown: "Your account is scheduled for deletion in X days"
- **Graph grayed out** (60% opacity, grayscale, no pointer events)
- **Hidden**: Legend, Filters, Export CV, Date slider, ChatBox, Add/Edit node
- **Accessible**: Account Settings (to recover), Notes, User menu

## Frontend — Account Settings

- **Normal state**: "Delete my account" with 30-day grace period explanation
- **Pending deletion**: Amber card with days remaining + "Recover my account" button

## Test plan

- [ ] Delete account → sets deletion_requested_at, logs out, shows toast
- [ ] Sign back in → banner shows with correct day count
- [ ] Graph is gray, non-interactive
- [ ] Filters, Export, Chat, Add node are hidden
- [ ] Date range slider is hidden
- [ ] Account Settings → "Recover my account" → clears flag, reloads
- [ ] Public orb URL returns 404 during grace period
- [ ] After 30 days, startup cleanup permanently deletes the account

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)