### PR TITLE
feat: store uploaded CVs encrypted for recovery

### DIFF
--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import Response
 from neo4j import AsyncDriver
 
 from app.config import settings
@@ -12,6 +13,9 @@ from app.cv.docling_extractor import extract_text as pdf_extract
 from app.cv.models import ConfirmRequest, ExtractedData
 from app.cv.ollama_classifier import classify_entries
 from app.cv.progress import CVStep
+from app.cv_storage.db import get_metadata as get_cv_metadata
+from app.cv_storage.storage import load_cv
+from app.cv_storage.storage import save_cv as store_cv_file
 from app.dependencies import get_current_user, get_db
 from app.graph.encryption import encrypt_properties, encrypt_value
 from app.graph.queries import (
@@ -60,6 +64,18 @@ async def upload_cv(
         raise HTTPException(status_code=400, detail="File too large (max 10MB)")
 
     user_id = current_user.get("user_id", "")
+
+    # Best-effort: store the original PDF encrypted for future recovery
+    try:
+        import fitz
+
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+        pc = len(doc)
+        doc.close()
+        store_cv_file(user_id, pdf_bytes, file.filename or "upload.pdf", pc)
+    except Exception as e:
+        logger.warning("Failed to store CV file: %s", e)
+
     counter.increment()
     try:
         # Step 1: Read PDF
@@ -150,6 +166,28 @@ async def upload_cv(
             progress.clear_progress(user_id)
 
         asyncio.create_task(_cleanup())
+
+
+@router.get("/download")
+async def download_cv(
+    current_user: dict = Depends(get_current_user),
+):
+    """Download the latest uploaded CV (decrypted)."""
+    user_id = current_user["user_id"]
+    meta = get_cv_metadata(user_id)
+    if meta is None:
+        raise HTTPException(status_code=404, detail="No CV stored")
+
+    pdf_bytes = load_cv(user_id)
+    if pdf_bytes is None:
+        raise HTTPException(status_code=404, detail="CV file not found")
+
+    filename = meta.get("original_filename", "cv.pdf")
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/processing-count")

--- a/backend/app/cv_storage/db.py
+++ b/backend/app/cv_storage/db.py
@@ -1,0 +1,77 @@
+"""SQLite database for CV upload metadata — separate from the main Neo4j graph."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_DB_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "cv_uploads.db"
+_conn: sqlite3.Connection | None = None
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+        _conn.row_factory = sqlite3.Row
+        _conn.execute("PRAGMA journal_mode=WAL")
+        _conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cv_uploads (
+                user_id TEXT PRIMARY KEY,
+                original_filename TEXT NOT NULL,
+                file_size_bytes INTEGER NOT NULL,
+                uploaded_at TEXT NOT NULL,
+                page_count INTEGER NOT NULL
+            )
+            """
+        )
+        _conn.commit()
+    return _conn
+
+
+def upsert_metadata(
+    user_id: str,
+    filename: str,
+    size: int,
+    page_count: int,
+    now: str,
+) -> dict:
+    conn = _get_conn()
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO cv_uploads
+            (user_id, original_filename, file_size_bytes, uploaded_at, page_count)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (user_id, filename, size, now, page_count),
+    )
+    conn.commit()
+    return {
+        "user_id": user_id,
+        "original_filename": filename,
+        "file_size_bytes": size,
+        "uploaded_at": now,
+        "page_count": page_count,
+    }
+
+
+def get_metadata(user_id: str) -> dict | None:
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT user_id, original_filename, file_size_bytes, uploaded_at, page_count "
+        "FROM cv_uploads WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def delete_metadata(user_id: str) -> bool:
+    conn = _get_conn()
+    cur = conn.execute(
+        "DELETE FROM cv_uploads WHERE user_id = ?",
+        (user_id,),
+    )
+    conn.commit()
+    return cur.rowcount > 0

--- a/backend/app/cv_storage/storage.py
+++ b/backend/app/cv_storage/storage.py
@@ -1,0 +1,56 @@
+"""Fernet-encrypted file storage for CV PDFs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.cv_storage import db
+from app.graph.encryption import _get_fernet
+
+_CV_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "cv_files"
+
+
+def _cv_path(user_id: str) -> Path:
+    return _CV_DIR / f"{user_id}.pdf.enc"
+
+
+def save_cv(
+    user_id: str,
+    pdf_bytes: bytes,
+    filename: str,
+    page_count: int,
+) -> dict:
+    """Encrypt *pdf_bytes* and persist to disk, then record metadata in SQLite."""
+    _CV_DIR.mkdir(parents=True, exist_ok=True)
+    encrypted = _get_fernet().encrypt(pdf_bytes)
+    _cv_path(user_id).write_bytes(encrypted)
+    now = datetime.now(timezone.utc).isoformat()
+    return db.upsert_metadata(
+        user_id=user_id,
+        filename=filename,
+        size=len(pdf_bytes),
+        page_count=page_count,
+        now=now,
+    )
+
+
+def load_cv(user_id: str) -> bytes | None:
+    """Return decrypted PDF bytes, or *None* if no file exists for *user_id*."""
+    path = _cv_path(user_id)
+    if not path.exists():
+        return None
+    return _get_fernet().decrypt(path.read_bytes())
+
+
+def delete_cv(user_id: str) -> bool:
+    """Delete the encrypted file and its metadata row.
+
+    Returns *True* when a file was removed, *False* when nothing existed.
+    """
+    path = _cv_path(user_id)
+    removed = path.exists()
+    if removed:
+        path.unlink()
+    db.delete_metadata(user_id)
+    return removed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,8 @@ from slowapi.middleware import SlowAPIMiddleware
 from app.auth.router import router as auth_router
 from app.config import settings
 from app.cv.router import router as cv_router
+from app.cv_storage.storage import delete_cv as delete_stored_cv
+from app.drafts.db import delete_all_for_user as delete_user_drafts
 from app.drafts.router import router as drafts_router
 from app.export.router import router as export_router
 from app.graph.neo4j_client import close_driver, get_driver
@@ -48,6 +50,19 @@ async def _cleanup_expired_accounts(driver):
             logging.getLogger(__name__).info(
                 "Permanently deleted expired account: %s", user_id
             )
+            # Clean up secondary databases
+            try:
+                delete_stored_cv(user_id)
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "Failed to delete CV for %s: %s", user_id, e
+                )
+            try:
+                delete_user_drafts(user_id)
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "Failed to delete drafts for %s: %s", user_id, e
+                )
 
     if expired:
         logging.getLogger(__name__).info(

--- a/backend/tests/unit/test_cv_storage_db.py
+++ b/backend/tests/unit/test_cv_storage_db.py
@@ -1,0 +1,90 @@
+"""Unit tests for app.cv_storage.db — SQLite metadata store for CV uploads."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.cv_storage.db as cv_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(monkeypatch, tmp_path):
+    """
+    Redirect _DB_PATH to a temp file and reset the module-level singleton
+    connection before each test so every test gets a fresh, empty database.
+    """
+    db_file = tmp_path / "cv_uploads_test.db"
+    monkeypatch.setattr(cv_db, "_DB_PATH", db_file)
+    monkeypatch.setattr(cv_db, "_conn", None)
+    yield
+    # Close the connection opened during the test to release the file handle.
+    if cv_db._conn is not None:
+        cv_db._conn.close()
+    monkeypatch.setattr(cv_db, "_conn", None)
+
+
+_NOW = "2026-01-01T00:00:00"
+
+
+def test_upsert_and_get():
+    cv_db.upsert_metadata(
+        user_id="user-1",
+        filename="cv.pdf",
+        size=12345,
+        page_count=3,
+        now=_NOW,
+    )
+    result = cv_db.get_metadata("user-1")
+    assert result is not None
+    assert result["user_id"] == "user-1"
+    assert result["original_filename"] == "cv.pdf"
+    assert result["file_size_bytes"] == 12345
+    assert result["page_count"] == 3
+    assert result["uploaded_at"] == _NOW
+
+
+def test_upsert_replaces():
+    cv_db.upsert_metadata(
+        user_id="user-2",
+        filename="old_cv.pdf",
+        size=1000,
+        page_count=1,
+        now="2026-01-01T00:00:00",
+    )
+    new_now = "2026-06-01T12:00:00"
+    cv_db.upsert_metadata(
+        user_id="user-2",
+        filename="new_cv.pdf",
+        size=2000,
+        page_count=5,
+        now=new_now,
+    )
+    result = cv_db.get_metadata("user-2")
+    assert result is not None
+    assert result["original_filename"] == "new_cv.pdf"
+    assert result["file_size_bytes"] == 2000
+    assert result["page_count"] == 5
+    assert result["uploaded_at"] == new_now
+
+
+def test_get_nonexistent():
+    result = cv_db.get_metadata("does-not-exist")
+    assert result is None
+
+
+def test_delete():
+    cv_db.upsert_metadata(
+        user_id="user-3",
+        filename="cv.pdf",
+        size=500,
+        page_count=2,
+        now=_NOW,
+    )
+    deleted = cv_db.delete_metadata("user-3")
+    assert deleted is True
+    assert cv_db.get_metadata("user-3") is None
+
+
+def test_delete_nonexistent():
+    deleted = cv_db.delete_metadata("ghost-user")
+    assert deleted is False

--- a/backend/tests/unit/test_cv_storage_file.py
+++ b/backend/tests/unit/test_cv_storage_file.py
@@ -1,0 +1,90 @@
+"""Unit tests for app.cv_storage.storage — encrypted file storage for CVs."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.cv_storage.db as cv_db
+import app.cv_storage.storage as cv_storage
+
+
+@pytest.fixture(autouse=True)
+def isolated_storage(monkeypatch, tmp_path):
+    """
+    Redirect both _CV_DIR (file storage) and _DB_PATH/_conn (SQLite metadata)
+    to tmp_path so every test runs fully isolated with a fresh directory and
+    an empty database.
+    """
+    cv_dir = tmp_path / "cv_files"
+    monkeypatch.setattr(cv_storage, "_CV_DIR", cv_dir)
+
+    db_file = tmp_path / "cv_uploads_test.db"
+    monkeypatch.setattr(cv_db, "_DB_PATH", db_file)
+    monkeypatch.setattr(cv_db, "_conn", None)
+
+    yield
+
+    if cv_db._conn is not None:
+        cv_db._conn.close()
+    monkeypatch.setattr(cv_db, "_conn", None)
+
+
+_PDF = b"%PDF-1.4 fake pdf content for testing"
+_USER = "user-test-001"
+
+
+def test_save_and_load():
+    cv_storage.save_cv(_USER, _PDF, "resume.pdf", page_count=2)
+    result = cv_storage.load_cv(_USER)
+    assert result == _PDF
+
+
+def test_save_overwrites():
+    cv_storage.save_cv(_USER, _PDF, "old.pdf", page_count=1)
+    new_pdf = b"%PDF-1.4 updated content"
+    cv_storage.save_cv(_USER, new_pdf, "new.pdf", page_count=3)
+    result = cv_storage.load_cv(_USER)
+    assert result == new_pdf
+
+
+def test_load_nonexistent():
+    result = cv_storage.load_cv("no-such-user")
+    assert result is None
+
+
+def test_delete():
+    cv_storage.save_cv(_USER, _PDF, "resume.pdf", page_count=2)
+    removed = cv_storage.delete_cv(_USER)
+    assert removed is True
+    assert cv_storage.load_cv(_USER) is None
+    assert not cv_storage._cv_path(_USER).exists()
+
+
+def test_delete_nonexistent():
+    removed = cv_storage.delete_cv("ghost-user")
+    assert removed is False
+
+
+def test_file_is_encrypted_on_disk():
+    cv_storage.save_cv(_USER, _PDF, "resume.pdf", page_count=1)
+    raw = cv_storage._cv_path(_USER).read_bytes()
+    # The Fernet token is base64 and starts with 'gAAAAA'; it must NOT contain
+    # plaintext PDF bytes.
+    assert _PDF not in raw
+    assert b"%PDF" not in raw
+
+
+def test_metadata_saved():
+    cv_storage.save_cv(_USER, _PDF, "resume.pdf", page_count=4)
+    meta = cv_db.get_metadata(_USER)
+    assert meta is not None
+    assert meta["original_filename"] == "resume.pdf"
+    assert meta["file_size_bytes"] == len(_PDF)
+    assert meta["page_count"] == 4
+    assert meta["user_id"] == _USER
+
+
+def test_delete_removes_metadata():
+    cv_storage.save_cv(_USER, _PDF, "resume.pdf", page_count=2)
+    cv_storage.delete_cv(_USER)
+    assert cv_db.get_metadata(_USER) is None

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -42,6 +42,19 @@ export async function confirmCV(
 }
 
 
+export async function downloadCV(): Promise<void> {
+  const response = await client.get('/cv/download', { responseType: 'blob' });
+  const disposition = response.headers['content-disposition'] || '';
+  const match = disposition.match(/filename="?([^"]+)"?/);
+  const filename = match ? match[1] : 'cv.pdf';
+  const url = URL.createObjectURL(response.data);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export async function getProcessingCount(): Promise<number> {
   const { data } = await client.get('/cv/processing-count');
   return data.count;

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -111,6 +111,25 @@ export default function UserMenu({ orbId, onOrbIdChanged, label }: UserMenuProps
               Account settings
             </button>
 
+            {/* Download CV */}
+            <button
+              onClick={async () => {
+                setOpen(false);
+                try {
+                  const { downloadCV } = await import('../api/cv');
+                  await downloadCV();
+                } catch {
+                  addToast('No CV uploaded yet', 'info');
+                }
+              }}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-white/70 hover:bg-white/5 hover:text-white transition-colors cursor-pointer"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 10v6m0 0l-3-3m3 3l3-3M3 17v3a2 2 0 002 2h14a2 2 0 002-2v-3" />
+              </svg>
+              My uploaded CV
+            </button>
+
             <div className="border-t border-white/5" />
 
             {/* Logout */}


### PR DESCRIPTION
## Summary

Store uploaded CV PDFs encrypted on disk with metadata in SQLite. One CV per user, downloadable from the user menu. Cascade-deleted when accounts expire.

## Architecture

- **PDF files**: Fernet-encrypted at `data/cv_files/{user_id}.pdf.enc`
- **Metadata**: SQLite at `data/cv_uploads.db` (separate from drafts)
- **Best-effort**: storage failure doesn't block CV extraction

## New module: `backend/app/cv_storage/`

| File | Purpose |
|------|---------|
| `db.py` | SQLite metadata CRUD |
| `storage.py` | Fernet encrypt/decrypt + file I/O |

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/cv/download` | Decrypt and download stored CV PDF |

## Frontend

- "My uploaded CV" entry in UserMenu dropdown
- Downloads the PDF or shows toast if none stored

## Cleanup

- Startup task cascade-deletes CVs + drafts for expired accounts (>30 days)

## Test plan

- [x] 347 tests pass (81% coverage)
- [x] Lint clean
- [x] Upload CV → encrypted file in `data/cv_files/`
- [x] Click "My uploaded CV" → downloads the PDF
- [x] No CV uploaded → toast "No CV uploaded yet"
- [ ] Account expires → file + metadata removed

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)