### PR TITLE
feat(ui): center graph on selected chat result and reset on chat close

### DIFF
--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -12,6 +12,7 @@ interface ChatMessage {
 
 interface ChatBoxProps {
   onHighlight: (nodeIds: Set<string>) => void;
+  onFocusNode?: (nodeUid: string) => void;
   highlightedNodeIds?: Set<string>;
   messages: ChatMessage[];
   onMessagesChange: (msgs: ChatMessage[]) => void;
@@ -75,6 +76,7 @@ function getScoreStyle(score: number): { dot: string; text: string } {
 
 export default function ChatBox({
   onHighlight,
+  onFocusNode,
   highlightedNodeIds,
   messages,
   onMessagesChange,
@@ -163,6 +165,7 @@ export default function ChatBox({
       } else {
         const selectedNodeUid = sortedResults[0].uid;
         onHighlight(new Set([selectedNodeUid]));
+        onFocusNode?.(selectedNodeUid);
 
         const summary = sortedResults.length === 1
           ? 'Found 1 matching node — highlighted in your graph.'
@@ -186,6 +189,7 @@ export default function ChatBox({
 
   const handleResultClick = (messageIndex: number, nodeUid: string) => {
     onHighlight(new Set([nodeUid]));
+    onFocusNode?.(nodeUid);
     setMessages((prev) => prev.map((msg, idx) => {
       if (idx !== messageIndex || !msg.matchedNodes) return msg;
       return { ...msg, selectedNodeUid: nodeUid };

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef, useCallback } from 'react';
 import { textSearch } from '../../api/orbs';
 import type { OrbNode } from '../../api/orbs';
 import { NODE_TYPE_COLORS } from '../graph/NodeColors';
@@ -13,6 +13,7 @@ interface ChatMessage {
 interface ChatBoxProps {
   onHighlight: (nodeIds: Set<string>) => void;
   onFocusNode?: (nodeUid: string) => void;
+  onClearResults?: () => void;
   highlightedNodeIds?: Set<string>;
   messages: ChatMessage[];
   onMessagesChange: (msgs: ChatMessage[]) => void;
@@ -77,6 +78,7 @@ function getScoreStyle(score: number): { dot: string; text: string } {
 export default function ChatBox({
   onHighlight,
   onFocusNode,
+  onClearResults,
   highlightedNodeIds,
   messages,
   onMessagesChange,
@@ -115,6 +117,13 @@ export default function ChatBox({
     [messages],
   );
 
+  const clearResults = useCallback(() => {
+    onMessagesChange([]);
+    onHighlight(new Set());
+    setActiveResultIndex(-1);
+    onClearResults?.();
+  }, [onMessagesChange, onHighlight, onClearResults]);
+
   useEffect(() => {
     if (resultNodes.length === 0) {
       setActiveResultIndex(-1);
@@ -134,14 +143,13 @@ export default function ChatBox({
       const target = event.target as Node | null;
       if (!target || !containerRef.current) return;
       if (!containerRef.current.contains(target)) {
-        onMessagesChange([]);
-        onHighlight(new Set());
+        clearResults();
       }
     };
 
     document.addEventListener('pointerdown', handlePointerDown);
     return () => document.removeEventListener('pointerdown', handlePointerDown);
-  }, [hasMessages, onHighlight, onMessagesChange]);
+  }, [hasMessages, clearResults]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -197,9 +205,7 @@ export default function ChatBox({
   };
 
   const handleClearResults = () => {
-    onMessagesChange([]);
-    onHighlight(new Set());
-    setActiveResultIndex(-1);
+    clearResults();
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -19,6 +19,8 @@ interface OrbGraph3DProps {
   enableZoom?: boolean;
   enablePan?: boolean;
   cameraDistance?: number;
+  focusNodeId?: string | null;
+  focusNodeToken?: number;
 }
 
 function getNodeName(node: any): string {
@@ -47,7 +49,21 @@ const SHARED_GEO = {
   highlightRing: new THREE.RingGeometry(5.1, 6.0, 24),
 };
 
-export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highlightedNodeIds, filteredNodeIds, hiddenNodeTypes, width, height, enableZoom = true, enablePan = true, cameraDistance = 400 }: OrbGraph3DProps) {
+export default function OrbGraph3D({
+  data,
+  onNodeClick,
+  onBackgroundClick,
+  highlightedNodeIds,
+  filteredNodeIds,
+  hiddenNodeTypes,
+  width,
+  height,
+  enableZoom = true,
+  enablePan = true,
+  cameraDistance = 400,
+  focusNodeId = null,
+  focusNodeToken = 0,
+}: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
   const hoveredNodeRef = useRef<Record<string, unknown> | null>(null);
@@ -208,7 +224,7 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
         }
 
         // Auto-rotate graph when no node is hovered
-        if (!hoveredNodeRef.current && scene) {
+        if (!hoveredNodeRef.current && !hasHighlightsRef.current && scene) {
           scene.rotation.y += 0.0012;
         }
 
@@ -270,6 +286,63 @@ export default function OrbGraph3D({ data, onNodeClick, onBackgroundClick, highl
       if (fg) fg.refresh();
     }
   }, [hiddenNodeTypes]);
+
+  // Center camera on requested node (chat result selection).
+  useEffect(() => {
+    if (!focusNodeId || focusNodeToken <= 0) return;
+    const fg = fgRef.current;
+    if (!fg) return;
+
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 60;
+
+    const centerOnNode = () => {
+      if (cancelled || !fgRef.current) return;
+      attempts += 1;
+
+      const liveGraph = fgRef.current.graphData?.() as { nodes?: any[] } | undefined;
+      const nodes = liveGraph?.nodes || graphData.nodes;
+      const targetNode = nodes.find((n: any) => (n.id || n.uid) === focusNodeId);
+
+      if (!targetNode) return;
+
+      const x = Number(targetNode.x);
+      const y = Number(targetNode.y);
+      const z = Number(targetNode.z);
+
+      if (![x, y, z].every(Number.isFinite)) {
+        if (attempts < maxAttempts) requestAnimationFrame(centerOnNode);
+        return;
+      }
+
+      const camera = fgRef.current.camera?.();
+      const controls = fgRef.current.controls?.();
+      const camPos = camera?.position;
+      const currentTarget = controls?.target;
+
+      const offset = new THREE.Vector3(0, 0, cameraDistance);
+      if (camPos && currentTarget) {
+        offset.set(
+          camPos.x - currentTarget.x,
+          camPos.y - currentTarget.y,
+          camPos.z - currentTarget.z,
+        );
+      }
+      if (!Number.isFinite(offset.length()) || offset.length() < 1) {
+        offset.set(0, 0, cameraDistance);
+      }
+
+      fgRef.current.cameraPosition(
+        { x: x + offset.x, y: y + offset.y, z: z + offset.z },
+        { x, y, z },
+        900,
+      );
+    };
+
+    requestAnimationFrame(centerOnNode);
+    return () => { cancelled = true; };
+  }, [focusNodeId, focusNodeToken, graphData.nodes, cameraDistance]);
 
   const handleNodeHover = useCallback((node: any) => {
     setHoveredNode(node || null);

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -520,6 +520,7 @@ export default function OrbViewPage() {
   const [pendingImportFile, setPendingImportFile] = useState<File | null>(null);
   const [importing, setImporting] = useState(false);
   const [importStatus, setImportStatus] = useState('');
+  const [focusRequest, setFocusRequest] = useState<{ nodeUid: string; seq: number } | null>(null);
   const [extractedImport, setExtractedImport] = useState<{
     nodes: Array<{ node_type: string; properties: Record<string, unknown> }>;
     relationships: Array<{ from_index: number; to_index: number; type: string }>;
@@ -798,6 +799,13 @@ export default function OrbViewPage() {
 
   const handleSetVisibleNodeTypes = useCallback((visibleTypes: Set<string>) => {
     setHiddenNodeTypes(new Set(ALL_FILTERABLE_TYPES.filter((t) => !visibleTypes.has(t))));
+  }, []);
+
+  const handleFocusNode = useCallback((nodeUid: string) => {
+    setFocusRequest((prev) => ({
+      nodeUid,
+      seq: (prev?.seq ?? 0) + 1,
+    }));
   }, []);
 
   const doImport = useCallback(async (file: File) => {
@@ -1110,6 +1118,8 @@ export default function OrbViewPage() {
           width={dimensions.width}
           height={dimensions.height}
           cameraDistance={MY_ORBIS_CAMERA_DISTANCE}
+          focusNodeId={focusRequest?.nodeUid || null}
+          focusNodeToken={focusRequest?.seq ?? 0}
         />
       </div>
 
@@ -1141,6 +1151,7 @@ export default function OrbViewPage() {
       {/* ── Chat Box ── */}
       {!isPendingDeletion && <ChatBox
         onHighlight={setHighlightedNodeIds}
+        onFocusNode={handleFocusNode}
         highlightedNodeIds={highlightedNodeIds}
         messages={chatMessages}
         onMessagesChange={setChatMessages}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -807,6 +807,11 @@ export default function OrbViewPage() {
       seq: (prev?.seq ?? 0) + 1,
     }));
   }, []);
+  const personNodeId = ((data?.person?.user_id || data?.person?.orb_id) as string) || '';
+  const handleChatClear = useCallback(() => {
+    if (!personNodeId) return;
+    handleFocusNode(personNodeId);
+  }, [personNodeId, handleFocusNode]);
 
   const doImport = useCallback(async (file: File) => {
     setImporting(true);
@@ -1152,6 +1157,7 @@ export default function OrbViewPage() {
       {!isPendingDeletion && <ChatBox
         onHighlight={setHighlightedNodeIds}
         onFocusNode={handleFocusNode}
+        onClearResults={handleChatClear}
         highlightedNodeIds={highlightedNodeIds}
         messages={chatMessages}
         onMessagesChange={setChatMessages}


### PR DESCRIPTION
## Summary
This PR implements the UX improvement requested in #197:
- center the graph on the top match after a chat query
- center the graph on any node selected from the chat result list

It also includes the follow-up behavior fix:
- when chat results are closed/cleared, recenter the camera on the central (Person) node.

## What changed
### Chat → focus event wiring
- Added `onFocusNode` callback in `ChatBox`.
- Triggered focus on:
  - auto-selected first match (highest score)
  - any clicked result row.

### Orb view integration
- Added focus request state in `OrbViewPage` and passed it to `OrbGraph3D` via:
  - `focusNodeId`
  - `focusNodeToken` (sequence trigger)
- Added `onClearResults` callback from chat to recenter on Person node when chat closes.

### Graph camera behavior
- Added camera-centering effect in `OrbGraph3D`:
  - waits for node coordinates to be available
  - animates camera transition to place target node at center
  - keeps current camera offset direction where possible
- Paused idle auto-rotation while a highlight is active, so selected node stays centered.

## Validation
- `npx eslint src/components/chat/ChatBox.tsx src/pages/OrbViewPage.tsx src/components/graph/OrbGraph3D.tsx`
- `npx eslint src/components/chat/ChatBox.tsx src/pages/OrbViewPage.tsx`

(Only pre-existing warnings; no new lint errors.)

Closes #197
