### PR TITLE
feat: allow importing PDF/DOCX/TXT to enrich existing orbs

### DIFF
--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -365,9 +365,7 @@ async def _persist_nodes(data, current_user, db, *, wipe_existing: bool):  # noq
                 merge_key_values = {k: properties.get(k, "") for k in merge_keys}
                 has_all = all(merge_key_values.values())
                 if has_all:
-                    merge_match = ", ".join(
-                        f"{k}: $merge_{k}" for k in merge_keys
-                    )
+                    merge_match = ", ".join(f"{k}: $merge_{k}" for k in merge_keys)
                     query = (
                         f"MATCH (p:Person {{user_id: $user_id}}) "
                         f"MERGE (p)-[:{rel_type}]->(n:{label} {{{merge_match}}}) "

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -13,6 +13,7 @@ from app.cv.docling_extractor import extract_text as pdf_extract
 from app.cv.models import ConfirmRequest, ExtractedData
 from app.cv.ollama_classifier import classify_entries
 from app.cv.progress import CVStep
+from app.cv.text_extractor import extract_text as multi_extract
 from app.cv_storage.db import get_metadata as get_cv_metadata
 from app.cv_storage.storage import load_cv
 from app.cv_storage.storage import save_cv as store_cv_file
@@ -190,6 +191,117 @@ async def download_cv(
     )
 
 
+ALLOWED_EXTENSIONS = {".pdf", ".docx", ".txt", ".text"}
+
+
+@router.post("/store-file")
+async def store_file(
+    file: UploadFile = File(...),
+    current_user: dict = Depends(get_current_user),
+):
+    """Store a file as the user's downloadable CV (replaces previous)."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+    file_bytes = await file.read()
+    if len(file_bytes) > 10 * 1024 * 1024:
+        raise HTTPException(status_code=400, detail="File too large (max 10MB)")
+    user_id = current_user["user_id"]
+    try:
+        import fitz
+
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        pc = len(doc)
+        doc.close()
+    except Exception:
+        pc = 1
+    store_cv_file(user_id, file_bytes, file.filename or "upload", pc)
+    return {"status": "stored"}
+
+
+@router.post("/import", response_model=ExtractedData)
+async def import_document(
+    file: UploadFile = File(...),
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Import a supplementary document (PDF, DOCX, TXT) to enrich the orb."""
+    await _require_consent(current_user, db)
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    from pathlib import Path as P
+
+    ext = P(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type. Allowed: {', '.join(ALLOWED_EXTENSIONS)}",
+        )
+
+    file_bytes = await file.read()
+    if len(file_bytes) > 10 * 1024 * 1024:
+        raise HTTPException(status_code=400, detail="File too large (max 10MB)")
+
+    user_id = current_user.get("user_id", "")
+    try:
+        progress.set_progress(user_id, CVStep.EXTRACTING_TEXT, file.filename)
+        raw_text = await multi_extract(file_bytes, file.filename)
+
+        if not raw_text.strip():
+            raise HTTPException(
+                status_code=400, detail="Could not extract text from file"
+            )
+
+        progress.set_progress(
+            user_id,
+            CVStep.CLASSIFYING,
+            f"Analyzing {len(raw_text):,} characters",
+        )
+        result = await classify_entries(raw_text)
+
+        if not result.nodes and not result.unmatched:
+            raise HTTPException(
+                status_code=400,
+                detail="No entries could be extracted from the document.",
+            )
+
+        progress.set_progress(user_id, CVStep.DONE)
+
+        from app.cv.models import ExtractedProfile
+
+        extracted_profile = None
+        if result.profile:
+            extracted_profile = ExtractedProfile(**result.profile)
+
+        return ExtractedData(
+            nodes=result.nodes,
+            unmatched=result.unmatched,
+            skipped_nodes=result.skipped,
+            relationships=result.relationships,
+            truncated=result.truncated,
+            cv_owner_name=result.cv_owner_name,
+            profile=extracted_profile,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Document import error: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to process document: {e!s}"
+        ) from None
+
+
+@router.post("/import-confirm")
+async def import_confirm(
+    data: ConfirmRequest,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Merge imported nodes into existing orb (no deletion of existing data)."""
+    await _require_consent(current_user, db)
+    return await _persist_nodes(data, current_user, db, wipe_existing=False)
+
+
 @router.get("/processing-count")
 async def get_processing_count():
     """Return the number of PDFs currently being processed."""
@@ -224,6 +336,101 @@ async def get_cv_progress(
     }
 
 
+async def _persist_nodes(data, current_user, db, *, wipe_existing: bool):  # noqa: C901
+    """Shared logic for confirm_cv and import_confirm."""
+    created: list[str | None] = []
+    async with db.session() as session:
+        if wipe_existing:
+            await session.run(DELETE_USER_GRAPH, user_id=current_user["user_id"])
+
+        person_updates = _build_person_updates(data)
+        if person_updates:
+            await session.run(
+                UPDATE_PERSON,
+                user_id=current_user["user_id"],
+                properties=person_updates,
+            )
+
+        for node in data.nodes:
+            if node.node_type not in NODE_TYPE_LABELS:
+                created.append(None)
+                continue
+            label = NODE_TYPE_LABELS[node.node_type]
+            rel_type = NODE_TYPE_RELATIONSHIPS[node.node_type]
+            uid = str(uuid.uuid4())
+            properties = encrypt_properties(node.properties)
+
+            merge_keys = NODE_TYPE_MERGE_KEYS.get(node.node_type)
+            if merge_keys:
+                merge_key_values = {k: properties.get(k, "") for k in merge_keys}
+                has_all = all(merge_key_values.values())
+                if has_all:
+                    merge_match = ", ".join(
+                        f"{k}: $merge_{k}" for k in merge_keys
+                    )
+                    query = (
+                        f"MATCH (p:Person {{user_id: $user_id}}) "
+                        f"MERGE (p)-[:{rel_type}]->(n:{label} {{{merge_match}}}) "
+                        f"ON CREATE SET n += $properties, n.uid = $uid "
+                        f"ON MATCH SET n += $properties "
+                        f"RETURN n"
+                    )
+                    params = {
+                        "user_id": current_user["user_id"],
+                        "properties": properties,
+                        "uid": uid,
+                    }
+                    for k, v in merge_key_values.items():
+                        params[f"merge_{k}"] = v
+                    result = await session.run(query, **params)
+                else:
+                    query = ADD_NODE.replace("{label}", label).replace(
+                        "{rel_type}", rel_type
+                    )
+                    result = await session.run(
+                        query,
+                        user_id=current_user["user_id"],
+                        properties=properties,
+                        uid=uid,
+                    )
+            else:
+                query = ADD_NODE.replace("{label}", label).replace(
+                    "{rel_type}", rel_type
+                )
+                result = await session.run(
+                    query,
+                    user_id=current_user["user_id"],
+                    properties=properties,
+                    uid=uid,
+                )
+
+            record = await result.single()
+            if record:
+                actual_uid = dict(record["n"]).get("uid", uid)
+                created.append(actual_uid)
+            else:
+                created.append(None)
+
+        for rel in data.relationships:
+            if rel.type != "USED_SKILL":
+                continue
+            if 0 <= rel.from_index < len(created) and 0 <= rel.to_index < len(created):
+                from_uid = created[rel.from_index]
+                to_uid = created[rel.to_index]
+                if from_uid and to_uid:
+                    try:
+                        await session.run(
+                            LINK_SKILL, node_uid=from_uid, skill_uid=to_uid
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to link %s -> %s: %s", from_uid, to_uid, e
+                        )
+
+    valid_ids = [uid for uid in created if uid is not None]
+    return {"created": len(valid_ids), "node_ids": valid_ids}
+
+
 def _build_person_updates(data: ConfirmRequest) -> dict:
     """Build Person node property updates from CV extraction results."""
     updates: dict[str, str] = {}
@@ -246,93 +453,4 @@ async def confirm_cv(
 ):
     """Persist confirmed CV nodes to Neo4j with dedup and cross-entity linking."""
     await _require_consent(current_user, db)
-    created: list[str | None] = []
-
-    async with db.session() as session:
-        # Wipe existing graph nodes (keep Person) so CV import replaces, not merges
-        await session.run(DELETE_USER_GRAPH, user_id=current_user["user_id"])
-
-        # Store CV owner name and extracted profile on the Person node
-        person_updates = _build_person_updates(data)
-        if person_updates:
-            await session.run(
-                UPDATE_PERSON,
-                user_id=current_user["user_id"],
-                properties=person_updates,
-            )
-        for node in data.nodes:
-            if node.node_type not in NODE_TYPE_LABELS:
-                created.append(None)
-                continue
-
-            label = NODE_TYPE_LABELS[node.node_type]
-            rel_type = NODE_TYPE_RELATIONSHIPS[node.node_type]
-            uid = str(uuid.uuid4())
-            properties = encrypt_properties(node.properties)
-
-            # Try MERGE with key properties for dedup, fall back to CREATE
-            merge_keys = NODE_TYPE_MERGE_KEYS.get(node.node_type, [])
-            merge_key_values = {
-                k: properties.get(k) for k in merge_keys if properties.get(k)
-            }
-
-            if merge_key_values and len(merge_key_values) == len(merge_keys):
-                key_clause = ", ".join(f"{k}: $merge_{k}" for k in merge_key_values)
-                query = (
-                    f"MATCH (p:Person {{user_id: $user_id}}) "
-                    f"MERGE (p)-[:{rel_type}]->(n:{label} {{{key_clause}}}) "
-                    f"ON CREATE SET n += $properties, n.uid = $uid "
-                    f"ON MATCH SET n += $properties "
-                    f"RETURN n"
-                )
-                params: dict = {
-                    "user_id": current_user["user_id"],
-                    "properties": properties,
-                    "uid": uid,
-                }
-                for k, v in merge_key_values.items():
-                    params[f"merge_{k}"] = v
-
-                result = await session.run(query, **params)
-            else:
-                query = ADD_NODE.replace("{label}", label).replace(
-                    "{rel_type}", rel_type
-                )
-                result = await session.run(
-                    query,
-                    user_id=current_user["user_id"],
-                    properties=properties,
-                    uid=uid,
-                )
-
-            record = await result.single()
-            if record:
-                actual_uid = dict(record["n"]).get("uid", uid)
-                created.append(actual_uid)
-            else:
-                created.append(None)
-
-        # Create cross-entity links (USED_SKILL)
-        for rel in data.relationships:
-            if rel.type != "USED_SKILL":
-                continue
-            if 0 <= rel.from_index < len(created) and 0 <= rel.to_index < len(created):
-                from_uid = created[rel.from_index]
-                to_uid = created[rel.to_index]
-                if from_uid and to_uid:
-                    try:
-                        await session.run(
-                            LINK_SKILL,
-                            node_uid=from_uid,
-                            skill_uid=to_uid,
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to create USED_SKILL link %s -> %s: %s",
-                            from_uid,
-                            to_uid,
-                            e,
-                        )
-
-    valid_ids = [uid for uid in created if uid is not None]
-    return {"created": len(valid_ids), "node_ids": valid_ids}
+    return await _persist_nodes(data, current_user, db, wipe_existing=True)

--- a/backend/app/cv/text_extractor.py
+++ b/backend/app/cv/text_extractor.py
@@ -1,0 +1,54 @@
+"""Extract text from PDF, DOCX, and TXT files."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import fitz
+
+logger = logging.getLogger(__name__)
+
+
+async def extract_text(file_bytes: bytes, filename: str) -> str:
+    """Extract text based on file extension. Supports PDF, DOCX, TXT."""
+    ext = Path(filename).suffix.lower()
+
+    if ext == ".pdf":
+        return await _extract_pdf(file_bytes)
+    if ext == ".docx":
+        return await _extract_docx(file_bytes)
+    if ext in (".txt", ".text"):
+        return file_bytes.decode("utf-8", errors="replace")
+
+    raise ValueError(f"Unsupported file type: {ext}")
+
+
+async def _extract_pdf(pdf_bytes: bytes) -> str:
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _pdf_sync, pdf_bytes)
+
+
+def _pdf_sync(pdf_bytes: bytes) -> str:
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    text = ""
+    for page in doc:
+        text += page.get_text()
+    doc.close()
+    return text
+
+
+async def _extract_docx(docx_bytes: bytes) -> str:
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _docx_sync, docx_bytes)
+
+
+def _docx_sync(docx_bytes: bytes) -> str:
+    from io import BytesIO
+
+    from docx import Document
+
+    doc = Document(BytesIO(docx_bytes))
+    paragraphs = [p.text for p in doc.paragraphs if p.text.strip()]
+    return "\n".join(paragraphs)

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -55,6 +55,36 @@ export async function downloadCV(): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
+export async function importDocument(file: File): Promise<ExtractedData> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const { data } = await client.post('/cv/import', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+    timeout: 1800000,
+  });
+  return data;
+}
+
+export async function confirmImport(
+  nodes: ExtractedData['nodes'],
+  relationships?: ExtractedRelationship[],
+  cv_owner_name?: string | null,
+): Promise<void> {
+  await client.post('/cv/import-confirm', {
+    nodes,
+    relationships: relationships || [],
+    cv_owner_name: cv_owner_name || null,
+  });
+}
+
+export async function storeFile(file: File): Promise<void> {
+  const formData = new FormData();
+  formData.append('file', file);
+  await client.post('/cv/store-file', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+}
+
 export async function getProcessingCount(): Promise<number> {
   const { data } = await client.get('/cv/processing-count');
   return data.count;

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -18,6 +18,10 @@ interface ExtractedDataReviewProps {
   truncated: boolean;
   onReset: () => void;
   resetLabel?: string;
+  /** Override the confirm function (default: confirmCV which wipes existing data) */
+  onConfirm?: (nodes: ExtractedData['nodes'], relationships: ExtractedRelationship[], cvOwnerName: string | null) => Promise<void>;
+  /** Extra content rendered below the header (e.g., checkbox) */
+  children?: React.ReactNode;
 }
 
 export default function ExtractedDataReview({
@@ -29,6 +33,8 @@ export default function ExtractedDataReview({
   truncated,
   onReset,
   resetLabel = 'Try another file',
+  onConfirm: onConfirmOverride,
+  children,
 }: ExtractedDataReviewProps) {
   const navigate = useNavigate();
   const { fetchUser } = useAuthStore();
@@ -40,8 +46,9 @@ export default function ExtractedDataReview({
   const [error, setError] = useState('');
   const [existingNodeCount, setExistingNodeCount] = useState<number | null>(null);
   const [showReplaceWarning, setShowReplaceWarning] = useState(false);
+  const isReplaceMode = !onConfirmOverride;
 
-  // Check how many nodes the user already has — we need to warn them that confirm wipes the graph
+  // Check how many nodes the user already has so we can show accurate import messaging
   useEffect(() => {
     getMyOrb()
       .then((orb) => setExistingNodeCount(orb.nodes.length))
@@ -65,8 +72,9 @@ export default function ExtractedDataReview({
 
   const handleConfirmClick = () => {
     if (extractedNodes.length === 0) return;
-    // If the user already has nodes, ask for explicit confirmation — confirmCV wipes the graph
-    if ((existingNodeCount ?? 0) > 0) {
+    // If using default confirmCV (which wipes the graph), warn the user
+    // If using a custom confirm (import mode — merge), skip the warning
+    if (isReplaceMode && (existingNodeCount ?? 0) > 0) {
       setShowReplaceWarning(true);
       return;
     }
@@ -78,9 +86,10 @@ export default function ExtractedDataReview({
     setConfirming(true);
     try {
       const replaced = existingNodeCount ?? 0;
-      await confirmCV(extractedNodes, relationships, cvOwnerName);
+      const doConfirm = onConfirmOverride || confirmCV;
+      await doConfirm(extractedNodes, relationships, cvOwnerName);
       await fetchUser();
-      if (replaced > 0) {
+      if (isReplaceMode && replaced > 0) {
         addToast(
           `Imported ${extractedNodes.length} entries (replaced ${replaced} existing)`,
           'success',
@@ -132,6 +141,7 @@ export default function ExtractedDataReview({
               {skippedCount} entr{skippedCount === 1 ? 'y was' : 'ies were'} skipped due to missing required fields or unknown types.
             </p>
           )}
+          {children}
         </div>
 
         <div className="space-y-6 mb-8">
@@ -223,7 +233,10 @@ export default function ExtractedDataReview({
 
         {(existingNodeCount ?? 0) > 0 && (
           <p className="text-amber-400/80 text-xs text-center mb-3">
-            You currently have {existingNodeCount} entries in your orb. Importing will replace them.
+            You currently have {existingNodeCount} entries in your orb.{' '}
+            {isReplaceMode
+              ? 'Importing will replace them.'
+              : 'Importing will merge with your existing entries.'}
           </p>
         )}
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -14,6 +14,7 @@ import FloatingInput from '../components/editor/FloatingInput';
 import ChatBox from '../components/chat/ChatBox';
 import type { ChatMessage } from '../components/chat/ChatBox';
 import DraftNotes from '../components/drafts/DraftNotes';
+import ExtractedDataReview from '../components/onboarding/ExtractedDataReview';
 import type { DraftNote } from '../components/drafts/DraftNotes';
 import { loadDraftNotes, loadDraftNotesAsync, saveDraftNotes } from '../components/drafts/DraftNotes';
 import ProcessingCounter from '../components/cv/ProcessingCounter';
@@ -492,6 +493,17 @@ export default function OrbViewPage() {
   const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
   const [pendingDraftRawText, setPendingDraftRawText] = useState<string>('');
   const [hiddenNodeTypes, setHiddenNodeTypes] = useState<Set<string>>(new Set());
+  const [importing, setImporting] = useState(false);
+  const [importStatus, setImportStatus] = useState('');
+  const [extractedImport, setExtractedImport] = useState<{
+    nodes: Array<{ node_type: string; properties: Record<string, unknown> }>;
+    relationships: Array<{ from_index: number; to_index: number; type: string }>;
+    cvOwnerName: string | null;
+    unmatchedCount: number;
+    skippedCount: number;
+    file: File;
+    replaceCV: boolean;
+  } | null>(null);
 
   // ESC key closes any open panel/modal
   useEffect(() => {
@@ -785,8 +797,77 @@ export default function OrbViewPage() {
                   className="flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
                 >
                   <IconDownload />
-                  <span className="hidden sm:inline">Export CV</span>
+                  <span className="hidden sm:inline">Export Orbis</span>
                 </button>
+                <label
+                  className={`flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg transition-all ${
+                    importing
+                      ? 'text-purple-400 bg-purple-500/10 cursor-wait'
+                      : 'text-white/40 hover:text-purple-400 hover:bg-purple-500/10 cursor-pointer'
+                  }`}
+                  title="Import a document (PDF, DOCX, TXT) to enrich your orbis"
+                >
+                  {importing ? (
+                    <div className="w-4 h-4 border-2 border-purple-400 border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                    </svg>
+                  )}
+                  <span className="hidden sm:inline">{importing ? 'Processing...' : 'Import new data'}</span>
+                  {importing && importStatus && (
+                    <span className="hidden sm:inline text-white/25 text-[10px] ml-1">{importStatus}</span>
+                  )}
+                  <input
+                    type="file"
+                    accept=".pdf,.docx,.txt"
+                    className="hidden"
+                    disabled={importing}
+                    onChange={async (e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      setImporting(true);
+                      setImportStatus('Reading file...');
+                      // Poll progress while importing
+                      const pollId = setInterval(async () => {
+                        try {
+                          const { getCVProgress } = await import('../api/cv');
+                          const p = await getCVProgress();
+                          if (p.active && p.message) {
+                            setImportStatus(p.detail || p.message);
+                          }
+                        } catch { /* ignore */ }
+                      }, 2000);
+                      try {
+                        const { importDocument } = await import('../api/cv');
+                        const result = await importDocument(file);
+                        clearInterval(pollId);
+                        if (result.nodes.length > 0) {
+                          setExtractedImport({
+                            nodes: result.nodes,
+                            relationships: result.relationships || [],
+                            cvOwnerName: result.cv_owner_name || null,
+                            unmatchedCount: result.unmatched?.length || 0,
+                            skippedCount: result.skipped_nodes?.length || 0,
+                            file,
+                            replaceCV: false,
+                          });
+                        } else {
+                          const { useToastStore } = await import('../stores/toastStore');
+                          useToastStore.getState().addToast('Error processing document. Please try again.', 'error');
+                        }
+                      } catch {
+                        clearInterval(pollId);
+                        const { useToastStore } = await import('../stores/toastStore');
+                        useToastStore.getState().addToast('Failed to import document', 'error');
+                      } finally {
+                        setImporting(false);
+                        setImportStatus('');
+                      }
+                      e.target.value = '';
+                    }}
+                  />
+                </label>
               </div>
             )}
           </div>
@@ -908,6 +989,48 @@ export default function OrbViewPage() {
       <AnimatePresence>
         {showProfile && <ProfilePanel key="profile" person={data.person} onClose={() => setShowProfile(false)} onSaved={fetchOrb} />}
       </AnimatePresence>
+
+      {/* ── Import review overlay ── */}
+      {extractedImport && (
+        <div className="fixed inset-0 z-50 bg-black overflow-y-auto">
+          <ExtractedDataReview
+            initialNodes={extractedImport.nodes}
+            initialRelationships={extractedImport.relationships}
+            cvOwnerName={extractedImport.cvOwnerName}
+            unmatchedCount={extractedImport.unmatchedCount}
+            skippedCount={extractedImport.skippedCount}
+            truncated={false}
+            onReset={() => setExtractedImport(null)}
+            resetLabel="Cancel import"
+            onConfirm={async (nodes, rels, name) => {
+              const { confirmImport } = await import('../api/cv');
+              await confirmImport(nodes, rels, name);
+              if (extractedImport.replaceCV) {
+                try {
+                  const { storeFile } = await import('../api/cv');
+                  await storeFile(extractedImport.file);
+                } catch { /* best effort */ }
+              }
+            }}
+          >
+            <div className="flex justify-center mt-4 mb-2">
+              <div className="bg-white/[0.03] border border-white/[0.08] rounded-xl px-4 py-3">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={extractedImport.replaceCV}
+                    onChange={(e) => setExtractedImport({ ...extractedImport, replaceCV: e.target.checked })}
+                    className="mt-0.5 w-4 h-4 rounded border-white/20 bg-white/5 text-purple-500 focus:ring-purple-500 focus:ring-offset-0 focus:ring-1"
+                  />
+                  <span className="text-amber-400 text-sm leading-relaxed font-semibold">
+                    Replace my latest uploaded CV with this document
+                  </span>
+                </label>
+              </div>
+            </div>
+          </ExtractedDataReview>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add backend support for importing supplementary documents via /cv/import and merging via /cv/import-confirm
- add a shared text extractor for PDF, DOCX, and TXT inputs
- add frontend import flow (Import new data) with review overlay and optional CV replacement storage
- fix import messaging to reflect merge behavior and show a generic red error toast when parsing returns no graph nodes

## Validation
- cd backend && .venv/bin/ruff check app/cv/router.py app/cv/text_extractor.py
- cd frontend && npx eslint src/api/cv.ts src/components/onboarding/ExtractedDataReview.tsx src/pages/OrbViewPage.tsx (1 pre-existing warning in OrbViewPage.tsx)

Closes #77