### PR TITLE
feat: draft notes UX, node form validation, and bug fixes

### DIFF
--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -73,7 +73,7 @@ Valid node_types and their expected properties:
     start_date (string), end_date (string or null), url (string or null)
 
 - patent:
-    title (string), patent_number (string or null), filing_date (string or null),
+    title (string), patent_number (string, REQUIRED), filing_date (string or null),
     grant_date (string or null), status (string or null), description (string or null),
     url (string or null)
 

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -188,7 +188,6 @@ interface DraftNotesProps {
 export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddToGraph, onEnhance }: DraftNotesProps) {
   const [input, setInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [bulkMode, setBulkMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
@@ -331,12 +330,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     addNote(input);
-  };
-
-  const handleToggleBulkMode = () => {
-    setBulkMode((prev) => !prev);
-    setSelectedIds(new Set());
-    setConfirmDeleteId(null);
   };
 
   const toggleSelected = (id: string) => {
@@ -583,60 +576,47 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                     </button>
                   )}
                 </div>
-                <button
-                  type="button"
-                  onClick={handleToggleBulkMode}
-                  className={`text-[11px] font-medium px-2.5 py-1.5 rounded-lg border transition-colors ${
-                    bulkMode
-                      ? 'border-purple-400/40 bg-purple-500/20 text-purple-200'
-                      : 'border-white/10 text-white/60 hover:text-white/80 hover:border-white/20'
-                  }`}
-                >
-                  {bulkMode ? 'Done' : 'Bulk'}
-                </button>
               </div>
-              {bulkMode && (
-                <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 space-y-2">
-                  <div className="flex items-center justify-between text-[10px] text-white/40">
-                    <span>{selectedCount} selected</span>
-                    <button
-                      type="button"
-                      onClick={selectAllFiltered}
-                      className="text-white/60 hover:text-white/85"
-                    >
-                      {allFilteredSelected ? 'Clear shown' : 'Select shown'}
-                    </button>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <button
-                      type="button"
-                      onClick={handleBulkAddToGraph}
-                      disabled={selectedCount !== 1}
-                      className="text-[10px] font-medium px-2 py-1 rounded-md text-purple-300 bg-purple-500/10 border border-purple-500/25 disabled:opacity-30"
-                    >
-                      Add to graph
-                    </button>
-                    {onEnhance && (
-                      <button
-                        type="button"
-                        onClick={handleBulkEnhance}
-                        disabled={selectedEnhanceableCount === 0 || bulkEnhancing}
-                        className="text-[10px] font-medium px-2 py-1 rounded-md text-amber-300 bg-amber-500/10 border border-amber-500/25 disabled:opacity-30"
-                      >
-                        {bulkEnhancing ? 'Enhancing...' : `Enhance (${selectedEnhanceableCount})`}
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      onClick={handleBulkDelete}
-                      disabled={selectedCount === 0}
-                      className="text-[10px] font-medium px-2 py-1 rounded-md text-red-300 bg-red-500/10 border border-red-500/25 disabled:opacity-30"
-                    >
-                      Delete
-                    </button>
-                  </div>
+              <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 space-y-2">
+                <div className="flex items-center justify-between text-[10px] text-white/40">
+                  <span>{selectedCount} selected</span>
+                  <button
+                    type="button"
+                    onClick={selectAllFiltered}
+                    className="text-white/60 hover:text-white/85"
+                  >
+                    {allFilteredSelected ? 'Clear shown' : 'Select shown'}
+                  </button>
                 </div>
-              )}
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={handleBulkAddToGraph}
+                    disabled={selectedCount !== 1}
+                    className="text-[10px] font-medium px-2 py-1 rounded-md text-purple-300 bg-purple-500/10 border border-purple-500/25 disabled:opacity-30"
+                  >
+                    Add to graph
+                  </button>
+                  {onEnhance && (
+                    <button
+                      type="button"
+                      onClick={handleBulkEnhance}
+                      disabled={selectedEnhanceableCount === 0 || bulkEnhancing}
+                      className="text-[10px] font-medium px-2 py-1 rounded-md text-amber-300 bg-amber-500/10 border border-amber-500/25 disabled:opacity-30"
+                    >
+                      {bulkEnhancing ? 'Enhancing...' : `Enhance (${selectedEnhanceableCount})`}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleBulkDelete}
+                    disabled={selectedCount === 0}
+                    className="text-[10px] font-medium px-2 py-1 rounded-md text-red-300 bg-red-500/10 border border-red-500/25 disabled:opacity-30"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
               {enhanceError && (
                 <div className="flex items-start justify-between gap-2 rounded-lg border border-red-400/30 bg-red-500/10 px-2.5 py-2">
                   <p className="text-red-300 text-[11px]">{enhanceError}</p>
@@ -693,25 +673,23 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                           : 'bg-white/5 border-white/5 hover:border-white/10'
                       }`}
                     >
-                      <div className={`flex ${bulkMode ? 'items-start gap-2.5' : 'items-start'}`}>
-                        {bulkMode && (
-                          <button
-                            type="button"
-                            onClick={() => toggleSelected(note.id)}
-                            className={`mt-0.5 h-4 w-4 rounded border flex items-center justify-center transition-colors ${
-                              isSelected
-                                ? 'border-purple-400 bg-purple-500/30'
-                                : 'border-white/30 bg-transparent hover:border-white/50'
-                            }`}
-                            title={isSelected ? 'Unselect note' : 'Select note'}
-                          >
-                            {isSelected && (
-                              <svg className="w-3 h-3 text-purple-100" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                              </svg>
-                            )}
-                          </button>
-                        )}
+                      <div className="flex items-start gap-2.5">
+                        <button
+                          type="button"
+                          onClick={() => toggleSelected(note.id)}
+                          className={`mt-0.5 h-4 w-4 rounded border flex items-center justify-center transition-colors ${
+                            isSelected
+                              ? 'border-purple-400 bg-purple-500/30'
+                              : 'border-white/30 bg-transparent hover:border-white/50'
+                          }`}
+                          title={isSelected ? 'Unselect note' : 'Select note'}
+                        >
+                          {isSelected && (
+                            <svg className="w-3 h-3 text-purple-100" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                          )}
+                        </button>
                         <div className="min-w-0 flex-1">
                           {editingId === note.id ? (
                             /* ── Inline edit mode ── */
@@ -793,65 +771,63 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                                 )}
                               </div>
 
-                              {!bulkMode && (
-                                <div className="flex flex-wrap items-center gap-1 mt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                              <div className="flex flex-wrap items-center gap-1 mt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                <button
+                                  onClick={() => onAddToGraph(note)}
+                                  className="text-[10px] font-medium text-purple-400 hover:text-purple-300 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors"
+                                >
+                                  + Add to graph
+                                </button>
+                                {onEnhance && (
                                   <button
-                                    onClick={() => onAddToGraph(note)}
-                                    className="text-[10px] font-medium text-purple-400 hover:text-purple-300 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors"
+                                    onClick={() => handleEnhance(note)}
+                                    disabled={enhancingNoteId !== null || bulkEnhancing}
+                                    className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
+                                      enhancingNoteId === note.id
+                                        ? 'text-amber-400/80 bg-amber-500/10'
+                                        : enhancingNoteId || bulkEnhancing
+                                          ? 'text-white/15 cursor-not-allowed'
+                                          : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
+                                    }`}
+                                    title="Enhance with AI: translate, improve, and extract fields"
                                   >
-                                    + Add to graph
+                                    {enhancingNoteId === note.id ? (
+                                      <>
+                                        <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                        </svg>
+                                        Enhancing...
+                                      </>
+                                    ) : (
+                                      <>
+                                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                                        </svg>
+                                        {note.enhanced ? 'Refine' : 'Enhance'}
+                                      </>
+                                    )}
                                   </button>
-                                  {onEnhance && (
-                                    <button
-                                      onClick={() => handleEnhance(note)}
-                                      disabled={enhancingNoteId !== null || bulkEnhancing}
-                                      className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
-                                        enhancingNoteId === note.id
-                                          ? 'text-amber-400/80 bg-amber-500/10'
-                                          : enhancingNoteId || bulkEnhancing
-                                            ? 'text-white/15 cursor-not-allowed'
-                                            : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
-                                      }`}
-                                      title="Enhance with AI: translate, improve, and extract fields"
-                                    >
-                                      {enhancingNoteId === note.id ? (
-                                        <>
-                                          <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                                          </svg>
-                                          Enhancing...
-                                        </>
-                                      ) : (
-                                        <>
-                                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                                          </svg>
-                                          {note.enhanced ? 'Refine' : 'Enhance'}
-                                        </>
-                                      )}
-                                    </button>
-                                  )}
-                                  <button
-                                    onClick={() => startEdit(note)}
-                                    className="text-white/30 hover:text-white/70 transition-colors p-0.5"
-                                    title="Edit note"
-                                  >
-                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                                    </svg>
-                                  </button>
-                                  <button
-                                    onClick={() => setConfirmDeleteId(note.id)}
-                                    className="text-white/30 hover:text-red-400 transition-colors p-0.5"
-                                    title="Delete note"
-                                  >
-                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                    </svg>
-                                  </button>
-                                </div>
-                              )}
+                                )}
+                                <button
+                                  onClick={() => startEdit(note)}
+                                  className="text-white/30 hover:text-white/70 transition-colors p-0.5"
+                                  title="Edit note"
+                                >
+                                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                  </svg>
+                                </button>
+                                <button
+                                  onClick={() => setConfirmDeleteId(note.id)}
+                                  className="text-white/30 hover:text-red-400 transition-colors p-0.5"
+                                  title="Delete note"
+                                >
+                                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                  </svg>
+                                </button>
+                              </div>
                             </>
                           )}
                         </div>

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -340,22 +340,8 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     });
   };
 
-  const selectAllFiltered = () => {
-    setSelectedIds((prev) => {
-      const allSelected = filteredNotes.length > 0 && filteredNotes.every((n) => prev.has(n.id));
-      return allSelected ? new Set() : new Set(filteredNotes.map((n) => n.id));
-    });
-  };
-
   const handleBulkDelete = () => {
     deleteByIds(new Set(selectedIds));
-  };
-
-  const handleBulkAddToGraph = () => {
-    if (selectedIds.size !== 1) return;
-    const note = notes.find((n) => selectedIds.has(n.id));
-    if (!note) return;
-    onAddToGraph(note);
   };
 
   const handleUndoDelete = () => {
@@ -377,7 +363,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
 
   const selectedCount = selectedIds.size;
   const filteredCount = filteredNotes.length;
-  const allFilteredSelected = filteredNotes.length > 0 && filteredNotes.every((n) => selectedIds.has(n.id));
 
   return (
     <AnimatePresence>
@@ -552,36 +537,17 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                     </button>
                   )}
                 </div>
-              </div>
-              <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 space-y-2">
-                <div className="flex items-center justify-between text-[10px] text-white/40">
-                  <span>{selectedCount} selected</span>
-                  <button
-                    type="button"
-                    onClick={selectAllFiltered}
-                    className="text-white/60 hover:text-white/85"
-                  >
-                    {allFilteredSelected ? 'Clear shown' : 'Select shown'}
-                  </button>
-                </div>
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <button
-                    type="button"
-                    onClick={handleBulkAddToGraph}
-                    disabled={selectedCount !== 1}
-                    className="text-[10px] font-medium px-2 py-1 rounded-md text-purple-300 bg-purple-500/10 border border-purple-500/25 disabled:opacity-30"
-                  >
-                    Add to graph
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleBulkDelete}
-                    disabled={selectedCount === 0}
-                    className="text-[10px] font-medium px-2 py-1 rounded-md text-red-300 bg-red-500/10 border border-red-500/25 disabled:opacity-30"
-                  >
-                    Delete
-                  </button>
-                </div>
+                <button
+                  type="button"
+                  onClick={handleBulkDelete}
+                  disabled={selectedCount === 0}
+                  className="h-7 w-7 flex items-center justify-center rounded-md border border-red-500/25 bg-red-500/10 text-red-300 disabled:opacity-30"
+                  title={selectedCount > 0 ? `Delete ${selectedCount} selected notes` : 'Select notes to delete'}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
               </div>
               {enhanceError && (
                 <div className="flex items-start justify-between gap-2 rounded-lg border border-red-400/30 bg-red-500/10 px-2.5 py-2">

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -375,7 +375,11 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   const handleBulkEnhance = async () => {
     if (!onEnhance || selectedIds.size === 0 || bulkEnhancing) return;
     setEnhanceError(null);
-    const selectedNotes = notes.filter((n) => selectedIds.has(n.id));
+    const selectedNotes = notes.filter((n) => selectedIds.has(n.id) && !n.enhanced);
+    if (selectedNotes.length === 0) {
+      setEnhanceError('Select at least one non-enhanced note to bulk enhance.');
+      return;
+    }
     setBulkEnhancing(true);
     try {
       for (const note of selectedNotes) {
@@ -408,6 +412,7 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   };
 
   const selectedCount = selectedIds.size;
+  const selectedEnhanceableCount = notes.filter((n) => selectedIds.has(n.id) && !n.enhanced).length;
   const filteredCount = filteredNotes.length;
   const allFilteredSelected = filteredNotes.length > 0 && filteredNotes.every((n) => selectedIds.has(n.id));
 
@@ -621,10 +626,10 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                       <button
                         type="button"
                         onClick={handleBulkEnhance}
-                        disabled={selectedCount === 0 || bulkEnhancing}
+                        disabled={selectedEnhanceableCount === 0 || bulkEnhancing}
                         className="text-[10px] font-medium px-2 py-1 rounded-md text-amber-300 bg-amber-500/10 border border-amber-500/25 disabled:opacity-30"
                       >
-                        {bulkEnhancing ? 'Enhancing...' : 'Enhance'}
+                        {bulkEnhancing ? 'Enhancing...' : `Enhance (${selectedEnhanceableCount})`}
                       </button>
                     )}
                     <button

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { NODE_TYPE_LABELS, NODE_TYPE_COLORS } from '../graph/NodeColors';
 
@@ -31,6 +31,8 @@ export interface EnhancedDraftState {
   properties: Record<string, unknown>;
   suggestedSkillUids: string[];
   updatedAt: number;
+  language?: string;
+  confidence?: number;
 }
 
 export interface DraftNote {
@@ -185,14 +187,42 @@ interface DraftNotesProps {
 
 export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddToGraph, onEnhance }: DraftNotesProps) {
   const [input, setInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [bulkMode, setBulkMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [targetLang, setTargetLang] = useState(loadTargetLang);
   const [enhancingNoteId, setEnhancingNoteId] = useState<string | null>(null);
+  const [bulkEnhancing, setBulkEnhancing] = useState(false);
+  const [enhanceError, setEnhanceError] = useState<string | null>(null);
+  const [undoSnapshot, setUndoSnapshot] = useState<DraftNote[] | null>(null);
+  const [undoDeletedCount, setUndoDeletedCount] = useState(0);
   const [showLangDropdown, setShowLangDropdown] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
+
+  const filteredNotes = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return notes;
+    return notes.filter((note) => {
+      const textMatch = note.text.toLowerCase().includes(q);
+      const nodeTypeMatch = note.enhanced?.nodeType?.toLowerCase().includes(q);
+      const heading = note.enhanced ? pickHeading(note.enhanced.nodeType, note.enhanced.properties) : '';
+      const headingMatch = heading.toLowerCase().includes(q);
+      return textMatch || nodeTypeMatch || headingMatch;
+    });
+  }, [notes, searchQuery]);
+
+  const duplicateMatch = useMemo(() => {
+    const q = input.trim().toLowerCase();
+    if (q.length < 4) return null;
+    return notes.find((note) => {
+      const t = note.text.toLowerCase();
+      return t.includes(q) || q.includes(t);
+    }) || null;
+  }, [input, notes]);
 
   const handleLangChange = (code: string) => {
     setTargetLang(code);
@@ -201,10 +231,13 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   };
 
   const handleEnhance = async (note: DraftNote) => {
-    if (!onEnhance || enhancingNoteId) return;
+    if (!onEnhance || enhancingNoteId || bulkEnhancing) return;
+    setEnhanceError(null);
     setEnhancingNoteId(note.id);
     try {
       await onEnhance(note, targetLang);
+    } catch {
+      setEnhanceError('Enhancement failed. Please try again.');
     } finally {
       setEnhancingNoteId(null);
     }
@@ -214,6 +247,7 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
 
   const handleEnhanceFromInput = async () => {
     if (!onEnhance || !input.trim() || enhancingInput) return;
+    setEnhanceError(null);
     const note: DraftNote = {
       id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
       text: input.trim(),
@@ -223,6 +257,8 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     try {
       await onEnhance(note, targetLang);
       setInput('');
+    } catch {
+      setEnhanceError('Enhancement failed. Please try again.');
     } finally {
       setEnhancingInput(false);
     }
@@ -236,6 +272,22 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     if (editingId) setTimeout(() => editRef.current?.focus(), 50);
   }, [editingId]);
 
+  useEffect(() => {
+    if (!undoSnapshot) {
+      setUndoDeletedCount(0);
+      return;
+    }
+    const t = window.setTimeout(() => setUndoSnapshot(null), 5000);
+    return () => window.clearTimeout(t);
+  }, [undoSnapshot]);
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const next = new Set(Array.from(prev).filter((id) => notes.some((n) => n.id === id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [notes]);
+
   const addNote = (text: string) => {
     if (!text.trim()) return;
     const note: DraftNote = {
@@ -247,9 +299,22 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     setInput('');
   };
 
-  const deleteNote = (id: string) => {
-    onNotesChange(notes.filter((n) => n.id !== id));
+  const deleteByIds = (ids: Set<string>) => {
+    if (ids.size === 0) return;
+    const remaining = notes.filter((n) => !ids.has(n.id));
+    setUndoSnapshot(notes);
+    setUndoDeletedCount(notes.length - remaining.length);
+    onNotesChange(remaining);
     setConfirmDeleteId(null);
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.delete(id));
+      return next;
+    });
+  };
+
+  const deleteNote = (id: string) => {
+    deleteByIds(new Set([id]));
   };
 
   const startEdit = (note: DraftNote) => {
@@ -274,6 +339,64 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     addNote(input);
   };
 
+  const handleToggleBulkMode = () => {
+    setBulkMode((prev) => !prev);
+    setSelectedIds(new Set());
+    setConfirmDeleteId(null);
+  };
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAllFiltered = () => {
+    setSelectedIds((prev) => {
+      const allSelected = filteredNotes.length > 0 && filteredNotes.every((n) => prev.has(n.id));
+      return allSelected ? new Set() : new Set(filteredNotes.map((n) => n.id));
+    });
+  };
+
+  const handleBulkDelete = () => {
+    deleteByIds(new Set(selectedIds));
+  };
+
+  const handleBulkAddToGraph = () => {
+    if (selectedIds.size !== 1) return;
+    const note = notes.find((n) => selectedIds.has(n.id));
+    if (!note) return;
+    onAddToGraph(note);
+  };
+
+  const handleBulkEnhance = async () => {
+    if (!onEnhance || selectedIds.size === 0 || bulkEnhancing) return;
+    setEnhanceError(null);
+    const selectedNotes = notes.filter((n) => selectedIds.has(n.id));
+    setBulkEnhancing(true);
+    try {
+      for (const note of selectedNotes) {
+        setEnhancingNoteId(note.id);
+        await onEnhance(note, targetLang);
+      }
+    } catch {
+      setEnhanceError('Bulk enhancement failed for at least one note.');
+    } finally {
+      setEnhancingNoteId(null);
+      setBulkEnhancing(false);
+    }
+  };
+
+  const handleUndoDelete = () => {
+    if (!undoSnapshot) return;
+    onNotesChange(undoSnapshot);
+    setUndoSnapshot(null);
+    setUndoDeletedCount(0);
+  };
+
   const formatTime = (ts: number) => {
     const d = new Date(ts);
     const now = new Date();
@@ -284,289 +407,485 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
       d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   };
 
+  const selectedCount = selectedIds.size;
+  const filteredCount = filteredNotes.length;
+  const allFilteredSelected = filteredNotes.length > 0 && filteredNotes.every((n) => selectedIds.has(n.id));
+
   return (
     <AnimatePresence>
       {open && (
-    <div className="fixed inset-0 z-50 flex justify-end">
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.2 }}
-        className="absolute inset-0 bg-black/40"
-        onClick={onClose}
-      />
-      <motion.div
-        initial={{ x: '100%' }}
-        animate={{ x: 0 }}
-        exit={{ x: '100%' }}
-        transition={{ type: 'spring', damping: 30, stiffness: 300 }}
-        className="relative w-full sm:max-w-sm h-full bg-gray-950/95 backdrop-blur-lg border-l border-white/10 flex flex-col"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
-          <div>
-            <h2 className="text-white text-base font-semibold">Draft Notes</h2>
-            <p className="text-white/40 text-xs mt-0.5">Quick notes to add to your orbis later</p>
-          </div>
-          <div className="flex items-center gap-2">
-            {/* Language selector */}
-            {onEnhance && (
-              <div className="relative">
-                <button
-                  onClick={() => setShowLangDropdown(!showLangDropdown)}
-                  className="flex items-center gap-1 text-[10px] font-medium text-white/40 hover:text-white/60 px-2 py-1 rounded-md border border-white/10 hover:border-white/20 transition-colors uppercase"
-                  title="Target language for AI enhancement"
-                >
-                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-                  </svg>
-                  {targetLang}
-                </button>
-                {showLangDropdown && (
-                  <>
-                    <div className="fixed inset-0 z-10" onClick={() => setShowLangDropdown(false)} />
-                    <div className="absolute right-0 top-full mt-1 z-20 bg-gray-900 border border-white/10 rounded-lg shadow-xl py-1 max-h-48 overflow-y-auto min-w-[140px]">
-                      {TARGET_LANGUAGES.map(({ code, label }) => (
-                        <button
-                          key={code}
-                          onClick={() => handleLangChange(code)}
-                          className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
-                            code === targetLang
-                              ? 'text-purple-400 bg-purple-500/10'
-                              : 'text-white/50 hover:text-white/80 hover:bg-white/5'
-                          }`}
-                        >
-                          <span className="uppercase font-medium mr-2">{code}</span>
-                          <span className="text-white/30">{label}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </>
-                )}
+        <div className="fixed inset-0 z-50 flex justify-end">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/40"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+            className="relative w-full sm:max-w-sm h-full bg-gray-950/95 backdrop-blur-lg border-l border-white/10 flex flex-col"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+              <div>
+                <h2 className="text-white text-base font-semibold">Draft Notes</h2>
+                <p className="text-white/40 text-xs mt-0.5">
+                  {filteredCount} / {notes.length} in view
+                </p>
               </div>
-            )}
-            <button onClick={onClose} className="text-white/30 hover:text-white/60 transition-colors">
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        {/* Input area */}
-        <div className="px-4 py-3 border-b border-white/5">
-          <form onSubmit={handleSubmit}>
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmit(e); }
-              }}
-              placeholder="Jot down something to add later..."
-              className="w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-white text-sm placeholder:text-white/25 resize-none focus:outline-none focus:ring-1 focus:ring-purple-500/50 focus:border-purple-500/30"
-              rows={2}
-            />
-            <div className="flex items-center justify-end mt-2">
               <div className="flex items-center gap-2">
+                {/* Language selector */}
                 {onEnhance && (
+                  <div className="relative">
+                    <button
+                      onClick={() => setShowLangDropdown(!showLangDropdown)}
+                      className="flex items-center gap-1 text-[10px] font-medium text-white/40 hover:text-white/60 px-2 py-1 rounded-md border border-white/10 hover:border-white/20 transition-colors uppercase"
+                      title="Target language for AI enhancement"
+                    >
+                      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+                      </svg>
+                      {targetLang}
+                    </button>
+                    {showLangDropdown && (
+                      <>
+                        <div className="fixed inset-0 z-10" onClick={() => setShowLangDropdown(false)} />
+                        <div className="absolute right-0 top-full mt-1 z-20 bg-gray-900 border border-white/10 rounded-lg shadow-xl py-1 max-h-48 overflow-y-auto min-w-[140px]">
+                          {TARGET_LANGUAGES.map(({ code, label }) => (
+                            <button
+                              key={code}
+                              onClick={() => handleLangChange(code)}
+                              className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+                                code === targetLang
+                                  ? 'text-purple-400 bg-purple-500/10'
+                                  : 'text-white/50 hover:text-white/80 hover:bg-white/5'
+                              }`}
+                            >
+                              <span className="uppercase font-medium mr-2">{code}</span>
+                              <span className="text-white/30">{label}</span>
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+                <button onClick={onClose} className="text-white/30 hover:text-white/60 transition-colors">
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            {/* Input area */}
+            <div className="px-4 py-3 border-b border-white/5 space-y-2">
+              <form onSubmit={handleSubmit} className="space-y-2">
+                <textarea
+                  ref={inputRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmit(e); }
+                  }}
+                  placeholder="Jot down something to add later..."
+                  className="w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-white text-sm placeholder:text-white/25 resize-none focus:outline-none focus:ring-1 focus:ring-purple-500/50 focus:border-purple-500/30"
+                  rows={2}
+                />
+                <div className="flex items-center justify-between text-[10px] text-white/30">
+                  <span>Enter to add · Shift+Enter newline</span>
+                  <span>{input.trim().length} chars</span>
+                </div>
+                {duplicateMatch && (
+                  <div className="flex items-center justify-between rounded-lg border border-amber-400/20 bg-amber-500/10 px-2.5 py-1.5 text-[10px]">
+                    <p className="text-amber-300/85 truncate pr-2">
+                      Possible duplicate: {duplicateMatch.text}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setSearchQuery(duplicateMatch.text)}
+                      className="text-amber-200 hover:text-amber-100 whitespace-nowrap"
+                    >
+                      Find
+                    </button>
+                  </div>
+                )}
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  {onEnhance && (
+                    <button
+                      type="button"
+                      onClick={handleEnhanceFromInput}
+                      disabled={!input.trim() || enhancingInput}
+                      className={`text-xs font-medium px-3 py-1.5 rounded-full transition-colors flex items-center gap-1 ${
+                        enhancingInput
+                          ? 'bg-amber-500/20 text-amber-400/80'
+                          : input.trim()
+                            ? 'bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-300 border border-amber-500/20'
+                            : 'bg-white/5 text-white/15 cursor-not-allowed'
+                      }`}
+                    >
+                      {enhancingInput ? (
+                        <>
+                          <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                          </svg>
+                          Enhancing...
+                        </>
+                      ) : (
+                        <>
+                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                          </svg>
+                          Enhance
+                        </>
+                      )}
+                    </button>
+                  )}
+                  <button
+                    type="submit"
+                    disabled={!input.trim()}
+                    className="text-xs font-medium px-3 py-1.5 bg-purple-600/80 hover:bg-purple-600 disabled:opacity-30 text-white rounded-full transition-colors"
+                  >
+                    Add note
+                  </button>
+                </div>
+              </form>
+            </div>
+
+            {/* Search and list controls */}
+            <div className="px-4 py-2.5 border-b border-white/5 space-y-2">
+              <div className="flex items-center gap-2">
+                <div className="relative flex-1">
+                  <svg className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+                  </svg>
+                  <input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search notes..."
+                    className="w-full bg-white/5 border border-white/10 rounded-lg pl-8 pr-8 py-1.5 text-xs text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-purple-500/40 focus:border-purple-500/30"
+                  />
+                  {searchQuery.trim() && (
+                    <button
+                      type="button"
+                      onClick={() => setSearchQuery('')}
+                      className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-white/30 hover:text-white/70"
+                      title="Clear search"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleToggleBulkMode}
+                  className={`text-[11px] font-medium px-2.5 py-1.5 rounded-lg border transition-colors ${
+                    bulkMode
+                      ? 'border-purple-400/40 bg-purple-500/20 text-purple-200'
+                      : 'border-white/10 text-white/60 hover:text-white/80 hover:border-white/20'
+                  }`}
+                >
+                  {bulkMode ? 'Done' : 'Bulk'}
+                </button>
+              </div>
+              {bulkMode && (
+                <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 space-y-2">
+                  <div className="flex items-center justify-between text-[10px] text-white/40">
+                    <span>{selectedCount} selected</span>
+                    <button
+                      type="button"
+                      onClick={selectAllFiltered}
+                      className="text-white/60 hover:text-white/85"
+                    >
+                      {allFilteredSelected ? 'Clear shown' : 'Select shown'}
+                    </button>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={handleBulkAddToGraph}
+                      disabled={selectedCount !== 1}
+                      className="text-[10px] font-medium px-2 py-1 rounded-md text-purple-300 bg-purple-500/10 border border-purple-500/25 disabled:opacity-30"
+                    >
+                      Add to graph
+                    </button>
+                    {onEnhance && (
+                      <button
+                        type="button"
+                        onClick={handleBulkEnhance}
+                        disabled={selectedCount === 0 || bulkEnhancing}
+                        className="text-[10px] font-medium px-2 py-1 rounded-md text-amber-300 bg-amber-500/10 border border-amber-500/25 disabled:opacity-30"
+                      >
+                        {bulkEnhancing ? 'Enhancing...' : 'Enhance'}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={handleBulkDelete}
+                      disabled={selectedCount === 0}
+                      className="text-[10px] font-medium px-2 py-1 rounded-md text-red-300 bg-red-500/10 border border-red-500/25 disabled:opacity-30"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              )}
+              {enhanceError && (
+                <div className="flex items-start justify-between gap-2 rounded-lg border border-red-400/30 bg-red-500/10 px-2.5 py-2">
+                  <p className="text-red-300 text-[11px]">{enhanceError}</p>
                   <button
                     type="button"
-                    onClick={handleEnhanceFromInput}
-                    disabled={!input.trim() || enhancingInput}
-                    className={`text-xs font-medium px-3 py-1.5 rounded-full transition-colors flex items-center gap-1 ${
-                      enhancingInput
-                        ? 'bg-amber-500/20 text-amber-400/80'
-                        : input.trim()
-                          ? 'bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-300 border border-amber-500/20'
-                          : 'bg-white/5 text-white/15 cursor-not-allowed'
-                    }`}
+                    onClick={() => setEnhanceError(null)}
+                    className="text-red-200/70 hover:text-red-100"
                   >
-                    {enhancingInput ? (
-                      <>
-                        <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                        </svg>
-                        Enhancing...
-                      </>
-                    ) : (
-                      <>
-                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                        </svg>
-                        Enhance
-                      </>
-                    )}
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
                   </button>
-                )}
-                <button
-                  type="submit"
-                  disabled={!input.trim()}
-                  className="text-xs font-medium px-3 py-1.5 bg-purple-600/80 hover:bg-purple-600 disabled:opacity-30 text-white rounded-full transition-colors"
-                >
-                  Add note
-                </button>
-              </div>
+                </div>
+              )}
             </div>
-          </form>
-        </div>
 
-        {/* Notes list */}
-        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
-          {notes.length === 0 ? (
-            <div className="text-center py-12">
-              <div className="text-white/15 text-4xl mb-3">
-                <svg className="w-10 h-10 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-              </div>
-              <p className="text-white/20 text-sm">No draft notes yet</p>
-              <p className="text-white/10 text-xs mt-1">Type a note to add later</p>
-            </div>
-          ) : (
-            notes.map((note) => (
-              <div
-                key={note.id}
-                className="group bg-white/5 border border-white/5 rounded-xl px-3.5 py-3 hover:border-white/10 transition-colors"
-              >
-                {editingId === note.id ? (
-                  /* ── Inline edit mode ── */
-                  <div>
-                    <textarea
-                      ref={editRef}
-                      value={editText}
-                      onChange={(e) => setEditText(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); saveEdit(); }
-                        if (e.key === 'Escape') cancelEdit();
-                      }}
-                      className="w-full bg-white/10 border border-purple-500/30 rounded-lg px-2.5 py-2 text-white text-sm resize-none focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-                      rows={3}
-                    />
-                    <div className="flex justify-end gap-1.5 mt-1.5">
-                      <button onClick={cancelEdit} className="text-[10px] text-white/40 hover:text-white/60 px-2 py-0.5 rounded-md transition-colors">Cancel</button>
-                      <button onClick={saveEdit} disabled={!editText.trim()} className="text-[10px] font-medium text-purple-400 hover:text-purple-300 disabled:opacity-30 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors">Save</button>
-                    </div>
+            {/* Notes list */}
+            <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
+              {notes.length === 0 ? (
+                <div className="text-center py-12">
+                  <div className="text-white/15 text-4xl mb-3">
+                    <svg className="w-10 h-10 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
                   </div>
-                ) : confirmDeleteId === note.id ? (
-                  /* ── Delete confirmation ── */
-                  <div className="flex items-center justify-between">
-                    <span className="text-red-400/80 text-xs">Delete this note?</span>
-                    <div className="flex items-center gap-1.5">
-                      <button onClick={() => setConfirmDeleteId(null)} className="text-[10px] text-white/40 hover:text-white/60 px-2 py-0.5 rounded-md transition-colors">Cancel</button>
-                      <button onClick={() => deleteNote(note.id)} className="text-[10px] font-medium text-red-400 hover:text-red-300 px-2 py-0.5 rounded-md hover:bg-red-500/10 transition-colors">Delete</button>
-                    </div>
-                  </div>
-                ) : (
-                  /* ── Normal display ── */
-                  <>
-                    {note.enhanced ? (
-                      (() => {
-                        const typeColor = NODE_TYPE_COLORS[note.enhanced.nodeType] || '#8b5cf6';
-                        const typeLabel = NODE_TYPE_LABELS[note.enhanced.nodeType] || note.enhanced.nodeType;
-                        const heading = pickHeading(note.enhanced.nodeType, note.enhanced.properties);
-                        return (
-                          <div>
-                            <div className="flex items-center gap-1.5 mb-1.5">
-                              <span
-                                className="text-[10px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded border"
-                                style={{
-                                  color: typeColor,
-                                  borderColor: `${typeColor}40`,
-                                  backgroundColor: `${typeColor}15`,
-                                }}
-                              >
-                                {typeLabel}
-                              </span>
-                              <span className="text-[10px] text-purple-300/70 flex items-center gap-0.5">
-                                <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                                </svg>
-                                Enhanced
-                              </span>
-                            </div>
-                            {heading && (
-                              <p className="text-white/90 text-sm font-medium leading-snug">{heading}</p>
-                            )}
-                            <p className="text-white/40 text-xs leading-relaxed mt-1 line-clamp-2">{note.text}</p>
-                          </div>
-                        );
-                      })()
-                    ) : (
-                      <p className="text-white/80 text-sm leading-relaxed">{note.text}</p>
-                    )}
-                    <div className="flex items-center justify-between mt-2">
-                      <div className="flex items-center gap-2">
-                        <span className="text-white/20 text-[10px]">{formatTime(note.createdAt)}</span>
-                      </div>
-                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <button
-                          onClick={() => onAddToGraph(note)}
-                          className="text-[10px] font-medium text-purple-400 hover:text-purple-300 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors"
-                        >
-                          + Add to graph
-                        </button>
-                        {onEnhance && (
+                  <p className="text-white/20 text-sm">No draft notes yet</p>
+                  <p className="text-white/10 text-xs mt-1">Type a note to add later</p>
+                </div>
+              ) : filteredNotes.length === 0 ? (
+                <div className="text-center py-12">
+                  <p className="text-white/30 text-sm">No notes match "{searchQuery}"</p>
+                  <button
+                    type="button"
+                    onClick={() => setSearchQuery('')}
+                    className="mt-2 text-xs text-purple-300/80 hover:text-purple-200"
+                  >
+                    Clear search
+                  </button>
+                </div>
+              ) : (
+                filteredNotes.map((note) => {
+                  const isSelected = selectedIds.has(note.id);
+                  const confidence = note.enhanced?.confidence;
+                  const confidencePct = typeof confidence === 'number'
+                    ? Math.round((confidence <= 1 ? confidence * 100 : confidence))
+                    : null;
+
+                  return (
+                    <div
+                      key={note.id}
+                      className={`group border rounded-xl px-3.5 py-3 transition-colors ${
+                        isSelected
+                          ? 'border-purple-500/40 bg-purple-500/10'
+                          : 'bg-white/5 border-white/5 hover:border-white/10'
+                      }`}
+                    >
+                      <div className={`flex ${bulkMode ? 'items-start gap-2.5' : 'items-start'}`}>
+                        {bulkMode && (
                           <button
-                            onClick={() => handleEnhance(note)}
-                            disabled={enhancingNoteId !== null}
-                            className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
-                              enhancingNoteId === note.id
-                                ? 'text-amber-400/80 bg-amber-500/10'
-                                : enhancingNoteId
-                                  ? 'text-white/15 cursor-not-allowed'
-                                  : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
+                            type="button"
+                            onClick={() => toggleSelected(note.id)}
+                            className={`mt-0.5 h-4 w-4 rounded border flex items-center justify-center transition-colors ${
+                              isSelected
+                                ? 'border-purple-400 bg-purple-500/30'
+                                : 'border-white/30 bg-transparent hover:border-white/50'
                             }`}
-                            title="Enhance with AI: translate, improve, and extract fields"
+                            title={isSelected ? 'Unselect note' : 'Select note'}
                           >
-                            {enhancingNoteId === note.id ? (
-                              <>
-                                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                                </svg>
-                                Enhancing...
-                              </>
-                            ) : (
-                              <>
-                                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                                </svg>
-                                {note.enhanced ? 'Refine' : 'Enhance'}
-                              </>
+                            {isSelected && (
+                              <svg className="w-3 h-3 text-purple-100" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                              </svg>
                             )}
                           </button>
                         )}
-                        <button
-                          onClick={() => startEdit(note)}
-                          className="text-white/20 hover:text-white/60 transition-colors p-0.5"
-                          title="Edit note"
-                        >
-                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                          </svg>
-                        </button>
-                        <button
-                          onClick={() => setConfirmDeleteId(note.id)}
-                          className="text-white/20 hover:text-red-400 transition-colors p-0.5"
-                          title="Delete note"
-                        >
-                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        </button>
+                        <div className="min-w-0 flex-1">
+                          {editingId === note.id ? (
+                            /* ── Inline edit mode ── */
+                            <div>
+                              <textarea
+                                ref={editRef}
+                                value={editText}
+                                onChange={(e) => setEditText(e.target.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); saveEdit(); }
+                                  if (e.key === 'Escape') cancelEdit();
+                                }}
+                                className="w-full bg-white/10 border border-purple-500/30 rounded-lg px-2.5 py-2 text-white text-sm resize-none focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+                                rows={3}
+                              />
+                              <div className="flex justify-end gap-1.5 mt-1.5">
+                                <button onClick={cancelEdit} className="text-[10px] text-white/40 hover:text-white/60 px-2 py-0.5 rounded-md transition-colors">Cancel</button>
+                                <button onClick={saveEdit} disabled={!editText.trim()} className="text-[10px] font-medium text-purple-400 hover:text-purple-300 disabled:opacity-30 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors">Save</button>
+                              </div>
+                            </div>
+                          ) : confirmDeleteId === note.id ? (
+                            /* ── Delete confirmation ── */
+                            <div className="flex items-center justify-between">
+                              <span className="text-red-400/80 text-xs">Delete this note?</span>
+                              <div className="flex items-center gap-1.5">
+                                <button onClick={() => setConfirmDeleteId(null)} className="text-[10px] text-white/40 hover:text-white/60 px-2 py-0.5 rounded-md transition-colors">Cancel</button>
+                                <button onClick={() => deleteNote(note.id)} className="text-[10px] font-medium text-red-400 hover:text-red-300 px-2 py-0.5 rounded-md hover:bg-red-500/10 transition-colors">Delete</button>
+                              </div>
+                            </div>
+                          ) : (
+                            /* ── Normal display ── */
+                            <>
+                              {note.enhanced ? (
+                                (() => {
+                                  const typeColor = NODE_TYPE_COLORS[note.enhanced.nodeType] || '#8b5cf6';
+                                  const typeLabel = NODE_TYPE_LABELS[note.enhanced.nodeType] || note.enhanced.nodeType;
+                                  const heading = pickHeading(note.enhanced.nodeType, note.enhanced.properties);
+                                  return (
+                                    <div>
+                                      <div className="flex items-center gap-1.5 mb-1.5">
+                                        <span
+                                          className="text-[10px] font-medium uppercase tracking-wider px-1.5 py-0.5 rounded border"
+                                          style={{
+                                            color: typeColor,
+                                            borderColor: `${typeColor}40`,
+                                            backgroundColor: `${typeColor}15`,
+                                          }}
+                                        >
+                                          {typeLabel}
+                                        </span>
+                                        <span className="text-[10px] text-purple-300/70 flex items-center gap-0.5">
+                                          <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                                          </svg>
+                                          Enhanced
+                                        </span>
+                                      </div>
+                                      {heading && (
+                                        <p className="text-white/90 text-sm font-medium leading-snug">{heading}</p>
+                                      )}
+                                      <p className="text-white/40 text-xs leading-relaxed mt-1 line-clamp-2">{note.text}</p>
+                                    </div>
+                                  );
+                                })()
+                              ) : (
+                                <p className="text-white/80 text-sm leading-relaxed">{note.text}</p>
+                              )}
+
+                              <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 mt-2 text-[10px] text-white/30">
+                                <span>Created {formatTime(note.createdAt)}</span>
+                                {note.enhanced && (
+                                  <span>Enhanced {formatTime(note.enhanced.updatedAt)}</span>
+                                )}
+                                {note.enhanced?.language && (
+                                  <span>Language {note.enhanced.language.toUpperCase()}</span>
+                                )}
+                                {confidencePct !== null && (
+                                  <span>Confidence {confidencePct}%</span>
+                                )}
+                              </div>
+
+                              {!bulkMode && (
+                                <div className="flex flex-wrap items-center gap-1 mt-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                  <button
+                                    onClick={() => onAddToGraph(note)}
+                                    className="text-[10px] font-medium text-purple-400 hover:text-purple-300 px-2 py-0.5 rounded-md hover:bg-purple-500/10 transition-colors"
+                                  >
+                                    + Add to graph
+                                  </button>
+                                  {onEnhance && (
+                                    <button
+                                      onClick={() => handleEnhance(note)}
+                                      disabled={enhancingNoteId !== null || bulkEnhancing}
+                                      className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
+                                        enhancingNoteId === note.id
+                                          ? 'text-amber-400/80 bg-amber-500/10'
+                                          : enhancingNoteId || bulkEnhancing
+                                            ? 'text-white/15 cursor-not-allowed'
+                                            : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
+                                      }`}
+                                      title="Enhance with AI: translate, improve, and extract fields"
+                                    >
+                                      {enhancingNoteId === note.id ? (
+                                        <>
+                                          <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                          </svg>
+                                          Enhancing...
+                                        </>
+                                      ) : (
+                                        <>
+                                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                                          </svg>
+                                          {note.enhanced ? 'Refine' : 'Enhance'}
+                                        </>
+                                      )}
+                                    </button>
+                                  )}
+                                  <button
+                                    onClick={() => startEdit(note)}
+                                    className="text-white/30 hover:text-white/70 transition-colors p-0.5"
+                                    title="Edit note"
+                                  >
+                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                    </svg>
+                                  </button>
+                                  <button
+                                    onClick={() => setConfirmDeleteId(note.id)}
+                                    className="text-white/30 hover:text-red-400 transition-colors p-0.5"
+                                    title="Delete note"
+                                  >
+                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                    </svg>
+                                  </button>
+                                </div>
+                              )}
+                            </>
+                          )}
+                        </div>
                       </div>
                     </div>
-                  </>
-                )}
-              </div>
-            ))
-          )}
+                  );
+                })
+              )}
+            </div>
+
+            <AnimatePresence>
+              {undoSnapshot && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 8 }}
+                  className="mx-4 mb-3 rounded-lg border border-purple-400/30 bg-purple-500/10 px-3 py-2 flex items-center justify-between gap-2"
+                >
+                  <p className="text-[11px] text-purple-100/90">
+                    {undoDeletedCount === 1 ? '1 note removed.' : `${undoDeletedCount} notes removed.`}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleUndoDelete}
+                    className="text-[11px] font-medium text-purple-200 hover:text-white"
+                  >
+                    Undo
+                  </button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
         </div>
-      </motion.div>
-    </div>
       )}
     </AnimatePresence>
   );

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -52,6 +52,8 @@ function userDraftsKey(userId: string) {
   return `orbis_drafts_${userId}`;
 }
 
+const MAX_DRAFT_NOTES = 50;
+
 /** Load drafts from API, falling back to localStorage. Also migrates localStorage → API. */
 export async function loadDraftNotesAsync(userId: string): Promise<DraftNote[]> {
   try {
@@ -63,21 +65,17 @@ export async function loadDraftNotesAsync(userId: string): Promise<DraftNote[]> 
       createdAt: new Date(d.created_at).getTime(),
     }));
 
-    // Migrate any localStorage drafts to the API
-    const localNotes = _loadFromLocalStorage(userId);
-    if (localNotes.length > 0) {
-      const serverIds = new Set(notes.map((n) => n.id));
-      for (const note of localNotes) {
-        if (!serverIds.has(note.id)) {
-          try {
-            const created = await createDraft(note.text);
-            notes.push({ id: created.uid, text: created.text, createdAt: new Date(created.created_at).getTime() });
-          } catch { /* ignore migration errors */ }
-        }
+    // Clear localStorage unconditionally (API is the source of truth)
+    localStorage.removeItem(userDraftsKey(userId));
+    for (const key of LEGACY_KEYS) localStorage.removeItem(key);
+
+    // Trim excess drafts: keep only the most recent MAX_DRAFT_NOTES
+    if (notes.length > MAX_DRAFT_NOTES) {
+      notes.sort((a, b) => b.createdAt - a.createdAt);
+      const toDelete = notes.splice(MAX_DRAFT_NOTES);
+      for (const old of toDelete) {
+        try { await apiDeleteDraft(old.id); } catch { /* ignore */ }
       }
-      // Clear localStorage after migration
-      localStorage.removeItem(userDraftsKey(userId));
-      for (const key of LEGACY_KEYS) localStorage.removeItem(key);
     }
 
     return notes;

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -194,7 +194,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [targetLang, setTargetLang] = useState(loadTargetLang);
   const [enhancingNoteId, setEnhancingNoteId] = useState<string | null>(null);
-  const [bulkEnhancing, setBulkEnhancing] = useState(false);
   const [enhanceError, setEnhanceError] = useState<string | null>(null);
   const [undoSnapshot, setUndoSnapshot] = useState<DraftNote[] | null>(null);
   const [undoDeletedCount, setUndoDeletedCount] = useState(0);
@@ -224,7 +223,7 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   };
 
   const handleEnhance = async (note: DraftNote) => {
-    if (!onEnhance || enhancingNoteId || bulkEnhancing) return;
+    if (!onEnhance || enhancingNoteId) return;
     setEnhanceError(null);
     setEnhancingNoteId(note.id);
     try {
@@ -359,28 +358,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
     onAddToGraph(note);
   };
 
-  const handleBulkEnhance = async () => {
-    if (!onEnhance || selectedIds.size === 0 || bulkEnhancing) return;
-    setEnhanceError(null);
-    const selectedNotes = notes.filter((n) => selectedIds.has(n.id) && !n.enhanced);
-    if (selectedNotes.length === 0) {
-      setEnhanceError('Select at least one non-enhanced note to bulk enhance.');
-      return;
-    }
-    setBulkEnhancing(true);
-    try {
-      for (const note of selectedNotes) {
-        setEnhancingNoteId(note.id);
-        await onEnhance(note, targetLang);
-      }
-    } catch {
-      setEnhanceError('Bulk enhancement failed for at least one note.');
-    } finally {
-      setEnhancingNoteId(null);
-      setBulkEnhancing(false);
-    }
-  };
-
   const handleUndoDelete = () => {
     if (!undoSnapshot) return;
     onNotesChange(undoSnapshot);
@@ -399,7 +376,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   };
 
   const selectedCount = selectedIds.size;
-  const selectedEnhanceableCount = notes.filter((n) => selectedIds.has(n.id) && !n.enhanced).length;
   const filteredCount = filteredNotes.length;
   const allFilteredSelected = filteredNotes.length > 0 && filteredNotes.every((n) => selectedIds.has(n.id));
 
@@ -597,16 +573,6 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                   >
                     Add to graph
                   </button>
-                  {onEnhance && (
-                    <button
-                      type="button"
-                      onClick={handleBulkEnhance}
-                      disabled={selectedEnhanceableCount === 0 || bulkEnhancing}
-                      className="text-[10px] font-medium px-2 py-1 rounded-md text-amber-300 bg-amber-500/10 border border-amber-500/25 disabled:opacity-30"
-                    >
-                      {bulkEnhancing ? 'Enhancing...' : `Enhance (${selectedEnhanceableCount})`}
-                    </button>
-                  )}
                   <button
                     type="button"
                     onClick={handleBulkDelete}
@@ -781,11 +747,11 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
                                 {onEnhance && (
                                   <button
                                     onClick={() => handleEnhance(note)}
-                                    disabled={enhancingNoteId !== null || bulkEnhancing}
+                                    disabled={enhancingNoteId !== null}
                                     className={`text-[10px] font-medium px-2 py-0.5 rounded-md transition-colors flex items-center gap-1 ${
                                       enhancingNoteId === note.id
                                         ? 'text-amber-400/80 bg-amber-500/10'
-                                        : enhancingNoteId || bulkEnhancing
+                                        : enhancingNoteId
                                           ? 'text-white/15 cursor-not-allowed'
                                           : 'text-amber-400/70 hover:text-amber-300 hover:bg-amber-500/10'
                                     }`}

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -206,13 +206,7 @@ export default function DraftNotes({ open, onClose, notes, onNotesChange, onAddT
   const filteredNotes = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return notes;
-    return notes.filter((note) => {
-      const textMatch = note.text.toLowerCase().includes(q);
-      const nodeTypeMatch = note.enhanced?.nodeType?.toLowerCase().includes(q);
-      const heading = note.enhanced ? pickHeading(note.enhanced.nodeType, note.enhanced.properties) : '';
-      const headingMatch = heading.toLowerCase().includes(q);
-      return textMatch || nodeTypeMatch || headingMatch;
-    });
+    return notes.filter((note) => note.text.toLowerCase().includes(q));
   }, [notes, searchQuery]);
 
   const duplicateMatch = useMemo(() => {

--- a/frontend/src/components/editor/FloatingInput.tsx
+++ b/frontend/src/components/editor/FloatingInput.tsx
@@ -6,6 +6,7 @@ import NodeForm from './NodeForm';
 interface FloatingInputProps {
   open: boolean;
   editNode?: { type: string; values: Record<string, unknown> } | null;
+  referenceNote?: string | null;
   onSubmit: (nodeType: string, properties: Record<string, unknown>) => void;
   onCancel: () => void;
   onDelete?: (uid: string) => void;
@@ -13,7 +14,7 @@ interface FloatingInputProps {
   onSaveDraft?: (nodeType: string, properties: Record<string, unknown>) => void;
 }
 
-export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDelete, onEnhance, onSaveDraft }: FloatingInputProps) {
+export default function FloatingInput({ open, editNode, referenceNote, onSubmit, onCancel, onDelete, onEnhance, onSaveDraft }: FloatingInputProps) {
   const [currentType, setCurrentType] = useState(editNode?.type || 'skill');
   const color = NODE_TYPE_COLORS[currentType] || '#8b5cf6';
   const isEditing = !!editNode?.values?.uid;
@@ -66,6 +67,21 @@ export default function FloatingInput({ open, editNode, onSubmit, onCancel, onDe
 
               {/* Form */}
               <div className="px-4 sm:px-6 pb-4 sm:pb-6">
+                {referenceNote && (
+                  <div className="mb-3 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+                    <div className="px-3 py-2 border-b border-slate-200 bg-slate-50">
+                      <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-700">Draft note</p>
+                    </div>
+                    <div className="p-3">
+                      <textarea
+                        readOnly
+                        value={referenceNote}
+                        rows={3}
+                        className="w-full bg-white text-slate-900 text-sm leading-relaxed border border-slate-300 rounded-lg px-3 py-2 resize-none focus:outline-none"
+                      />
+                    </div>
+                  </div>
+                )}
                 <NodeForm
                   initialType={editNode?.type}
                   initialValues={editNode?.values && Object.keys(editNode.values).length > 0 ? editNode.values : undefined}

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -142,7 +142,7 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
 };
 
 // Additional fields that should be required whenever they exist in the active modal.
-const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date', 'issue_date', 'expiry_date'];
+const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date', 'issue_date', 'expiry_date', 'date'];
 
 function FieldInput({
   field,

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -141,6 +141,9 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
   outreach: ['title', 'venue'],
 };
 
+// Additional fields that should be required whenever they exist in the active modal.
+const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date'];
+
 function FieldInput({
   field,
   value,
@@ -219,7 +222,19 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
     (initialValues as Record<string, string>) || {}
   );
   const [isCurrent, setIsCurrent] = useState(false);
-  const requiredFields = REQUIRED_FIELDS[nodeType] || [];
+  const layoutForType = LAYOUT_CONFIG[nodeType];
+  const renderableFields = layoutForType
+    ? [...layoutForType.left, ...layoutForType.main, ...layoutForType.extra]
+    : (SIMPLE_FIELDS[nodeType] || []);
+  const requiredSet = new Set(REQUIRED_FIELDS[nodeType] || []);
+  for (const field of ALWAYS_REQUIRED_IF_PRESENT) {
+    if (renderableFields.includes(field)) requiredSet.add(field);
+  }
+  // "Current" means the toggle date field (e.g. end_date) is intentionally omitted.
+  if (isCurrent && layoutForType?.currentToggle) {
+    requiredSet.delete(layoutForType.currentToggle);
+  }
+  const requiredFields = Array.from(requiredSet);
   const missingRequiredFields = requiredFields.filter((f) => !(values[f] || '').trim());
   const isRequiredField = (field: string) => requiredFields.includes(field);
   const isMissingRequiredField = (field: string) => missingRequiredFields.includes(field);
@@ -286,7 +301,7 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
   const hasAnyText = Object.values(values).some((v) => v && v.trim());
 
   const color = NODE_TYPE_COLORS[nodeType] || '#8b5cf6';
-  const layout = LAYOUT_CONFIG[nodeType];
+  const layout = layoutForType;
   const simple = SIMPLE_FIELDS[nodeType];
 
   const actionButtons = (

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -96,8 +96,8 @@ const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
  * For allowYearOnly, also accepts bare YYYY (4 digits, no slash).
  */
 function maskDateInput(raw: string, prev: string, allowYearOnly: boolean): string {
-  // Strip non-digit, non-slash characters
-  const v = raw.replace(/[^\d/]/g, '');
+  // Strip non-digit, non-slash, non-dash characters, then convert dashes to slashes
+  const v = raw.replace(/[^\d/-]/g, '').replace(/-/g, '/');
 
   // Detect if user is deleting (backspace)
   if (v.length < prev.length) return v;

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -90,6 +90,41 @@ const YEAR_ONLY_TYPES = new Set(['publication']);
 
 const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
+/**
+ * Mask date input to enforce MM/YYYY or DD/MM/YYYY structure.
+ * Auto-inserts `/` after 2-digit segments. Only allows digits and `/`.
+ * For allowYearOnly, also accepts bare YYYY (4 digits, no slash).
+ */
+function maskDateInput(raw: string, prev: string, allowYearOnly: boolean): string {
+  // Strip non-digit, non-slash characters
+  const v = raw.replace(/[^\d/]/g, '');
+
+  // Detect if user is deleting (backspace)
+  if (v.length < prev.length) return v;
+
+  // Remove any manually typed slashes — we'll add them automatically
+  const digits = v.replace(/\//g, '');
+
+  // For year-only mode: if 4 digits or fewer and no slash typed, allow bare digits
+  if (allowYearOnly && digits.length <= 4 && !v.includes('/')) {
+    return digits;
+  }
+
+  // Build masked string: groups of 2 digits separated by `/`, last group is 4 digits
+  // Patterns: DD/MM/YYYY (10 chars) or MM/YYYY (7 chars)
+  let result = '';
+  for (let i = 0; i < digits.length; i++) {
+    // Insert `/` after position 2 and 4 (for DD/MM/YYYY) or after position 2 (for MM/YYYY)
+    if (i === 2 || i === 4) result += '/';
+    result += digits[i];
+  }
+
+  // Cap at DD/MM/YYYY length (10 chars = 8 digits + 2 slashes)
+  if (result.length > 10) result = result.slice(0, 10);
+
+  return result;
+}
+
 /** Convert ISO dates (YYYY-MM-DD, YYYY-MM, YYYY) to display format (DD/MM/YYYY, MM/YYYY). */
 function isoToDisplay(value: string): string {
   if (!value) return value;
@@ -265,7 +300,14 @@ function FieldInput({
         <input
           type="text"
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => {
+            if (isDate) {
+              onChange(maskDateInput(e.target.value, value, allowYearOnly));
+            } else {
+              onChange(e.target.value);
+            }
+          }}
+          maxLength={isDate ? 10 : undefined}
           placeholder={isDate ? (allowYearOnly ? 'YYYY, MM/YYYY, or DD/MM/YYYY' : 'MM/YYYY or DD/MM/YYYY') : label}
           className={`${baseClass} ${borderClass}`}
           style={{ '--tw-ring-color': `${color}60`, ...(isFilled ? { borderColor: `${color}70` } : {}) } as React.CSSProperties}

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -84,6 +84,32 @@ const DATE_PAIRS: Record<string, [string, string, string][]> = {
 // Accept: MM/YYYY or DD/MM/YYYY
 const DATE_FORMAT_RE = /^(\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/;
 
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/** Validate that a date string has valid month (1-12) and day (1-maxForMonth). */
+function isValidDate(dateStr: string): string | null {
+  const parts = dateStr.split('/');
+  if (parts.length === 2) {
+    // MM/YYYY
+    const month = parseInt(parts[0], 10);
+    if (month < 1 || month > 12) return 'Month must be between 01 and 12';
+  } else if (parts.length === 3) {
+    // DD/MM/YYYY
+    const day = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10);
+    const year = parseInt(parts[2], 10);
+    if (month < 1 || month > 12) return 'Month must be between 01 and 12';
+    let maxDay = DAYS_IN_MONTH[month];
+    // Adjust February for non-leap years
+    if (month === 2) {
+      const isLeap = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+      if (!isLeap) maxDay = 28;
+    }
+    if (day < 1 || day > maxDay) return `Day must be between 01 and ${maxDay} for month ${String(month).padStart(2, '0')}`;
+  }
+  return null;
+}
+
 /** Convert DD/MM/YYYY or MM/YYYY to sortable YYYY-MM-DD or YYYY-MM for comparison. */
 function toSortable(dateStr: string): string {
   const parts = dateStr.split('/');
@@ -93,11 +119,15 @@ function toSortable(dateStr: string): string {
 }
 
 function validateDates(nodeType: string, values: Record<string, string>, isCurrent: boolean): string | null {
-  // Check format of all date fields
+  // Check format and validity of all date fields
   for (const [key, val] of Object.entries(values)) {
     if (!key.includes('date') || !val.trim()) continue;
     if (!DATE_FORMAT_RE.test(val.trim())) {
       return `Invalid date format for ${key.replace(/_/g, ' ')}. Use MM/YYYY or DD/MM/YYYY.`;
+    }
+    const dateError = isValidDate(val.trim());
+    if (dateError) {
+      return `Invalid ${key.replace(/_/g, ' ')}: ${dateError}.`;
     }
   }
 
@@ -164,7 +194,7 @@ function FieldInput({
   const isUrl = field.includes('url');
   const isTextarea = field === 'description' || field === 'abstract';
   const showUrlHint = isUrl && value.trim() !== '' && !/^(https?:\/\/)?[\w.-]+\.[a-z]{2,}/i.test(value.trim());
-  const showDateHint = isDate && value.trim() !== '' && !/^(\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/.test(value.trim());
+  const showDateHint = isDate && value.trim() !== '' && (!DATE_FORMAT_RE.test(value.trim()) || isValidDate(value.trim()) !== null);
 
   const borderClass = required
     ? (missing ? 'border-red-500/85' : 'border-red-500/45')
@@ -207,7 +237,9 @@ function FieldInput({
       )}
       {showDateHint && (
         <p className="text-[10px] text-amber-400/60 mt-1">
-          Use format MM/YYYY or DD/MM/YYYY
+          {!DATE_FORMAT_RE.test(value.trim())
+            ? 'Use format MM/YYYY or DD/MM/YYYY'
+            : isValidDate(value.trim()) || 'Invalid date'}
         </p>
       )}
     </div>

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -127,16 +127,34 @@ const SIMPLE_FIELDS: Record<string, string[]> = {
   language: ['name', 'proficiency'],
 };
 
+// Required fields aligned with backend merge keys to ensure a valid add/update payload.
+const REQUIRED_FIELDS: Record<string, string[]> = {
+  skill: ['name'],
+  language: ['name'],
+  work_experience: ['company', 'title'],
+  education: ['institution', 'degree'],
+  certification: ['name', 'issuing_organization'],
+  publication: ['title'],
+  project: ['name'],
+  patent: ['title'],
+  award: ['name'],
+  outreach: ['title', 'venue'],
+};
+
 function FieldInput({
   field,
   value,
   onChange,
   color,
+  required = false,
+  missing = false,
 }: {
   field: string;
   value: string;
   onChange: (v: string) => void;
   color: string;
+  required?: boolean;
+  missing?: boolean;
 }) {
   const label = field.replace(/_/g, ' ');
   const isDate = field.includes('date');
@@ -145,12 +163,15 @@ function FieldInput({
   const showUrlHint = isUrl && value.trim() !== '' && !/^(https?:\/\/)?[\w.-]+\.[a-z]{2,}/i.test(value.trim());
   const showDateHint = isDate && value.trim() !== '' && !/^(\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/.test(value.trim());
 
-  const baseClass = 'w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white text-sm placeholder:text-white/25 focus:outline-none focus:ring-1 focus:border-transparent transition-colors';
+  const borderClass = required
+    ? (missing ? 'border-red-500/85' : 'border-red-500/45')
+    : 'border-white/10';
+  const baseClass = `w-full bg-white/5 border ${borderClass} rounded-lg px-3 py-2 text-white text-sm placeholder:text-white/25 focus:outline-none focus:ring-1 focus:border-transparent transition-colors`;
 
   return (
     <div>
       <label className="block text-[10px] font-medium text-white/35 uppercase tracking-wider mb-1">
-        {label}
+        {label}{required && <span className="text-red-400 ml-0.5">*</span>}
       </label>
       {isTextarea ? (
         <textarea
@@ -198,6 +219,10 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
     (initialValues as Record<string, string>) || {}
   );
   const [isCurrent, setIsCurrent] = useState(false);
+  const requiredFields = REQUIRED_FIELDS[nodeType] || [];
+  const missingRequiredFields = requiredFields.filter((f) => !(values[f] || '').trim());
+  const isRequiredField = (field: string) => requiredFields.includes(field);
+  const isMissingRequiredField = (field: string) => missingRequiredFields.includes(field);
 
   const set = (field: string, v: string) => {
     setValues({ ...values, [field]: v });
@@ -206,6 +231,10 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (missingRequiredFields.length > 0) {
+      setDateError(`Required fields missing: ${missingRequiredFields.map((f) => f.replace(/_/g, ' ')).join(', ')}`);
+      return;
+    }
     const error = validateDates(nodeType, values, isCurrent);
     if (error) {
       setDateError(error);
@@ -323,7 +352,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
       )}
       <button
         type="submit"
-        className="flex-1 text-white font-medium py-2.5 px-4 rounded-lg transition-all hover:brightness-110 text-sm shadow-lg"
+        disabled={missingRequiredFields.length > 0}
+        className="flex-1 text-white font-medium py-2.5 px-4 rounded-lg transition-all hover:brightness-110 text-sm shadow-lg disabled:opacity-35 disabled:cursor-not-allowed disabled:hover:brightness-100"
         style={{ backgroundColor: color, boxShadow: `0 4px 14px ${color}30` }}
       >
         {initialValues ? 'Update' : 'Add to Graph'}
@@ -389,6 +419,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
                   value={values[field] || ''}
                   onChange={(v) => set(field, v)}
                   color={color}
+                  required={isRequiredField(field)}
+                  missing={isMissingRequiredField(field)}
                 />
               );
             })}
@@ -414,6 +446,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
                 value={values[field] || ''}
                 onChange={(v) => set(field, v)}
                 color={color}
+                required={isRequiredField(field)}
+                missing={isMissingRequiredField(field)}
               />
             ))}
           </div>
@@ -429,6 +463,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
                 value={values[field] || ''}
                 onChange={(v) => set(field, v)}
                 color={color}
+                required={isRequiredField(field)}
+                missing={isMissingRequiredField(field)}
               />
             ))}
           </div>
@@ -467,6 +503,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
             value={values[field] || ''}
             onChange={(v) => set(field, v)}
             color={color}
+            required={isRequiredField(field)}
+            missing={isMissingRequiredField(field)}
           />
         ))}
       </div>

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -142,7 +142,7 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
 };
 
 // Additional fields that should be required whenever they exist in the active modal.
-const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date', 'issue_date', 'expiry_date', 'date'];
+const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date', 'issue_date', 'expiry_date', 'date', 'filing_date', 'grant_date'];
 
 function FieldInput({
   field,

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -198,13 +198,6 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
     (initialValues as Record<string, string>) || {}
   );
   const [isCurrent, setIsCurrent] = useState(false);
-  const [expanded, setExpanded] = useState(() => {
-    // Auto-expand if any extra field has a pre-filled value
-    if (!initialValues) return false;
-    const layout = LAYOUT_CONFIG[initialType || 'skill'];
-    if (!layout) return false;
-    return layout.extra.some((f) => initialValues[f]);
-  });
 
   const set = (field: string, v: string) => {
     setValues({ ...values, [field]: v });
@@ -255,11 +248,6 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
       if (result) {
         setNodeType(result.node_type);
         setValues(result.properties);
-        // Auto-expand extra fields if they have values
-        const newLayout = LAYOUT_CONFIG[result.node_type];
-        if (newLayout && newLayout.extra.some((f) => result.properties[f])) {
-          setExpanded(true);
-        }
       }
     } finally {
       setEnhancing(false);
@@ -379,7 +367,7 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
 
     return (
       <form onSubmit={handleSubmit}>
-        <TypeSelector nodeType={nodeType} color={color} onChange={(t) => { setNodeType(t); setValues({}); setExpanded(false); }} />
+        <TypeSelector nodeType={nodeType} color={color} onChange={(t) => { setNodeType(t); setValues({}); }} />
 
         <AnimatePresence mode="wait">
         <motion.div
@@ -431,36 +419,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
           </div>
         </div>
 
-        {/* Toggle button for extra fields */}
+        {/* Extra fields */}
         {layout.extra.length > 0 && (
-          <div className="flex justify-end mt-3">
-            <button
-              type="button"
-              onClick={() => setExpanded(!expanded)}
-              className="flex items-center gap-1 text-xs font-medium transition-colors"
-              style={{ color: `${color}aa` }}
-            >
-              {expanded ? (
-                <>
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-                  </svg>
-                  Less details
-                </>
-              ) : (
-                <>
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                  </svg>
-                  More details
-                </>
-              )}
-            </button>
-          </div>
-        )}
-
-        {/* Extra fields (expanded) */}
-        {expanded && (
           <div className="mt-4 pt-4 border-t border-white/5 space-y-3">
             {layout.extra.map((field) => (
               <FieldInput

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -86,6 +86,32 @@ const DATE_FORMAT_RE = /^(\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/;
 
 const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
+/** Convert ISO dates (YYYY-MM-DD, YYYY-MM, YYYY) to display format (DD/MM/YYYY, MM/YYYY). */
+function isoToDisplay(value: string): string {
+  if (!value) return value;
+  const v = value.trim();
+  // YYYY-MM-DD → DD/MM/YYYY
+  const full = v.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (full) return `${full[3]}/${full[2]}/${full[1]}`;
+  // YYYY-MM → MM/YYYY
+  const partial = v.match(/^(\d{4})-(\d{2})$/);
+  if (partial) return `${partial[2]}/${partial[1]}`;
+  // YYYY alone → 01/YYYY
+  const yearOnly = v.match(/^(\d{4})$/);
+  if (yearOnly) return `01/${yearOnly[1]}`;
+  return value;
+}
+
+/** Normalize date fields in initial values from ISO to display format. */
+function normalizeInitialDates(values: Record<string, unknown>, fields: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(values)) {
+    const str = v != null ? String(v) : '';
+    result[k] = fields.includes(k) ? isoToDisplay(str) : str;
+  }
+  return result;
+}
+
 /** Validate that a date string has valid month (1-12) and day (1-maxForMonth). */
 function isValidDate(dateStr: string): string | null {
   const parts = dateStr.split('/');
@@ -255,9 +281,11 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
   useEffect(() => {
     onTypeChange?.(nodeType);
   }, [nodeType, onTypeChange]);
-  const [values, setValues] = useState<Record<string, string>>(
-    (initialValues as Record<string, string>) || {}
-  );
+  const dateFields = (LAYOUT_CONFIG[nodeType]?.left || []).filter((f) => f.includes('date'));
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    if (!initialValues) return {};
+    return normalizeInitialDates(initialValues, dateFields);
+  });
   const [isCurrent, setIsCurrent] = useState(false);
   const layoutForType = LAYOUT_CONFIG[nodeType];
   const renderableFields = layoutForType
@@ -328,7 +356,8 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
       const result = await onEnhance(text);
       if (result) {
         setNodeType(result.node_type);
-        setValues(result.properties);
+        const enhanceDateFields = (LAYOUT_CONFIG[result.node_type]?.left || []).filter((f) => f.includes('date'));
+        setValues(normalizeInitialDates(result.properties, enhanceDateFields));
       }
     } finally {
       setEnhancing(false);

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -81,8 +81,12 @@ const DATE_PAIRS: Record<string, [string, string, string][]> = {
   patent: [['filing_date', 'grant_date', 'Filing date must be before grant date']],
 };
 
-// Accept: MM/YYYY or DD/MM/YYYY
+// Accept: MM/YYYY or DD/MM/YYYY (or YYYY for types that allow it)
 const DATE_FORMAT_RE = /^(\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/;
+const DATE_FORMAT_WITH_YEAR_RE = /^(\d{4}|\d{2}\/\d{4}|\d{2}\/\d{2}\/\d{4})$/;
+
+// Node types where date fields accept year-only (YYYY) format
+const YEAR_ONLY_TYPES = new Set(['publication']);
 
 const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
@@ -145,12 +149,18 @@ function toSortable(dateStr: string): string {
 }
 
 function validateDates(nodeType: string, values: Record<string, string>, isCurrent: boolean): string | null {
+  const allowYearOnly = YEAR_ONLY_TYPES.has(nodeType);
+  const formatRe = allowYearOnly ? DATE_FORMAT_WITH_YEAR_RE : DATE_FORMAT_RE;
+  const formatHint = allowYearOnly ? 'YYYY, MM/YYYY, or DD/MM/YYYY' : 'MM/YYYY or DD/MM/YYYY';
+
   // Check format and validity of all date fields
   for (const [key, val] of Object.entries(values)) {
     if (!key.includes('date') || !val.trim()) continue;
-    if (!DATE_FORMAT_RE.test(val.trim())) {
-      return `Invalid date format for ${key.replace(/_/g, ' ')}. Use MM/YYYY or DD/MM/YYYY.`;
+    if (!formatRe.test(val.trim())) {
+      return `Invalid date format for ${key.replace(/_/g, ' ')}. Use ${formatHint}.`;
     }
+    // Skip deep validation for year-only values
+    if (/^\d{4}$/.test(val.trim())) continue;
     const dateError = isValidDate(val.trim());
     if (dateError) {
       return `Invalid ${key.replace(/_/g, ' ')}: ${dateError}.`;
@@ -207,6 +217,7 @@ function FieldInput({
   color,
   required = false,
   missing = false,
+  allowYearOnly = false,
 }: {
   field: string;
   value: string;
@@ -214,13 +225,15 @@ function FieldInput({
   color: string;
   required?: boolean;
   missing?: boolean;
+  allowYearOnly?: boolean;
 }) {
   const label = field.replace(/_/g, ' ');
   const isDate = field.includes('date');
   const isUrl = field.includes('url');
   const isTextarea = field === 'description' || field === 'abstract';
+  const dateRe = allowYearOnly ? DATE_FORMAT_WITH_YEAR_RE : DATE_FORMAT_RE;
   const showUrlHint = isUrl && value.trim() !== '' && !/^(https?:\/\/)?[\w.-]+\.[a-z]{2,}/i.test(value.trim());
-  const showDateHint = isDate && value.trim() !== '' && (!DATE_FORMAT_RE.test(value.trim()) || isValidDate(value.trim()) !== null);
+  const showDateHint = isDate && value.trim() !== '' && (!dateRe.test(value.trim()) || (/^\d{4}$/.test(value.trim()) ? false : isValidDate(value.trim()) !== null));
 
   const borderClass = required
     ? (missing ? 'border-red-500/85' : 'border-red-500/45')
@@ -251,7 +264,7 @@ function FieldInput({
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={isDate ? 'MM/YYYY or DD/MM/YYYY' : label}
+          placeholder={isDate ? (allowYearOnly ? 'YYYY, MM/YYYY, or DD/MM/YYYY' : 'MM/YYYY or DD/MM/YYYY') : label}
           className={baseClass}
           style={{ '--tw-ring-color': `${color}60` } as React.CSSProperties}
         />
@@ -263,8 +276,8 @@ function FieldInput({
       )}
       {showDateHint && (
         <p className="text-[10px] text-amber-400/60 mt-1">
-          {!DATE_FORMAT_RE.test(value.trim())
-            ? 'Use format MM/YYYY or DD/MM/YYYY'
+          {!dateRe.test(value.trim())
+            ? (allowYearOnly ? 'Use format YYYY, MM/YYYY, or DD/MM/YYYY' : 'Use format MM/YYYY or DD/MM/YYYY')
             : isValidDate(value.trim()) || 'Invalid date'}
         </p>
       )}
@@ -502,6 +515,7 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
                   color={color}
                   required={isRequiredField(field)}
                   missing={isMissingRequiredField(field)}
+                  allowYearOnly={YEAR_ONLY_TYPES.has(nodeType)}
                 />
               );
             })}

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -235,15 +235,17 @@ function FieldInput({
   const showUrlHint = isUrl && value.trim() !== '' && !/^(https?:\/\/)?[\w.-]+\.[a-z]{2,}/i.test(value.trim());
   const showDateHint = isDate && value.trim() !== '' && (!dateRe.test(value.trim()) || (/^\d{4}$/.test(value.trim()) ? false : isValidDate(value.trim()) !== null));
 
+  const isFilled = required && !missing;
   const borderClass = required
-    ? (missing ? 'border-red-500/85' : 'border-red-500/45')
+    ? (missing ? 'border-red-500/85' : '')
     : 'border-white/10';
-  const baseClass = `w-full bg-white/5 border ${borderClass} rounded-lg px-3 py-2 text-white text-sm placeholder:text-white/25 focus:outline-none focus:ring-1 focus:border-transparent transition-colors`;
+  const baseClass = `w-full bg-white/5 border rounded-lg px-3 py-2 text-white text-sm placeholder:text-white/25 focus:outline-none focus:ring-1 focus:border-transparent transition-colors`;
 
   return (
     <div>
-      <label className="flex items-center gap-1 text-[10px] font-medium text-white/35 uppercase tracking-wider mb-1">
-        {label}{required && <span className="text-red-400 ml-0.5">*</span>}
+      <label className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider mb-1" style={{ color: isFilled ? color : undefined }}>
+        <span className={isFilled ? '' : 'text-white/35'}>{label}</span>
+        {required && <span style={isFilled ? { color } : undefined} className={isFilled ? '' : 'text-red-400 ml-0.5'}>*</span>}
         {isDate && (
           <svg className="w-3 h-3 text-white/20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -255,8 +257,8 @@ function FieldInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={label}
-          className={baseClass}
-          style={{ '--tw-ring-color': `${color}60` } as React.CSSProperties}
+          className={`${baseClass} ${borderClass}`}
+          style={{ '--tw-ring-color': `${color}60`, ...(isFilled ? { borderColor: `${color}70` } : {}) } as React.CSSProperties}
           rows={3}
         />
       ) : (
@@ -265,8 +267,8 @@ function FieldInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={isDate ? (allowYearOnly ? 'YYYY, MM/YYYY, or DD/MM/YYYY' : 'MM/YYYY or DD/MM/YYYY') : label}
-          className={baseClass}
-          style={{ '--tw-ring-color': `${color}60` } as React.CSSProperties}
+          className={`${baseClass} ${borderClass}`}
+          style={{ '--tw-ring-color': `${color}60`, ...(isFilled ? { borderColor: `${color}70` } : {}) } as React.CSSProperties}
         />
       )}
       {showUrlHint && (
@@ -334,8 +336,11 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
       return;
     }
     setDateError(null);
+    // Only submit renderable fields — exclude metadata (_labels, uid, score, etc.)
     const filtered = Object.fromEntries(
-      Object.entries(values).filter(([, v]) => v !== '')
+      renderableFields
+        .map((f) => [f, values[f] || ''] as const)
+        .filter(([, v]) => v !== '')
     );
     if (isCurrent) {
       delete filtered.end_date;
@@ -347,7 +352,9 @@ export default function NodeForm({ initialType, initialValues, onSubmit, onCance
   const handleSaveDraftClick = () => {
     if (!onSaveDraft) return;
     const filtered = Object.fromEntries(
-      Object.entries(values).filter(([, v]) => v !== '')
+      renderableFields
+        .map((f) => [f, values[f] || ''] as const)
+        .filter(([, v]) => v !== '')
     );
     if (isCurrent) {
       delete filtered.end_date;

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -142,7 +142,7 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
 };
 
 // Additional fields that should be required whenever they exist in the active modal.
-const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date'];
+const ALWAYS_REQUIRED_IF_PRESENT = ['field_of_study', 'location', 'start_date', 'end_date', 'issue_date', 'expiry_date'];
 
 function FieldInput({
   field,

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -92,37 +92,41 @@ const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 /**
  * Mask date input to enforce MM/YYYY or DD/MM/YYYY structure.
- * Auto-inserts `/` after 2-digit segments. Only allows digits and `/`.
- * For allowYearOnly, also accepts bare YYYY (4 digits, no slash).
+ * Allows `/` or `-` as separators (dashes converted to `/`).
+ * Auto-inserts `/` after 2-digit groups when typing digits only.
+ * Respects user-typed separators to distinguish MM/YYYY from DD/MM/YYYY.
  */
 function maskDateInput(raw: string, prev: string, allowYearOnly: boolean): string {
-  // Strip non-digit, non-slash, non-dash characters, then convert dashes to slashes
+  // Normalize: strip invalid chars, convert dashes to slashes
   const v = raw.replace(/[^\d/-]/g, '').replace(/-/g, '/');
 
-  // Detect if user is deleting (backspace)
+  // Detect backspace — let the user delete freely
   if (v.length < prev.length) return v;
 
-  // Remove any manually typed slashes — we'll add them automatically
-  const digits = v.replace(/\//g, '');
+  // Split on slashes to get user-typed segments
+  const parts = v.split('/');
 
-  // For year-only mode: if 4 digits or fewer and no slash typed, allow bare digits
-  if (allowYearOnly && digits.length <= 4 && !v.includes('/')) {
-    return digits;
+  // For year-only mode: if no slash and <= 4 digits, allow bare YYYY
+  if (allowYearOnly && parts.length === 1 && parts[0].length <= 4) {
+    return parts[0].replace(/\D/g, '').slice(0, 4);
   }
 
-  // Build masked string: groups of 2 digits separated by `/`, last group is 4 digits
-  // Patterns: DD/MM/YYYY (10 chars) or MM/YYYY (7 chars)
-  let result = '';
-  for (let i = 0; i < digits.length; i++) {
-    // Insert `/` after position 2 and 4 (for DD/MM/YYYY) or after position 2 (for MM/YYYY)
-    if (i === 2 || i === 4) result += '/';
-    result += digits[i];
+  // Enforce segment lengths: each segment max 2 digits, last segment max 4
+  const maxLens = parts.length <= 2 ? [2, 4] : [2, 2, 4];
+  const capped: string[] = [];
+  for (let i = 0; i < parts.length && i < maxLens.length; i++) {
+    capped.push(parts[i].replace(/\D/g, '').slice(0, maxLens[i]));
   }
 
-  // Cap at DD/MM/YYYY length (10 chars = 8 digits + 2 slashes)
-  if (result.length > 10) result = result.slice(0, 10);
+  // Auto-insert `/` when a segment reaches its max and user is typing digits
+  const last = capped[capped.length - 1];
+  const lastMax = maxLens[capped.length - 1];
+  if (capped.length < maxLens.length && last.length >= lastMax) {
+    // Segment is full, start next segment
+    return capped.join('/') + '/';
+  }
 
-  return result;
+  return capped.join('/');
 }
 
 /** Convert ISO dates (YYYY-MM-DD, YYYY-MM, YYYY) to display format (DD/MM/YYYY, MM/YYYY). */

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -136,7 +136,7 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
   certification: ['name', 'issuing_organization'],
   publication: ['title'],
   project: ['name'],
-  patent: ['title'],
+  patent: ['title', 'patent_number'],
   award: ['name'],
   outreach: ['title', 'venue'],
 };
@@ -173,8 +173,13 @@ function FieldInput({
 
   return (
     <div>
-      <label className="block text-[10px] font-medium text-white/35 uppercase tracking-wider mb-1">
+      <label className="flex items-center gap-1 text-[10px] font-medium text-white/35 uppercase tracking-wider mb-1">
         {label}{required && <span className="text-red-400 ml-0.5">*</span>}
+        {isDate && (
+          <svg className="w-3 h-3 text-white/20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+        )}
       </label>
       {isTextarea ? (
         <textarea

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -690,7 +690,7 @@ export default function OrbViewPage() {
     setPendingDraftRawText(note.text);
     setPendingSkillLinks([]);
     setDraftReferenceText(note.text);
-    setEditNode({ type: 'work_experience', values: { description: note.text } });
+    setEditNode({ type: 'work_experience', values: {} });
     setShowInput(true);
     setShowDrafts(false);
   };

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -529,6 +529,7 @@ export default function OrbViewPage() {
   const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
   const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
   const [pendingDraftRawText, setPendingDraftRawText] = useState<string>('');
+  const [draftReferenceText, setDraftReferenceText] = useState<string | null>(null);
   const [hiddenNodeTypes, setHiddenNodeTypes] = useState<Set<string>>(new Set());
   const [showToolsMenu, setShowToolsMenu] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
@@ -554,7 +555,15 @@ export default function OrbViewPage() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (showToolsMenu) { setShowToolsMenu(false); return; }
-      if (showInput) { setShowInput(false); setEditNode(null); return; }
+      if (showInput) {
+        setShowInput(false);
+        setEditNode(null);
+        setPendingSkillLinks([]);
+        setPendingDraftNoteId(null);
+        setPendingDraftRawText('');
+        setDraftReferenceText(null);
+        return;
+      }
       if (showProfile) { setShowProfile(false); return; }
       if (showShare) { setShowShare(false); return; }
       if (showDrafts) { setShowDrafts(false); return; }
@@ -671,36 +680,17 @@ export default function OrbViewPage() {
     }
     setPendingDraftRawText('');
     setPendingSkillLinks([]);
+    setDraftReferenceText(null);
     setShowInput(false);
     setEditNode(null);
   };
 
   const handleDraftToGraph = (note: DraftNote) => {
     setPendingDraftNoteId(note.id);
-    // If the draft has been enhanced, jump straight into the form with the
-    // enhanced state so the user only has to confirm before creating the node.
-    if (note.enhanced) {
-      setPendingSkillLinks(note.enhanced.suggestedSkillUids);
-      setEditNode({ type: note.enhanced.nodeType, values: note.enhanced.properties });
-      setShowInput(true);
-      setShowDrafts(false);
-      return;
-    }
-    const text = note.text.toLowerCase();
-    const detect: [RegExp, string][] = [
-      [/\b(python|javascript|typescript|react|angular|vue|java|c\+\+|node\.?js|sql|docker|kubernetes|aws|git|html|css|figma|photoshop|agile|scrum|machine learning|data science|deep learning|tensorflow|pytorch)\b/i, 'skill'],
-      [/\b(university|degree|bachelor|master|phd|diploma|graduated|school|college|mba|studies|thesis)\b/i, 'education'],
-      [/\b(certified|certification|certificate|license|accredit|aws certified|pmp|cpa|comptia)\b/i, 'certification'],
-      [/\b(english|french|spanish|german|italian|portuguese|chinese|japanese|korean|arabic|hindi|russian|dutch|fluent|native speaker|bilingual)\b/i, 'language'],
-      [/\b(published|paper|article|journal|conference|proceedings|co-author|isbn|doi)\b/i, 'publication'],
-      [/\b(project|built|developed|created|launched|side project|open.?source|hackathon|prototype|app|website)\b/i, 'project'],
-      [/\b(patent|invention|filed|provisional|granted patent|patent number)\b/i, 'patent'],
-    ];
-    let type = 'work_experience';
-    for (const [regex, nodeType] of detect) {
-      if (regex.test(text)) { type = nodeType; break; }
-    }
-    setEditNode({ type, values: { description: note.text } });
+    setPendingDraftRawText(note.text);
+    setPendingSkillLinks([]);
+    setDraftReferenceText(note.text);
+    setEditNode({ type: 'work_experience', values: { description: note.text } });
     setShowInput(true);
     setShowDrafts(false);
   };
@@ -709,6 +699,7 @@ export default function OrbViewPage() {
     // Already enhanced: re-open the form with the saved structured data so
     // the user can keep refining without spending another LLM call.
     if (note.enhanced) {
+      setDraftReferenceText(null);
       setPendingDraftNoteId(note.id);
       setPendingDraftRawText(note.text);
       setPendingSkillLinks(note.enhanced.suggestedSkillUids);
@@ -724,6 +715,7 @@ export default function OrbViewPage() {
 
     const result = await enhanceNote(note.text, targetLang, existingSkills);
 
+    setDraftReferenceText(null);
     setPendingDraftNoteId(note.id);
     setPendingDraftRawText(note.text);
     setPendingSkillLinks(result.suggested_skill_uids);
@@ -760,6 +752,7 @@ export default function OrbViewPage() {
     setPendingDraftNoteId(null);
     setPendingDraftRawText('');
     setPendingSkillLinks([]);
+    setDraftReferenceText(null);
     setShowInput(false);
     setEditNode(null);
     setShowDrafts(true);
@@ -1233,7 +1226,14 @@ export default function OrbViewPage() {
         open={showInput}
         editNode={editNode}
         onSubmit={handleSubmit}
-        onCancel={() => { setShowInput(false); setEditNode(null); setPendingSkillLinks([]); setPendingDraftNoteId(null); setPendingDraftRawText(''); }}
+        onCancel={() => {
+          setShowInput(false);
+          setEditNode(null);
+          setPendingSkillLinks([]);
+          setPendingDraftNoteId(null);
+          setPendingDraftRawText('');
+          setDraftReferenceText(null);
+        }}
         onDelete={async (uid) => {
           const nodeToDelete = data?.nodes.find(n => n.uid === uid);
           const nodeTypeKey = nodeToDelete?._labels?.[0] ? LABEL_TO_TYPE[nodeToDelete._labels[0]] || '' : '';
@@ -1249,6 +1249,7 @@ export default function OrbViewPage() {
           await deleteNode(uid, nodeTypeKey, nodeProps, nodeRelationships);
           setShowInput(false);
           setEditNode(null);
+          setDraftReferenceText(null);
         }}
         onEnhance={async (text) => {
           const existingSkills = (data?.nodes || [])
@@ -1262,6 +1263,20 @@ export default function OrbViewPage() {
         onSaveDraft={pendingDraftNoteId ? handleSaveDraftEnhanced : undefined}
       />}
 
+      {/* ── Draft reference helper (stays above form while adding from notes) ── */}
+      {!isPendingDeletion && showInput && draftReferenceText && (
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[70] w-full max-w-[95vw] sm:max-w-xl px-2 sm:px-0">
+          <div className="bg-white border border-gray-300 rounded-xl shadow-2xl p-3 sm:p-4">
+            <textarea
+              readOnly
+              value={draftReferenceText}
+              rows={4}
+              className="w-full bg-white text-gray-900 text-sm leading-relaxed border border-gray-200 rounded-lg px-3 py-2 resize-none focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+
       {/* ── Chat Box ── */}
       {!isPendingDeletion && <ChatBox
         onHighlight={setHighlightedNodeIds}
@@ -1270,7 +1285,7 @@ export default function OrbViewPage() {
         highlightedNodeIds={highlightedNodeIds}
         messages={chatMessages}
         onMessagesChange={setChatMessages}
-        onAdd={() => { setEditNode(null); setShowInput(true); }}
+        onAdd={() => { setEditNode(null); setDraftReferenceText(null); setShowInput(true); }}
         onShare={() => setShowShare(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
       />}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1225,6 +1225,7 @@ export default function OrbViewPage() {
       {!isPendingDeletion && <FloatingInput
         open={showInput}
         editNode={editNode}
+        referenceNote={draftReferenceText}
         onSubmit={handleSubmit}
         onCancel={() => {
           setShowInput(false);
@@ -1262,20 +1263,6 @@ export default function OrbViewPage() {
         }}
         onSaveDraft={pendingDraftNoteId ? handleSaveDraftEnhanced : undefined}
       />}
-
-      {/* ── Draft reference helper (stays above form while adding from notes) ── */}
-      {!isPendingDeletion && showInput && draftReferenceText && (
-        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[70] w-full max-w-[95vw] sm:max-w-xl px-2 sm:px-0">
-          <div className="bg-white border border-gray-300 rounded-xl shadow-2xl p-3 sm:p-4">
-            <textarea
-              readOnly
-              value={draftReferenceText}
-              rows={4}
-              className="w-full bg-white text-gray-900 text-sm leading-relaxed border border-gray-200 rounded-lg px-3 py-2 resize-none focus:outline-none"
-            />
-          </div>
-        </div>
-      )}
 
       {/* ── Chat Box ── */}
       {!isPendingDeletion && <ChatBox

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -594,33 +594,28 @@ export default function OrbViewPage() {
     fetchDocuments();
   }, [fetchDocuments]);
 
-  // Load drafts when userId becomes available — try API first, fall back to localStorage
+  // Load drafts when userId becomes available — API is the source of truth
   useEffect(() => {
     if (!userId) return;
-    // Show localStorage drafts immediately for fast render
-    const local = loadDraftNotes(userId);
-    if (local.length > 0) setDraftNotes(local);
-
-    // Then load from API (includes migration of localStorage → server)
     loadDraftNotesAsync(userId).then((notes) => {
       if (notes.length > 0) {
         setDraftNotes(notes);
-      } else if (local.length === 0) {
+      } else {
         // Seed a sample note for first-time users
-        setDraftNotes([{
-          id: 'sample-1',
-          text: '💡 This is a draft note! Jot down quick thoughts here — a new skill you learned, a project idea, or something to add to your Orbis later. When ready, click "Add to graph" to turn a note into a real entry.',
-          createdAt: Date.now(),
-        }]);
+        const local = loadDraftNotes(userId);
+        if (local.length > 0) {
+          setDraftNotes(local);
+        } else {
+          setDraftNotes([{
+            id: 'sample-1',
+            text: '💡 This is a draft note! Jot down quick thoughts here — a new skill you learned, a project idea, or something to add to your Orbis later. When ready, click "Add to graph" to turn a note into a real entry.',
+            createdAt: Date.now(),
+          }]);
+        }
       }
       setDraftsLoaded(true);
     });
   }, [userId]);
-
-  // Persist drafts to localStorage (user-scoped) — only after initial load
-  useEffect(() => {
-    if (userId && draftsLoaded) saveDraftNotes(userId, draftNotes);
-  }, [draftNotes, userId, draftsLoaded]);
 
   useEffect(() => { fetchOrb(); }, [fetchOrb]);
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -16,7 +16,7 @@ import type { ChatMessage } from '../components/chat/ChatBox';
 import DraftNotes from '../components/drafts/DraftNotes';
 import ExtractedDataReview from '../components/onboarding/ExtractedDataReview';
 import type { DraftNote } from '../components/drafts/DraftNotes';
-import { loadDraftNotes, loadDraftNotesAsync, saveDraftNotes } from '../components/drafts/DraftNotes';
+import { loadDraftNotes, loadDraftNotesAsync } from '../components/drafts/DraftNotes';
 import ProcessingCounter from '../components/cv/ProcessingCounter';
 import KeywordFilterDropdown from '../components/cv/KeywordFilterDropdown';
 import UserMenu from '../components/UserMenu';
@@ -525,7 +525,6 @@ export default function OrbViewPage() {
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const userId = user?.user_id ?? '';
   const [draftNotes, setDraftNotes] = useState<DraftNote[]>([]);
-  const [draftsLoaded, setDraftsLoaded] = useState(false);
   const [pendingSkillLinks, setPendingSkillLinks] = useState<string[]>([]);
   const [pendingDraftNoteId, setPendingDraftNoteId] = useState<string | null>(null);
   const [pendingDraftRawText, setPendingDraftRawText] = useState<string>('');
@@ -613,7 +612,6 @@ export default function OrbViewPage() {
           }]);
         }
       }
-      setDraftsLoaded(true);
     });
   }, [userId]);
 
@@ -625,9 +623,16 @@ export default function OrbViewPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const allowEmpty = (location.state as { allowEmpty?: boolean } | null)?.allowEmpty === true;
+  const hasRedirectedRef = useRef(false);
   useEffect(() => {
+    // Only redirect on the very first successful load, never on subsequent refetches
+    if (hasRedirectedRef.current) return;
     if (!loading && data && data.nodes.length === 0 && !allowEmpty) {
+      hasRedirectedRef.current = true;
       navigate('/create', { replace: true });
+    }
+    if (!loading && data && data.nodes.length > 0) {
+      hasRedirectedRef.current = true; // Had content on first load, never redirect
     }
   }, [loading, data, allowEmpty, navigate]);
 

--- a/frontend/src/stores/undoStore.ts
+++ b/frontend/src/stores/undoStore.ts
@@ -18,13 +18,15 @@ interface UndoState {
   clear: () => void;
 }
 
+const MAX_UNDO_STEPS = 100;
+
 export const useUndoStore = create<UndoState>((set, get) => ({
   undoStack: [],
   redoStack: [],
 
   pushUndo: (entry: UndoEntry) => {
     set((state) => ({
-      undoStack: [...state.undoStack, entry],
+      undoStack: [...state.undoStack, entry].slice(-MAX_UNDO_STEPS),
       redoStack: [],
     }));
   },


### PR DESCRIPTION
## Summary

Closes #201

### Draft Notes UX
- Improved search, bulk actions, undo for draft notes
- Embedded draft note panel inside node modal
- Fixed draft notes duplication bug (localStorage race condition with API migration)
- Trim excess drafts to 50, delete old ones from API
- Clear localStorage unconditionally (API is source of truth)

### Node Form Validation
- Required fields: patent_number, issue_date, expiry_date, filing_date, grant_date, date (outreach/publication/award)
- Date input masking: enforces MM/YYYY or DD/MM/YYYY as user types, auto-inserts `/`, accepts `-` (converts to `/`)
- Month validation (1-12), day validation (1-31 per month, leap year aware)
- Publications accept year-only (YYYY) format
- Calendar icon on date field labels
- Required field label + border turns to node type color when filled (red when empty)
- ISO date normalization: LLM-extracted dates (YYYY-MM-DD) auto-converted to DD/MM/YYYY display format
- Patent number marked as REQUIRED in LLM classification prompt

### Bug Fixes
- **Node edit corruption**: Form now only submits renderable fields, preventing metadata (`_labels`, `uid`, `score`) from being written to Neo4j via `SET n += $properties`
- **Orb vanishing on refresh**: Empty-orb redirect to `/create` now only fires on initial page load, never on subsequent refetches

## Documentation

No doc changes needed — internal UI/UX improvements.

## Test plan

- [ ] Manual: Create a patent node — patent_number is required
- [ ] Manual: Type dates — input masking enforces format, `/` and `-` both work
- [ ] Manual: Enter invalid month (13) or day (32) — validation error shown
- [ ] Manual: Edit a node and save — orb persists after refresh
- [ ] Manual: Check draft notes count is reasonable (not growing on each login)
- [ ] Manual: Required fields show red when empty, node color when filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)