### PR TITLE
fix: only pause orb rotation when hovering a node

### DIFF
--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -50,6 +50,7 @@ const SHARED_GEO = {
 export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, filteredNodeIds, hiddenNodeTypes, width, height, enableZoom = true, enablePan = true, cameraDistance = 400 }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
+  const hoveredNodeRef = useRef<Record<string, unknown> | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const highlightRingsRef = useRef<Map<string, THREE.Mesh>>(new Map());
   const nodeObjectCacheRef = useRef<Map<string, THREE.Group>>(new Map());
@@ -206,8 +207,8 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
           particles.rotation.x += 0.00003;
         }
 
-        // Auto-rotate graph when not hovering
-        if (!isHoveringRef.current && scene) {
+        // Auto-rotate graph when no node is hovered
+        if (!hoveredNodeRef.current && scene) {
           scene.rotation.y += 0.0012;
         }
 
@@ -272,6 +273,7 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
 
   const handleNodeHover = useCallback((node: any) => {
     setHoveredNode(node || null);
+    hoveredNodeRef.current = node || null;
     const el = document.querySelector('canvas');
     if (el) el.style.cursor = node ? 'pointer' : 'default';
   }, []);


### PR DESCRIPTION
## Problem

The demo orb on the landing page (and myorbis) stopped rotating whenever the mouse entered the canvas area, making it appear frozen even when not interacting with any node.

## Fix

- Rotation now only pauses when a **specific node** is hovered (tooltip visible)
- Moving the mouse over the canvas background keeps the rotation going
- Add `hoveredNodeRef` to track hovered node in the animation loop without re-renders

## Test plan

- [ ] Landing page demo orb keeps rotating when mouse is over the canvas
- [ ] Rotation pauses when hovering a specific node (tooltip shows)
- [ ] Rotation resumes when cursor leaves the node
- [ ] Same behavior on /myorbis

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)