### PR TITLE
feat: orb versioning with restore and undo/redo

### DIFF
--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -30,6 +30,7 @@ from app.graph.queries import (
     NODE_TYPE_RELATIONSHIPS,
     UPDATE_PERSON,
 )
+from app.snapshots.service import create_snapshot as create_orb_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -467,6 +468,17 @@ async def confirm_cv(
     """Persist confirmed CV nodes to Neo4j with dedup and cross-entity linking."""
     await _require_consent(current_user, db)
     user_id = current_user["user_id"]
+
+    # Auto-snapshot before destructive CV import
+    try:
+        await create_orb_snapshot(
+            user_id=user_id,
+            db=db,
+            trigger="cv_import",
+            label="Before CV import",
+        )
+    except Exception as e:
+        logger.warning("Failed to create pre-import snapshot: %s", e)
 
     if data.document_id:
         evict_oldest_if_at_limit(user_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.notes.router import router as notes_router
 from app.orbs.router import router as orbs_router
 from app.rate_limit import limiter
 from app.search.router import router as search_router
+from app.snapshots.db import delete_all_for_user as delete_user_snapshots
 
 logging.basicConfig(level=logging.INFO)
 
@@ -62,6 +63,12 @@ async def _cleanup_expired_accounts(driver):
             except Exception as e:
                 logging.getLogger(__name__).warning(
                     "Failed to delete drafts for %s: %s", user_id, e
+                )
+            try:
+                delete_user_snapshots(user_id)
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    "Failed to delete snapshots for %s: %s", user_id, e
                 )
 
     if expired:

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -34,6 +34,8 @@ from app.orbs.filter_token import (
 )
 from app.orbs.models import NodeCreate, NodeUpdate, OrbIdUpdate, PersonUpdate
 from app.rate_limit import limiter
+from app.snapshots import db as snap_db
+from app.snapshots.service import create_snapshot, restore_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -323,6 +325,60 @@ async def unlink_skill(
         if record is None:
             raise HTTPException(status_code=404, detail="Link not found")
         return {"status": "unlinked"}
+
+
+# ── Versions ──
+
+
+@router.get("/me/versions")
+async def list_versions(
+    current_user: dict = Depends(get_current_user),
+):
+    """List orb snapshots (metadata only, no data)."""
+    return snap_db.list_snapshots(current_user["user_id"])
+
+
+@router.post("/me/versions")
+async def create_version(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Manually create a snapshot of the current orb state."""
+    return await create_snapshot(
+        user_id=current_user["user_id"],
+        db=db,
+        trigger="manual",
+        label="Manual save",
+    )
+
+
+@router.post("/me/versions/{snapshot_id}/restore")
+async def restore_version(
+    snapshot_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Restore an orb from a snapshot. Current state is saved first."""
+    try:
+        return await restore_snapshot(
+            user_id=current_user["user_id"],
+            snapshot_id=snapshot_id,
+            db=db,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+
+@router.delete("/me/versions/{snapshot_id}")
+async def delete_version(
+    snapshot_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Delete a specific snapshot."""
+    deleted = snap_db.delete_snapshot(current_user["user_id"], snapshot_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+    return {"status": "deleted"}
 
 
 @router.post("/me/filter-token")

--- a/backend/app/snapshots/db.py
+++ b/backend/app/snapshots/db.py
@@ -1,0 +1,137 @@
+"""SQLite database for orb snapshot metadata and data."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_DB_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "cv_uploads.db"
+_conn: sqlite3.Connection | None = None
+
+MAX_SNAPSHOTS_PER_USER = 3
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+        _conn.row_factory = sqlite3.Row
+        _conn.execute("PRAGMA journal_mode=WAL")
+        _conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orb_snapshots (
+                snapshot_id TEXT NOT NULL,
+                user_id     TEXT NOT NULL,
+                created_at  TEXT NOT NULL,
+                trigger     TEXT NOT NULL,
+                label       TEXT,
+                node_count  INTEGER NOT NULL,
+                edge_count  INTEGER NOT NULL,
+                data        TEXT NOT NULL,
+                PRIMARY KEY (user_id, snapshot_id)
+            )
+            """
+        )
+        _conn.commit()
+    return _conn
+
+
+def insert_snapshot(
+    snapshot_id: str,
+    user_id: str,
+    trigger: str,
+    label: str | None,
+    node_count: int,
+    edge_count: int,
+    data: str,
+    now: str,
+) -> dict:
+    conn = _get_conn()
+    conn.execute(
+        """
+        INSERT INTO orb_snapshots
+            (snapshot_id, user_id, created_at, trigger, label,
+             node_count, edge_count, data)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (snapshot_id, user_id, now, trigger, label, node_count, edge_count, data),
+    )
+    conn.commit()
+    return {
+        "snapshot_id": snapshot_id,
+        "user_id": user_id,
+        "created_at": now,
+        "trigger": trigger,
+        "label": label,
+        "node_count": node_count,
+        "edge_count": edge_count,
+    }
+
+
+def list_snapshots(user_id: str) -> list[dict]:
+    conn = _get_conn()
+    rows = conn.execute(
+        "SELECT snapshot_id, user_id, created_at, trigger, label, "
+        "node_count, edge_count "
+        "FROM orb_snapshots WHERE user_id = ? ORDER BY created_at DESC",
+        (user_id,),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def get_snapshot(user_id: str, snapshot_id: str) -> dict | None:
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT snapshot_id, user_id, created_at, trigger, label, "
+        "node_count, edge_count, data "
+        "FROM orb_snapshots WHERE user_id = ? AND snapshot_id = ?",
+        (user_id, snapshot_id),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def count_snapshots(user_id: str) -> int:
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM orb_snapshots WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    return row[0]
+
+
+def delete_snapshot(user_id: str, snapshot_id: str) -> bool:
+    conn = _get_conn()
+    cur = conn.execute(
+        "DELETE FROM orb_snapshots WHERE user_id = ? AND snapshot_id = ?",
+        (user_id, snapshot_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0
+
+
+def delete_oldest_if_at_limit(user_id: str) -> dict | None:
+    if count_snapshots(user_id) < MAX_SNAPSHOTS_PER_USER:
+        return None
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT snapshot_id, user_id, created_at, trigger, label, "
+        "node_count, edge_count "
+        "FROM orb_snapshots WHERE user_id = ? ORDER BY created_at ASC LIMIT 1",
+        (user_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    oldest = dict(row)
+    delete_snapshot(user_id, oldest["snapshot_id"])
+    return oldest
+
+
+def delete_all_for_user(user_id: str) -> int:
+    conn = _get_conn()
+    cur = conn.execute(
+        "DELETE FROM orb_snapshots WHERE user_id = ?",
+        (user_id,),
+    )
+    conn.commit()
+    return cur.rowcount

--- a/backend/app/snapshots/service.py
+++ b/backend/app/snapshots/service.py
@@ -1,0 +1,257 @@
+"""Snapshot creation and restore logic for orb versioning."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import uuid
+
+from neo4j import AsyncDriver
+from neo4j.time import Date as Neo4jDate
+from neo4j.time import DateTime as Neo4jDateTime
+from neo4j.time import Time as Neo4jTime
+
+from app.graph.queries import (
+    ADD_NODE,
+    DELETE_USER_GRAPH,
+    GET_FULL_ORB,
+    LINK_SKILL,
+    NODE_TYPE_LABELS,
+    NODE_TYPE_RELATIONSHIPS,
+    UPDATE_PERSON,
+)
+from app.snapshots import db as snap_db
+
+logger = logging.getLogger(__name__)
+
+_LABEL_TO_TYPE: dict[str, str] = {v: k for k, v in NODE_TYPE_LABELS.items()}
+
+
+def _sanitize(d: dict) -> dict:
+    """Convert Neo4j temporal types to ISO strings; pass everything else through."""
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, (Neo4jDateTime, Neo4jDate, Neo4jTime)):
+            result[k] = v.iso_format()
+        else:
+            result[k] = v
+    return result
+
+
+def serialize_orb_raw(record) -> str:
+    """Serialize an orb record to JSON WITHOUT decrypting PII.
+
+    Raw encrypted values are preserved so snapshots can be restored
+    without access to the encryption key at read time.
+    """
+    person = _sanitize(dict(record["p"]))
+    nodes: list[dict] = []
+    links: list[dict] = []
+    seen: set[str] = set()
+
+    for conn in record["connections"]:
+        if conn["node"] is None:
+            continue
+        node_data = _sanitize(dict(conn["node"]))
+        uid = node_data.get("uid")
+        if uid and uid in seen:
+            continue
+        if uid:
+            seen.add(uid)
+        node_data.pop("embedding", None)
+        node_data["_labels"] = list(conn["node"].labels)
+        nodes.append(node_data)
+        links.append(
+            {
+                "source": person.get("user_id") or person.get("orb_id"),
+                "target": uid,
+                "type": conn["rel"],
+            }
+        )
+
+    for skill_node in record.get("cross_skill_nodes") or []:
+        if skill_node is None:
+            continue
+        skill_data = _sanitize(dict(skill_node))
+        uid = skill_data.get("uid")
+        if uid and uid in seen:
+            continue
+        if uid:
+            seen.add(uid)
+        skill_data.pop("embedding", None)
+        skill_data["_labels"] = list(skill_node.labels)
+        nodes.append(skill_data)
+        links.append(
+            {
+                "source": person.get("user_id") or person.get("orb_id"),
+                "target": uid,
+                "type": "HAS_SKILL",
+            }
+        )
+
+    seen_links: set[tuple] = set()
+    for cl in record.get("cross_links") or []:
+        src, tgt = cl.get("source"), cl.get("target")
+        if src and tgt and src in seen and tgt in seen:
+            key = (src, tgt, cl.get("rel", ""))
+            if key not in seen_links:
+                seen_links.add(key)
+                links.append(
+                    {
+                        "source": src,
+                        "target": tgt,
+                        "type": cl.get("rel", "USED_SKILL"),
+                    }
+                )
+
+    return json.dumps({"person": person, "nodes": nodes, "links": links})
+
+
+def count_from_serialized(data: str) -> tuple[int, int]:
+    """Return (node_count, edge_count) from a serialized orb JSON string."""
+    parsed = json.loads(data)
+    return len(parsed.get("nodes", [])), len(parsed.get("links", []))
+
+
+async def create_snapshot(
+    user_id: str,
+    db: AsyncDriver,
+    trigger: str,
+    label: str | None = None,
+) -> dict:
+    """Fetch the current orb from Neo4j and store a snapshot in SQLite."""
+    from datetime import datetime, timezone
+
+    async with db.session() as session:
+        result = await session.run(GET_FULL_ORB, user_id=user_id)
+        record = await result.single()
+
+    if record is None:
+        raise ValueError(f"No orb found for user {user_id}")
+
+    data = serialize_orb_raw(record)
+    node_count, edge_count = count_from_serialized(data)
+    snapshot_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    snap_db.delete_oldest_if_at_limit(user_id)
+
+    return snap_db.insert_snapshot(
+        snapshot_id=snapshot_id,
+        user_id=user_id,
+        trigger=trigger,
+        label=label,
+        node_count=node_count,
+        edge_count=edge_count,
+        data=data,
+        now=now,
+    )
+
+
+async def restore_snapshot(
+    user_id: str,
+    snapshot_id: str,
+    db: AsyncDriver,
+) -> dict:
+    """Restore a previously saved snapshot: wipe graph, recreate nodes."""
+    snap = snap_db.get_snapshot(user_id, snapshot_id)
+    if snap is None:
+        raise ValueError(f"Snapshot {snapshot_id} not found")
+
+    # Create a safety snapshot before wiping
+    with contextlib.suppress(ValueError):
+        await create_snapshot(
+            user_id=user_id,
+            db=db,
+            trigger="pre_restore",
+            label="Before restoring version",
+        )
+
+    async with db.session() as session:
+        await session.run(DELETE_USER_GRAPH, user_id=user_id)
+
+    parsed = json.loads(snap["data"])
+    await _restore_nodes(user_id, parsed, db)
+
+    return {"status": "restored", "snapshot_id": snapshot_id}
+
+
+async def _restore_nodes(
+    user_id: str,
+    parsed: dict,
+    db: AsyncDriver,
+) -> None:
+    """Recreate nodes and cross-links from parsed snapshot JSON."""
+    uid_map: dict[str, str] = {}
+
+    async with db.session() as session:
+        # Restore person profile fields
+        person_data = parsed.get("person", {})
+        profile_fields = {}
+        for key in (
+            "name",
+            "headline",
+            "location",
+            "email",
+            "phone",
+            "linkedin_url",
+            "github_url",
+            "twitter_url",
+            "instagram_url",
+            "scholar_url",
+            "website_url",
+            "orcid_url",
+            "open_to_work",
+            "cv_display_name",
+            "profile_image",
+        ):
+            if key in person_data and person_data[key]:
+                profile_fields[key] = person_data[key]
+        if profile_fields:
+            await session.run(
+                UPDATE_PERSON,
+                user_id=user_id,
+                properties=profile_fields,
+            )
+
+        # Restore child nodes
+        for node in parsed.get("nodes", []):
+            labels = node.get("_labels", [])
+            if not labels:
+                continue
+            label = labels[0]
+            node_type = _LABEL_TO_TYPE.get(label)
+            if node_type is None:
+                logger.warning("Skipping unknown node type: %s", label)
+                continue
+            rel_type = NODE_TYPE_RELATIONSHIPS[node_type]
+
+            old_uid = node.get("uid", str(uuid.uuid4()))
+            new_uid = old_uid
+
+            properties = {
+                k: v
+                for k, v in node.items()
+                if k not in ("_labels", "uid", "embedding") and v is not None
+            }
+
+            query = ADD_NODE.replace("{label}", label).replace("{rel_type}", rel_type)
+            await session.run(
+                query,
+                user_id=user_id,
+                properties=properties,
+                uid=new_uid,
+            )
+            uid_map[old_uid] = new_uid
+
+        # Restore cross-links (USED_SKILL)
+        for link in parsed.get("links", []):
+            if link.get("type") != "USED_SKILL":
+                continue
+            src = uid_map.get(link["source"], link["source"])
+            tgt = uid_map.get(link["target"], link["target"])
+            try:
+                await session.run(LINK_SKILL, node_uid=src, skill_uid=tgt)
+            except Exception as e:
+                logger.warning("Failed to restore link %s->%s: %s", src, tgt, e)

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -59,6 +59,10 @@ def test_confirm_cv_success(client, mock_db):
     result_mock_consent = MagicMock()
     result_mock_consent.single = AsyncMock(return_value={"consent": True})
 
+    # Auto-snapshot GET_FULL_ORB returns None (no existing orb), caught by try/except
+    result_mock_snapshot = MagicMock()
+    result_mock_snapshot.single = AsyncMock(return_value=None)
+
     result_mock_1 = MagicMock()
     result_mock_1.single = AsyncMock(return_value=None)
 
@@ -78,6 +82,7 @@ def test_confirm_cv_success(client, mock_db):
 
     run_mock.side_effect = [
         result_mock_consent,  # _require_consent
+        result_mock_snapshot,  # auto-snapshot GET_FULL_ORB (returns None -> ValueError caught)
         result_mock_1,  # DELETE_USER_GRAPH
         result_mock_2,  # UPDATE_PERSON
         result_mock_3,  # ADD_NODE 1
@@ -110,6 +115,10 @@ def test_confirm_cv_partial_link_failure(client, mock_db):
     res_consent = MagicMock()
     res_consent.single = AsyncMock(return_value={"consent": True})
 
+    # Auto-snapshot GET_FULL_ORB returns None (no existing orb), caught by try/except
+    res_snapshot = MagicMock()
+    res_snapshot.single = AsyncMock(return_value=None)
+
     res_ok = MagicMock()
     res_ok.single = AsyncMock(return_value=None)
 
@@ -123,6 +132,7 @@ def test_confirm_cv_partial_link_failure(client, mock_db):
 
     run_mock.side_effect = [
         res_consent,  # _require_consent
+        res_snapshot,  # auto-snapshot GET_FULL_ORB (returns None -> ValueError caught)
         res_ok,  # DELETE_USER_GRAPH
         res_node_1,  # MERGE (work_experience)
         res_node_2,  # MERGE (skill)

--- a/backend/tests/unit/test_snapshots_db.py
+++ b/backend/tests/unit/test_snapshots_db.py
@@ -1,0 +1,133 @@
+"""Unit tests for app.snapshots.db — SQLite snapshot metadata store."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.snapshots.db as snap_db
+
+_NOW = "2026-01-01T00:00:00"
+_DATA = '{"person":{},"nodes":[],"links":[]}'
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(monkeypatch, tmp_path):
+    db_file = tmp_path / "snapshots_test.db"
+    monkeypatch.setattr(snap_db, "_DB_PATH", db_file)
+    monkeypatch.setattr(snap_db, "_conn", None)
+    yield
+    if snap_db._conn is not None:
+        snap_db._conn.close()
+    monkeypatch.setattr(snap_db, "_conn", None)
+
+
+def test_insert_and_list():
+    snap_db.insert_snapshot(
+        snapshot_id="snap-1",
+        user_id="user-1",
+        trigger="manual",
+        label="Test save",
+        node_count=10,
+        edge_count=5,
+        data=_DATA,
+        now=_NOW,
+    )
+    snaps = snap_db.list_snapshots("user-1")
+    assert len(snaps) == 1
+    assert snaps[0]["snapshot_id"] == "snap-1"
+    assert snaps[0]["trigger"] == "manual"
+    assert snaps[0]["label"] == "Test save"
+    assert snaps[0]["node_count"] == 10
+    assert snaps[0]["edge_count"] == 5
+    assert "data" not in snaps[0]
+
+
+def test_list_ordered_by_date_desc():
+    snap_db.insert_snapshot(
+        "snap-old", "user-1", "manual", None, 5, 2, _DATA, "2026-01-01T00:00:00"
+    )
+    snap_db.insert_snapshot(
+        "snap-new", "user-1", "manual", None, 10, 4, _DATA, "2026-06-01T00:00:00"
+    )
+    snap_db.insert_snapshot(
+        "snap-mid", "user-1", "manual", None, 7, 3, _DATA, "2026-03-01T00:00:00"
+    )
+    snaps = snap_db.list_snapshots("user-1")
+    assert [s["snapshot_id"] for s in snaps] == ["snap-new", "snap-mid", "snap-old"]
+
+
+def test_get_snapshot_with_data():
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    snap = snap_db.get_snapshot("user-1", "snap-1")
+    assert snap is not None
+    assert snap["data"] == _DATA
+    assert snap["snapshot_id"] == "snap-1"
+
+
+def test_get_snapshot_nonexistent():
+    assert snap_db.get_snapshot("user-1", "no-such") is None
+
+
+def test_count_snapshots():
+    assert snap_db.count_snapshots("user-1") == 0
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    assert snap_db.count_snapshots("user-1") == 1
+    snap_db.insert_snapshot("snap-2", "user-1", "manual", None, 10, 4, _DATA, _NOW)
+    assert snap_db.count_snapshots("user-1") == 2
+
+
+def test_count_scoped_to_user():
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    snap_db.insert_snapshot("snap-2", "user-2", "manual", None, 10, 4, _DATA, _NOW)
+    assert snap_db.count_snapshots("user-1") == 1
+    assert snap_db.count_snapshots("user-2") == 1
+
+
+def test_delete_snapshot():
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    deleted = snap_db.delete_snapshot("user-1", "snap-1")
+    assert deleted is True
+    assert snap_db.count_snapshots("user-1") == 0
+
+
+def test_delete_snapshot_nonexistent():
+    assert snap_db.delete_snapshot("user-1", "no-such") is False
+
+
+def test_delete_oldest_if_at_limit():
+    snap_db.insert_snapshot(
+        "snap-old", "user-1", "manual", None, 5, 2, _DATA, "2026-01-01T00:00:00"
+    )
+    snap_db.insert_snapshot(
+        "snap-mid", "user-1", "manual", None, 7, 3, _DATA, "2026-03-01T00:00:00"
+    )
+    snap_db.insert_snapshot(
+        "snap-new", "user-1", "manual", None, 10, 4, _DATA, "2026-06-01T00:00:00"
+    )
+    evicted = snap_db.delete_oldest_if_at_limit("user-1")
+    assert evicted is not None
+    assert evicted["snapshot_id"] == "snap-old"
+    assert snap_db.count_snapshots("user-1") == 2
+
+
+def test_delete_oldest_under_limit():
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    evicted = snap_db.delete_oldest_if_at_limit("user-1")
+    assert evicted is None
+    assert snap_db.count_snapshots("user-1") == 1
+
+
+def test_delete_all_for_user():
+    snap_db.insert_snapshot("snap-1", "user-1", "manual", None, 5, 2, _DATA, _NOW)
+    snap_db.insert_snapshot("snap-2", "user-1", "manual", None, 10, 4, _DATA, _NOW)
+    snap_db.insert_snapshot("snap-3", "user-2", "manual", None, 15, 6, _DATA, _NOW)
+    count = snap_db.delete_all_for_user("user-1")
+    assert count == 2
+    assert snap_db.count_snapshots("user-1") == 0
+    assert snap_db.count_snapshots("user-2") == 1
+
+
+def test_nullable_label():
+    snap_db.insert_snapshot("snap-1", "user-1", "cv_import", None, 5, 2, _DATA, _NOW)
+    snaps = snap_db.list_snapshots("user-1")
+    assert snaps[0]["label"] is None

--- a/backend/tests/unit/test_snapshots_service.py
+++ b/backend/tests/unit/test_snapshots_service.py
@@ -1,0 +1,301 @@
+"""Unit tests for app.snapshots.service — snapshot creation and restore."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.snapshots.db as snap_db
+import app.snapshots.service as snap_service
+from tests.unit.conftest import MockNode
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(monkeypatch, tmp_path):
+    db_file = tmp_path / "snapshots_test.db"
+    monkeypatch.setattr(snap_db, "_DB_PATH", db_file)
+    monkeypatch.setattr(snap_db, "_conn", None)
+    yield
+    if snap_db._conn is not None:
+        snap_db._conn.close()
+    monkeypatch.setattr(snap_db, "_conn", None)
+
+
+# ── Helpers ──
+
+
+def _make_orb_record():
+    person = MockNode(
+        {"user_id": "user-1", "name": "Test User", "email": "enc:test@example.com"},
+        ["Person"],
+    )
+    skill = MockNode({"uid": "skill-1", "name": "Python"}, ["Skill"])
+    work = MockNode(
+        {"uid": "work-1", "company": "Acme", "title": "Dev"},
+        ["WorkExperience"],
+    )
+    return {
+        "p": person,
+        "connections": [
+            {"node": skill, "rel": "HAS_SKILL"},
+            {"node": work, "rel": "HAS_WORK_EXPERIENCE"},
+        ],
+        "cross_skill_nodes": [],
+        "cross_links": [
+            {"source": "work-1", "target": "skill-1", "rel": "USED_SKILL"},
+        ],
+    }
+
+
+def _mock_db_with_record(record):
+    """Build a MagicMock AsyncDriver whose session().run().single() returns *record*."""
+    mock_session = AsyncMock()
+    mock_session.run.return_value.single = AsyncMock(return_value=record)
+
+    mock_db = MagicMock()
+    mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_db, mock_session
+
+
+# ── serialize_orb_raw ──
+
+
+def test_serialize_orb_raw_preserves_encrypted_pii():
+    record = _make_orb_record()
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    # The encrypted email must be preserved verbatim — not decrypted
+    assert parsed["person"]["email"] == "enc:test@example.com"
+    assert parsed["person"]["name"] == "Test User"
+
+
+def test_serialize_orb_raw_nodes_and_links():
+    record = _make_orb_record()
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    assert len(parsed["nodes"]) == 2
+    # 2 direct links (person→skill, person→work) + 1 cross-link (work→skill)
+    assert len(parsed["links"]) == 3
+
+
+def test_serialize_orb_raw_stores_labels():
+    record = _make_orb_record()
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    labels = {tuple(n["_labels"]) for n in parsed["nodes"]}
+    assert ("Skill",) in labels
+    assert ("WorkExperience",) in labels
+
+
+def test_serialize_orb_raw_strips_embedding():
+    """Embeddings should be removed — they are large and regenerated."""
+    person = MockNode({"user_id": "u1", "name": "X"}, ["Person"])
+    node_with_embed = MockNode(
+        {"uid": "n1", "name": "Foo", "embedding": [0.1, 0.2, 0.3]},
+        ["Skill"],
+    )
+    record = {
+        "p": person,
+        "connections": [{"node": node_with_embed, "rel": "HAS_SKILL"}],
+        "cross_skill_nodes": [],
+        "cross_links": [],
+    }
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    assert "embedding" not in parsed["nodes"][0]
+
+
+def test_serialize_orb_raw_deduplicates_nodes():
+    """Nodes seen via connections should not appear again from cross_skill_nodes."""
+    person = MockNode({"user_id": "u1", "name": "X"}, ["Person"])
+    skill = MockNode({"uid": "s1", "name": "Python"}, ["Skill"])
+    record = {
+        "p": person,
+        "connections": [{"node": skill, "rel": "HAS_SKILL"}],
+        "cross_skill_nodes": [skill],  # same node duplicated
+        "cross_links": [],
+    }
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    assert len(parsed["nodes"]) == 1
+
+
+def test_serialize_orb_raw_skips_none_nodes():
+    person = MockNode({"user_id": "u1", "name": "X"}, ["Person"])
+    record = {
+        "p": person,
+        "connections": [{"node": None, "rel": "HAS_SKILL"}],
+        "cross_skill_nodes": [None],
+        "cross_links": [],
+    }
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    assert len(parsed["nodes"]) == 0
+
+
+def test_serialize_orb_raw_empty_orb():
+    person = MockNode({"user_id": "u1", "name": "Empty"}, ["Person"])
+    record = {
+        "p": person,
+        "connections": [],
+        "cross_skill_nodes": [],
+        "cross_links": [],
+    }
+    data = snap_service.serialize_orb_raw(record)
+    parsed = json.loads(data)
+    assert parsed["person"]["name"] == "Empty"
+    assert parsed["nodes"] == []
+    assert parsed["links"] == []
+
+
+# ── count_from_serialized ──
+
+
+def test_count_from_serialized():
+    record = _make_orb_record()
+    data = snap_service.serialize_orb_raw(record)
+    node_count, edge_count = snap_service.count_from_serialized(data)
+    assert node_count == 2
+    assert edge_count == 3
+
+
+# ── create_snapshot ──
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot():
+    record = _make_orb_record()
+    mock_db, _ = _mock_db_with_record(record)
+
+    result = await snap_service.create_snapshot(
+        user_id="user-1",
+        db=mock_db,
+        trigger="manual",
+        label="Test save",
+    )
+    assert result["trigger"] == "manual"
+    assert result["label"] == "Test save"
+    assert result["node_count"] == 2
+    assert snap_db.count_snapshots("user-1") == 1
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot_empty_orb():
+    person = MockNode({"user_id": "user-1", "name": "Empty User"}, ["Person"])
+    record = {
+        "p": person,
+        "connections": [],
+        "cross_skill_nodes": [],
+        "cross_links": [],
+    }
+    mock_db, _ = _mock_db_with_record(record)
+
+    result = await snap_service.create_snapshot(
+        user_id="user-1",
+        db=mock_db,
+        trigger="manual",
+    )
+    assert result["node_count"] == 0
+    assert result["edge_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot_no_orb_raises():
+    mock_db, _ = _mock_db_with_record(None)  # no record
+    with pytest.raises(ValueError, match="No orb found"):
+        await snap_service.create_snapshot(
+            user_id="no-user", db=mock_db, trigger="manual"
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot_evicts_oldest():
+    """When at the limit, the oldest snapshot should be evicted."""
+    record = _make_orb_record()
+    mock_db, _ = _mock_db_with_record(record)
+
+    for i in range(snap_db.MAX_SNAPSHOTS_PER_USER):
+        await snap_service.create_snapshot(
+            user_id="user-1", db=mock_db, trigger="manual", label=f"v{i}"
+        )
+    assert snap_db.count_snapshots("user-1") == snap_db.MAX_SNAPSHOTS_PER_USER
+
+    # One more should evict the oldest
+    await snap_service.create_snapshot(
+        user_id="user-1", db=mock_db, trigger="manual", label="new"
+    )
+    assert snap_db.count_snapshots("user-1") == snap_db.MAX_SNAPSHOTS_PER_USER
+
+
+# ── restore_snapshot ──
+
+
+@pytest.mark.asyncio
+async def test_restore_snapshot():
+    record = _make_orb_record()
+    mock_db, mock_session = _mock_db_with_record(record)
+
+    snap = await snap_service.create_snapshot(
+        user_id="user-1", db=mock_db, trigger="manual", label="Before"
+    )
+    snapshot_id = snap["snapshot_id"]
+
+    result = await snap_service.restore_snapshot(
+        user_id="user-1", snapshot_id=snapshot_id, db=mock_db
+    )
+    assert result["status"] == "restored"
+    assert result["snapshot_id"] == snapshot_id
+
+    # The session should have run DELETE_USER_GRAPH and then ADD_NODE queries
+    calls = mock_session.run.call_args_list
+    assert len(calls) > 1  # at least read + delete + node creation
+
+
+@pytest.mark.asyncio
+async def test_restore_snapshot_not_found():
+    record = _make_orb_record()
+    mock_db, _ = _mock_db_with_record(record)
+
+    with pytest.raises(ValueError, match="not found"):
+        await snap_service.restore_snapshot(
+            user_id="user-1", snapshot_id="no-such", db=mock_db
+        )
+
+
+@pytest.mark.asyncio
+async def test_restore_creates_pre_restore_snapshot():
+    """Restoring should first create a pre_restore snapshot."""
+    record = _make_orb_record()
+    mock_db, _ = _mock_db_with_record(record)
+
+    snap = await snap_service.create_snapshot(
+        user_id="user-1", db=mock_db, trigger="manual"
+    )
+    assert snap_db.count_snapshots("user-1") == 1
+
+    await snap_service.restore_snapshot(
+        user_id="user-1", snapshot_id=snap["snapshot_id"], db=mock_db
+    )
+    # Should now have the original + a pre_restore snapshot
+    assert snap_db.count_snapshots("user-1") == 2
+    snaps = snap_db.list_snapshots("user-1")
+    triggers = {s["trigger"] for s in snaps}
+    assert "pre_restore" in triggers
+
+
+# ── _sanitize (neo4j temporal types) ──
+
+
+def test_sanitize_neo4j_date():
+    from neo4j.time import Date as Neo4jDate
+
+    result = snap_service._sanitize({"started": Neo4jDate(2024, 1, 15)})
+    assert result["started"] == "2024-01-15"
+
+
+def test_sanitize_passthrough():
+    result = snap_service._sanitize({"name": "Alice", "count": 42})
+    assert result == {"name": "Alice", "count": 42}

--- a/docs/api.md
+++ b/docs/api.md
@@ -98,6 +98,33 @@ When `document_id` is provided, the confirm endpoint records document metadata (
 ]
 ```
 
+## Versions (`/orbs/me/versions`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/orbs/me/versions` | JWT | List orb snapshots (metadata only, up to 3, ordered by date desc) |
+| POST | `/orbs/me/versions` | JWT | Manually save current orb state as a snapshot |
+| POST | `/orbs/me/versions/{snapshot_id}/restore` | JWT | Restore orb from a snapshot (current state saved first) |
+| DELETE | `/orbs/me/versions/{snapshot_id}` | JWT | Delete a specific snapshot |
+
+Snapshots are automatically created before destructive CV imports (`POST /cv/confirm`). Up to 3 snapshots per user; oldest is evicted when a 4th is created. Restoring always saves the current state first so the restore is undoable.
+
+### Snapshot Metadata Response (`GET /orbs/me/versions`)
+
+```json
+[
+  {
+    "snapshot_id": "uuid",
+    "user_id": "user-id",
+    "created_at": "2026-04-09T12:00:00+00:00",
+    "trigger": "cv_import",
+    "label": "Before CV import",
+    "node_count": 42,
+    "edge_count": 15
+  }
+]
+```
+
 ## Export (`/export`)
 
 | Method | Path | Auth | Rate Limit | Description |

--- a/docs/database.md
+++ b/docs/database.md
@@ -131,6 +131,27 @@ Encrypted document files are stored on disk at `backend/data/cv_files/{user_id}_
 
 **Migration:** On first connection, if the old `cv_uploads` table exists (single row per user), rows are migrated to `cv_documents` with generated UUIDs and NULL entities/edges counts.
 
+## SQLite — Orb Snapshots
+
+Orb version snapshots are stored in the same SQLite database (`backend/data/cv_uploads.db`).
+
+### `orb_snapshots` Table
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `snapshot_id` | TEXT | UUID |
+| `user_id` | TEXT | Links to Person node |
+| `created_at` | TEXT | ISO timestamp |
+| `trigger` | TEXT | What caused it: "cv_import", "manual", "pre_restore" |
+| `label` | TEXT | Nullable — user-facing label, e.g. "Before CV import" |
+| `node_count` | INTEGER | Total nodes at time of snapshot |
+| `edge_count` | INTEGER | Total edges at time of snapshot |
+| `data` | TEXT | JSON-serialized graph (person + nodes + links) |
+
+Primary key: `(user_id, snapshot_id)`. Maximum 3 snapshots per user — oldest evicted when a 4th is created. PII fields are stored encrypted as-is (no decrypt/re-encrypt on restore).
+
+Auto-created before destructive CV imports. Manually creatable from Settings > Versions tab.
+
 ## Constraints and Indexes
 
 Defined in `infra/neo4j/init.cypher`:

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -117,3 +117,32 @@ export async function enhanceNote(
   return data;
 }
 
+// ── Versions ──
+
+export interface SnapshotMetadata {
+  snapshot_id: string;
+  user_id: string;
+  created_at: string;
+  trigger: string;
+  label: string | null;
+  node_count: number;
+  edge_count: number;
+}
+
+export async function getVersions(): Promise<SnapshotMetadata[]> {
+  const { data } = await client.get('/orbs/me/versions');
+  return data;
+}
+
+export async function createVersion(): Promise<SnapshotMetadata> {
+  const { data } = await client.post('/orbs/me/versions');
+  return data;
+}
+
+export async function restoreVersion(snapshotId: string): Promise<void> {
+  await client.post(`/orbs/me/versions/${snapshotId}/restore`);
+}
+
+export async function deleteVersion(snapshotId: string): Promise<void> {
+  await client.delete(`/orbs/me/versions/${snapshotId}`);
+}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -5,7 +5,8 @@ import { createPortal } from 'react-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
-import { claimOrbId } from '../api/orbs';
+import { claimOrbId, getVersions, createVersion, restoreVersion, deleteVersion } from '../api/orbs';
+import type { SnapshotMetadata } from '../api/orbs';
 import { getDocuments, downloadCV } from '../api/cv';
 import type { DocumentMetadata } from '../api/cv';
 
@@ -232,7 +233,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
   onOrbIdChanged?: () => void;
   onClose: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState<'orb-id' | 'account'>('orb-id');
+  const [activeTab, setActiveTab] = useState<'orb-id' | 'versions' | 'account'>('orb-id');
   const { user, logout } = useAuthStore();
   const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
@@ -243,9 +244,63 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
 
+  // Versions state
+  const [versions, setVersions] = useState<SnapshotMetadata[]>([]);
+  const [versionsLoading, setVersionsLoading] = useState(false);
+  const [restoreConfirm, setRestoreConfirm] = useState<SnapshotMetadata | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [savingVersion, setSavingVersion] = useState(false);
+
   // Delete account state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  const fetchVersions = useCallback(async () => {
+    setVersionsLoading(true);
+    try {
+      const v = await getVersions();
+      setVersions(v);
+    } catch { /* ignore */ }
+    finally { setVersionsLoading(false); }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'versions') fetchVersions();
+  }, [activeTab, fetchVersions]);
+
+  const handleSaveVersion = async () => {
+    setSavingVersion(true);
+    try {
+      await createVersion();
+      addToast('Version saved', 'success');
+      await fetchVersions();
+    } catch {
+      addToast('Failed to save version', 'error');
+    } finally { setSavingVersion(false); }
+  };
+
+  const handleRestore = async (snap: SnapshotMetadata) => {
+    setRestoring(true);
+    try {
+      await restoreVersion(snap.snapshot_id);
+      addToast('Orb restored to previous version', 'success');
+      setRestoreConfirm(null);
+      onClose();
+      window.location.reload();
+    } catch {
+      addToast('Failed to restore version', 'error');
+    } finally { setRestoring(false); }
+  };
+
+  const handleDeleteVersion = async (snapshotId: string) => {
+    try {
+      await deleteVersion(snapshotId);
+      await fetchVersions();
+      addToast('Version deleted', 'success');
+    } catch {
+      addToast('Failed to delete version', 'error');
+    }
+  };
 
   const handleSaveOrbId = async () => {
     const trimmed = customId.trim().toLowerCase();
@@ -298,6 +353,11 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101" />
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.172 13.828a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.102 1.101" />
+      </svg>
+    )},
+    { id: 'versions' as const, label: 'Versions', icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     )},
     { id: 'account' as const, label: 'Account', icon: (
@@ -392,6 +452,103 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                     <button onClick={handleSaveOrbId} disabled={saving} className="flex-1 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-medium py-2 rounded-lg transition-colors text-sm cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300">{saving ? 'Saving...' : 'Save'}</button>
                     <button onClick={onClose} className="flex-1 border border-white/15 text-white/75 hover:bg-white/10 font-medium py-2 rounded-lg transition-colors text-sm cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40">Cancel</button>
                   </div>
+                </motion.div>
+              )}
+
+              {/* ── Versions tab ── */}
+              {activeTab === 'versions' && (
+                <motion.div
+                  key="versions"
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -8 }}
+                  transition={{ duration: 0.15, ease: 'easeInOut' }}
+                  className="flex flex-col h-full"
+                >
+                  <p className="text-[11px] text-gray-500 mb-3">
+                    Your orb is automatically saved before major changes like CV imports.
+                  </p>
+
+                  <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+                    {versionsLoading ? (
+                      <p className="text-white/30 text-xs py-4 text-center">Loading versions...</p>
+                    ) : versions.length === 0 ? (
+                      <p className="text-white/30 text-xs py-4 text-center">No saved versions yet.</p>
+                    ) : (
+                      versions.map((snap) => (
+                        <div key={snap.snapshot_id} className="bg-white/[0.03] border border-white/[0.06] rounded-xl px-3 py-2.5">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <div className="text-white/70 text-sm font-medium">
+                                {snap.label || (snap.trigger === 'cv_import' ? 'Before CV import' : snap.trigger === 'pre_restore' ? 'Before restore' : 'Manual save')}
+                              </div>
+                              <div className="text-white/30 text-xs mt-0.5">
+                                {new Date(snap.created_at).toLocaleString()} · {snap.node_count} nodes · {snap.edge_count} edges
+                              </div>
+                            </div>
+                          </div>
+                          <div className="flex gap-2 mt-2">
+                            <button
+                              onClick={() => setRestoreConfirm(snap)}
+                              className="text-xs text-purple-400 hover:text-purple-300 font-medium cursor-pointer"
+                            >
+                              Restore
+                            </button>
+                            <button
+                              onClick={() => handleDeleteVersion(snap.snapshot_id)}
+                              className="text-xs text-white/30 hover:text-red-400 font-medium cursor-pointer"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  <div className="mt-3 pt-3 border-t border-white/5">
+                    <button
+                      onClick={handleSaveVersion}
+                      disabled={savingVersion}
+                      className="w-full bg-purple-600/20 hover:bg-purple-600/30 border border-purple-500/30 text-purple-300 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+                    >
+                      {savingVersion ? 'Saving...' : 'Save current version'}
+                    </button>
+                    <p className="text-white/20 text-[10px] mt-2 text-center">
+                      Up to 3 versions are kept. Oldest are automatically removed.
+                    </p>
+                  </div>
+
+                  {restoreConfirm && (
+                    <div className="absolute inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center rounded-2xl">
+                      <div className="bg-neutral-950 border border-white/10 rounded-xl p-5 max-w-sm w-full mx-4">
+                        <h3 className="text-white text-sm font-semibold mb-2">Restore this version?</h3>
+                        <p className="text-white/50 text-xs leading-relaxed mb-1">
+                          This will replace your current orb with the version from{' '}
+                          <span className="text-white font-medium">{new Date(restoreConfirm.created_at).toLocaleString()}</span>{' '}
+                          ({restoreConfirm.node_count} nodes).
+                        </p>
+                        <p className="text-white/40 text-xs mb-4">
+                          Your current orb will be saved as a new version before restoring.
+                        </p>
+                        <div className="flex gap-2 justify-end">
+                          <button
+                            onClick={() => setRestoreConfirm(null)}
+                            className="border border-white/10 text-white/60 hover:text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            onClick={() => handleRestore(restoreConfirm)}
+                            disabled={restoring}
+                            className="bg-purple-600 hover:bg-purple-500 text-white text-xs font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+                          >
+                            {restoring ? 'Restoring...' : 'Restore'}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </motion.div>
               )}
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -944,7 +944,7 @@ export default function OrbViewPage() {
                 <span className="text-white font-bold text-sm tracking-tight hidden sm:inline">OpenOrbis</span>
               </div>
               <div className="hidden sm:block w-px h-5 bg-white/10" />
-              <span className="text-white/25 text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
+              <span className="text-white text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
 
               {!isPendingDeletion && (
                 <div className="hidden sm:flex items-center gap-1.5 ml-2">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -21,6 +21,7 @@ import ProcessingCounter from '../components/cv/ProcessingCounter';
 import KeywordFilterDropdown from '../components/cv/KeywordFilterDropdown';
 import UserMenu from '../components/UserMenu';
 import { useToastStore } from '../stores/toastStore';
+import { useUndoStore } from '../stores/undoStore';
 import { getDocuments, confirmImport } from '../api/cv';
 import type { DocumentMetadata } from '../api/cv';
 
@@ -490,12 +491,29 @@ function HeaderBtn({ onClick, children, variant = 'ghost' }: {
 const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach'];
 const MY_ORBIS_CAMERA_DISTANCE = 200;
 
+const LABEL_TO_TYPE: Record<string, string> = {
+  Education: 'education',
+  WorkExperience: 'work_experience',
+  Certification: 'certification',
+  Language: 'language',
+  Publication: 'publication',
+  Project: 'project',
+  Skill: 'skill',
+  Patent: 'patent',
+  Award: 'award',
+  Outreach: 'outreach',
+};
+
 // ── Page ──
 
 export default function OrbViewPage() {
   const { data, loading, fetchOrb, addNode, updateNode, deleteNode } = useOrbStore();
   const { user } = useAuthStore();
   const addToast = useToastStore((s) => s.addToast);
+  const undoStack = useUndoStore((s) => s.undoStack);
+  const redoStack = useUndoStore((s) => s.redoStack);
+  const undo = useUndoStore((s) => s.undo);
+  const redo = useUndoStore((s) => s.redo);
   const isPendingDeletion = user?.deletion_days_remaining != null;
   const [showInput, setShowInput] = useState(false);
   const [showShare, setShowShare] = useState(false);
@@ -813,6 +831,24 @@ export default function OrbViewPage() {
     handleFocusNode(personNodeId);
   }, [personNodeId, handleFocusNode]);
 
+  const handleUndo = useCallback(async () => {
+    try {
+      await undo();
+      await fetchOrb();
+    } catch {
+      addToast('Failed to undo', 'error');
+    }
+  }, [undo, fetchOrb, addToast]);
+
+  const handleRedo = useCallback(async () => {
+    try {
+      await redo();
+      await fetchOrb();
+    } catch {
+      addToast('Failed to redo', 'error');
+    }
+  }, [redo, fetchOrb, addToast]);
+
   const doImport = useCallback(async (file: File) => {
     setImporting(true);
     setImportStatus('Reading PDF');
@@ -912,6 +948,37 @@ export default function OrbViewPage() {
 
               {!isPendingDeletion && (
                 <div className="hidden sm:flex items-center gap-1.5 ml-2">
+                  {/* Undo / Redo */}
+                  <div className="flex items-center">
+                    <button
+                      onClick={handleUndo}
+                      disabled={undoStack.length === 0}
+                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
+                        undoStack.length === 0
+                          ? 'text-white/15 cursor-default'
+                          : 'text-white/40 hover:text-white hover:bg-white/10'
+                      }`}
+                      title="Undo"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={handleRedo}
+                      disabled={redoStack.length === 0}
+                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
+                        redoStack.length === 0
+                          ? 'text-white/15 cursor-default'
+                          : 'text-white/40 hover:text-white hover:bg-white/10'
+                      }`}
+                      title="Redo"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 10H11a5 5 0 00-5 5v2M21 10l-4-4M21 10l-4 4" />
+                      </svg>
+                    </button>
+                  </div>
                   <NodeTypeFilter
                     hiddenTypes={hiddenNodeTypes}
                     onShowAll={handleShowAllNodeTypes}
@@ -983,6 +1050,37 @@ export default function OrbViewPage() {
 
                   {showToolsMenu && (
                     <div className="absolute right-0 top-full mt-2 w-64 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl p-3 space-y-2">
+                      {/* Undo / Redo (mobile) */}
+                      <div className="flex items-center gap-1 mb-2">
+                        <button
+                          onClick={handleUndo}
+                          disabled={undoStack.length === 0}
+                          className={`flex-1 flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border transition-all ${
+                            undoStack.length === 0
+                              ? 'border-white/5 text-white/20 cursor-default'
+                              : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10 cursor-pointer'
+                          }`}
+                        >
+                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+                          </svg>
+                          Undo
+                        </button>
+                        <button
+                          onClick={handleRedo}
+                          disabled={redoStack.length === 0}
+                          className={`flex-1 flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border transition-all ${
+                            redoStack.length === 0
+                              ? 'border-white/5 text-white/20 cursor-default'
+                              : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10 cursor-pointer'
+                          }`}
+                        >
+                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 10H11a5 5 0 00-5 5v2M21 10l-4-4M21 10l-4 4" />
+                          </svg>
+                          Redo
+                        </button>
+                      </div>
                       <p className="text-[10px] uppercase tracking-[0.12em] text-white/35 font-semibold px-1">View & Data</p>
                       <div className="flex items-center justify-between px-1">
                         <span className="text-xs text-white/65">Node types</span>
@@ -1137,7 +1235,18 @@ export default function OrbViewPage() {
         onSubmit={handleSubmit}
         onCancel={() => { setShowInput(false); setEditNode(null); setPendingSkillLinks([]); setPendingDraftNoteId(null); setPendingDraftRawText(''); }}
         onDelete={async (uid) => {
-          await deleteNode(uid);
+          const nodeToDelete = data?.nodes.find(n => n.uid === uid);
+          const nodeTypeKey = nodeToDelete?._labels?.[0] ? LABEL_TO_TYPE[nodeToDelete._labels[0]] || '' : '';
+          const nodeProps: Record<string, unknown> = {};
+          if (nodeToDelete) {
+            for (const [k, v] of Object.entries(nodeToDelete)) {
+              if (!['uid', '_labels', 'score', 'embedding'].includes(k)) nodeProps[k] = v;
+            }
+          }
+          const nodeRelationships = data?.links
+            .filter(l => l.type === 'USED_SKILL' && (l.source === uid || l.target === uid))
+            .map(l => ({ source: l.source, target: l.target, type: l.type }));
+          await deleteNode(uid, nodeTypeKey, nodeProps, nodeRelationships);
           setShowInput(false);
           setEditNode(null);
         }}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -955,8 +955,8 @@ export default function OrbViewPage() {
                       disabled={undoStack.length === 0}
                       className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
                         undoStack.length === 0
-                          ? 'text-white/15 cursor-default'
-                          : 'text-white/40 hover:text-white hover:bg-white/10'
+                          ? 'text-teal-500/20 cursor-default'
+                          : 'text-teal-400 hover:text-teal-300 hover:bg-teal-500/10'
                       }`}
                       title="Undo"
                     >
@@ -969,8 +969,8 @@ export default function OrbViewPage() {
                       disabled={redoStack.length === 0}
                       className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
                         redoStack.length === 0
-                          ? 'text-white/15 cursor-default'
-                          : 'text-white/40 hover:text-white hover:bg-white/10'
+                          ? 'text-sky-500/20 cursor-default'
+                          : 'text-sky-400 hover:text-sky-300 hover:bg-sky-500/10'
                       }`}
                       title="Redo"
                     >
@@ -1057,8 +1057,8 @@ export default function OrbViewPage() {
                           disabled={undoStack.length === 0}
                           className={`flex-1 flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border transition-all ${
                             undoStack.length === 0
-                              ? 'border-white/5 text-white/20 cursor-default'
-                              : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10 cursor-pointer'
+                              ? 'border-teal-500/10 text-teal-500/20 cursor-default'
+                              : 'border-teal-500/30 text-teal-400 hover:text-teal-300 hover:bg-teal-500/10 cursor-pointer'
                           }`}
                         >
                           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1071,8 +1071,8 @@ export default function OrbViewPage() {
                           disabled={redoStack.length === 0}
                           className={`flex-1 flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border transition-all ${
                             redoStack.length === 0
-                              ? 'border-white/5 text-white/20 cursor-default'
-                              : 'border-white/10 text-white/70 hover:text-white hover:bg-white/10 cursor-pointer'
+                              ? 'border-sky-500/10 text-sky-500/20 cursor-default'
+                              : 'border-sky-500/30 text-sky-400 hover:text-sky-300 hover:bg-sky-500/10 cursor-pointer'
                           }`}
                         >
                           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/stores/orbStore.ts
+++ b/frontend/src/stores/orbStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import * as orbsApi from '../api/orbs';
 import type { OrbData, OrbNode } from '../api/orbs';
 import { useToastStore } from './toastStore';
+import { useUndoStore } from './undoStore';
 
 interface OrbState {
   data: OrbData | null;
@@ -11,7 +12,7 @@ interface OrbState {
   fetchPublicOrb: (orbId: string, filterToken?: string) => Promise<void>;
   addNode: (nodeType: string, properties: Record<string, unknown>) => Promise<OrbNode>;
   updateNode: (uid: string, properties: Record<string, unknown>) => Promise<void>;
-  deleteNode: (uid: string) => Promise<void>;
+  deleteNode: (uid: string, nodeType?: string, properties?: Record<string, unknown>, relationships?: Array<{ source: string; target: string; type: string }>) => Promise<void>;
 }
 
 export const useOrbStore = create<OrbState>((set, get) => ({
@@ -44,6 +45,12 @@ export const useOrbStore = create<OrbState>((set, get) => ({
       const node = await orbsApi.addNode(nodeType, properties);
       await get().fetchOrb();
       useToastStore.getState().addToast('Entry added to your orbis', 'success');
+      useUndoStore.getState().pushUndo({
+        type: 'add',
+        nodeUid: node.uid,
+        nodeType,
+        properties,
+      });
       return node;
     } catch (e) {
       useToastStore.getState().addToast('Failed to add entry', 'error');
@@ -62,11 +69,20 @@ export const useOrbStore = create<OrbState>((set, get) => ({
     }
   },
 
-  deleteNode: async (uid: string) => {
+  deleteNode: async (uid: string, nodeType?: string, properties?: Record<string, unknown>, relationships?: Array<{ source: string; target: string; type: string }>) => {
     try {
       await orbsApi.deleteNode(uid);
       await get().fetchOrb();
       useToastStore.getState().addToast('Entry deleted', 'success');
+      if (nodeType && properties) {
+        useUndoStore.getState().pushUndo({
+          type: 'delete',
+          nodeUid: uid,
+          nodeType,
+          properties,
+          relationships,
+        });
+      }
     } catch (e) {
       useToastStore.getState().addToast('Failed to delete entry', 'error');
       throw e;

--- a/frontend/src/stores/undoStore.ts
+++ b/frontend/src/stores/undoStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand';
+import * as orbsApi from '../api/orbs';
+
+interface UndoEntry {
+  type: 'add' | 'delete';
+  nodeUid: string;
+  nodeType: string;
+  properties: Record<string, unknown>;
+  relationships?: Array<{ source: string; target: string; type: string }>;
+}
+
+interface UndoState {
+  undoStack: UndoEntry[];
+  redoStack: UndoEntry[];
+  pushUndo: (entry: UndoEntry) => void;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+  clear: () => void;
+}
+
+export const useUndoStore = create<UndoState>((set, get) => ({
+  undoStack: [],
+  redoStack: [],
+
+  pushUndo: (entry: UndoEntry) => {
+    set((state) => ({
+      undoStack: [...state.undoStack, entry],
+      redoStack: [],
+    }));
+  },
+
+  undo: async () => {
+    const { undoStack } = get();
+    if (undoStack.length === 0) return;
+
+    const entry = undoStack[undoStack.length - 1];
+
+    if (entry.type === 'add') {
+      await orbsApi.deleteNode(entry.nodeUid);
+    } else {
+      const node = await orbsApi.addNode(entry.nodeType, entry.properties);
+      if (entry.relationships) {
+        for (const rel of entry.relationships) {
+          if (rel.type === 'USED_SKILL') {
+            try {
+              await orbsApi.linkSkill(node.uid, rel.target);
+            } catch { /* best effort */ }
+          }
+        }
+      }
+      entry.nodeUid = node.uid;
+    }
+
+    set((state) => ({
+      undoStack: state.undoStack.slice(0, -1),
+      redoStack: [...state.redoStack, entry],
+    }));
+  },
+
+  redo: async () => {
+    const { redoStack } = get();
+    if (redoStack.length === 0) return;
+
+    const entry = redoStack[redoStack.length - 1];
+
+    if (entry.type === 'add') {
+      const node = await orbsApi.addNode(entry.nodeType, entry.properties);
+      entry.nodeUid = node.uid;
+    } else {
+      await orbsApi.deleteNode(entry.nodeUid);
+    }
+
+    set((state) => ({
+      redoStack: state.redoStack.slice(0, -1),
+      undoStack: [...state.undoStack, entry],
+    }));
+  },
+
+  clear: () => set({ undoStack: [], redoStack: [] }),
+}));


### PR DESCRIPTION
## Summary

Closes #149

- **Graph snapshots**: Up to 3 version snapshots per user stored in SQLite. Full orb state (person + nodes + links) serialized as JSON with encrypted PII preserved as-is
- **Auto-snapshot before CV import**: `POST /cv/confirm` automatically saves the current orb state before wiping the graph
- **Manual save/restore/delete**: New "Versions" tab in Account Settings for managing snapshots. Restore always saves current state first (so it's undoable)
- **Undo/redo for node operations**: Ephemeral Zustand store tracking node add (via "+") and delete (via trash icon). Undo/redo buttons in navbar (desktop + mobile)
- **New API endpoints**: `GET/POST/DELETE /orbs/me/versions`, `POST /orbs/me/versions/{id}/restore`
- **GDPR cleanup**: Account deletion removes all snapshots

## Documentation

- Updated `docs/api.md` — new version endpoints and snapshot metadata response
- Updated `docs/database.md` — new `orb_snapshots` SQLite table schema

## Test plan

- [x] 385 backend unit tests pass (78.68% coverage, above 75% threshold)
- [x] Backend lint clean (ruff check + format)
- [x] Frontend lint: 0 errors
- [x] No TypeScript errors in modified files
- [ ] Manual: Upload a CV, verify snapshot auto-created (check Versions tab)
- [ ] Manual: Click "Save current version" in Versions tab
- [ ] Manual: Restore a version, verify graph updates and pre-restore snapshot created
- [ ] Manual: Add a node via "+", click undo, verify node removed
- [ ] Manual: Delete a node, click undo, verify node restored
- [ ] Manual: Verify undo/redo buttons disabled state matches stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)