### PR TITLE
feat: guided tour for new users

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.2.4",
         "react-dropzone": "^15.0.0",
         "react-force-graph-3d": "^1.29.1",
+        "react-joyride": "^3.0.2",
         "react-router-dom": "^7.13.1",
         "three": "^0.183.2",
         "zustand": "^5.0.12"
@@ -708,6 +709,87 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3868,6 +3950,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -4998,11 +5086,43 @@
         "react": "*"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-kapsule": {
       "version": "2.5.7",
@@ -5181,6 +5301,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5655,6 +5787,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.2.4",
     "react-dropzone": "^15.0.0",
     "react-force-graph-3d": "^1.29.1",
+    "react-joyride": "^3.0.2",
     "react-router-dom": "^7.13.1",
     "three": "^0.183.2",
     "zustand": "^5.0.12"

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import Joyride, { CallBackProps, STATUS, ACTIONS, EVENTS } from 'react-joyride';
-import type { Step } from 'react-joyride';
+import Joyride, { STATUS, ACTIONS, EVENTS } from 'react-joyride';
+import type { CallBackProps, Step } from 'react-joyride';
 
 const TOUR_COMPLETED_KEY = 'orbis_tour_completed';
 

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,0 +1,171 @@
+import { useState, useEffect, useCallback } from 'react';
+import Joyride, { CallBackProps, STATUS, ACTIONS, EVENTS } from 'react-joyride';
+import type { Step } from 'react-joyride';
+
+const TOUR_COMPLETED_KEY = 'orbis_tour_completed';
+
+function isTourCompleted(): boolean {
+  return localStorage.getItem(TOUR_COMPLETED_KEY) === 'true';
+}
+
+export function markTourCompleted(): void {
+  localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
+}
+
+export function resetTour(): void {
+  localStorage.removeItem(TOUR_COMPLETED_KEY);
+}
+
+const STEPS: Step[] = [
+  {
+    target: '[data-tour="graph"]',
+    content: 'This is your Orbis — a 3D knowledge graph of your professional profile. Rotate by dragging, zoom with scroll, and click any node to view or edit it.',
+    placement: 'center',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="node-count"]',
+    content: 'Here you can see how many nodes and edges your orbis contains.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="undo-redo"]',
+    content: 'Undo and redo your recent changes — adding or deleting nodes can be reversed.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="node-types"]',
+    content: 'Filter which types of nodes are visible in the graph — education, skills, work experience, and more.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="export"]',
+    content: 'Export your orbis as a formatted PDF CV.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="import"]',
+    content: 'Import documents (PDF, DOCX, TXT) to enrich your orbis with new data. Up to 3 documents are tracked.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="notes"]',
+    content: 'Draft notes — jot down quick thoughts, then convert them into graph entries when ready. AI enhancement can help structure your notes.',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="chatbox"]',
+    content: 'Search your orbis by typing queries here. Matching nodes will be highlighted in the graph. You can also share your orbis from here.',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="user-menu"]',
+    content: 'Access your account settings, uploaded CVs, and sign out from here. In Settings you can claim a custom Orbis ID, manage saved versions, or delete your account.',
+    placement: 'bottom-end',
+  },
+];
+
+interface GuidedTourProps {
+  run?: boolean;
+  onFinish?: () => void;
+}
+
+export default function GuidedTour({ run: runOverride, onFinish }: GuidedTourProps) {
+  const [run, setRun] = useState(false);
+
+  useEffect(() => {
+    if (runOverride !== undefined) {
+      setRun(runOverride);
+      return;
+    }
+    // Auto-start for new users who haven't completed the tour
+    if (!isTourCompleted()) {
+      // Small delay to let the page render and elements mount
+      const timer = setTimeout(() => setRun(true), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [runOverride]);
+
+  const handleCallback = useCallback((data: CallBackProps) => {
+    const { status, action, type } = data;
+
+    if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
+      markTourCompleted();
+      setRun(false);
+      onFinish?.();
+    }
+
+    // Close on overlay click
+    if (type === EVENTS.STEP_AFTER && action === ACTIONS.CLOSE) {
+      markTourCompleted();
+      setRun(false);
+      onFinish?.();
+    }
+  }, [onFinish]);
+
+  return (
+    <Joyride
+      steps={STEPS}
+      run={run}
+      continuous
+      showSkipButton
+      showProgress
+      disableOverlayClose={false}
+      callback={handleCallback}
+      locale={{
+        back: 'Back',
+        close: 'Got it',
+        last: 'Finish',
+        next: 'Next',
+        skip: 'Skip tour',
+      }}
+      styles={{
+        options: {
+          arrowColor: 'rgb(23, 23, 23)',
+          backgroundColor: 'rgb(23, 23, 23)',
+          overlayColor: 'rgba(0, 0, 0, 0.75)',
+          primaryColor: '#a855f6',
+          textColor: 'rgba(255, 255, 255, 0.85)',
+          zIndex: 10000,
+        },
+        tooltip: {
+          borderRadius: 16,
+          padding: '20px 24px',
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          boxShadow: '0 25px 50px rgba(0, 0, 0, 0.5)',
+        },
+        tooltipContent: {
+          fontSize: 14,
+          lineHeight: '1.6',
+          padding: '8px 0',
+        },
+        tooltipTitle: {
+          fontSize: 16,
+          fontWeight: 600,
+        },
+        buttonNext: {
+          backgroundColor: '#a855f6',
+          borderRadius: 8,
+          fontSize: 13,
+          fontWeight: 600,
+          padding: '8px 16px',
+        },
+        buttonBack: {
+          color: 'rgba(255, 255, 255, 0.5)',
+          fontSize: 13,
+          marginRight: 8,
+        },
+        buttonSkip: {
+          color: 'rgba(255, 255, 255, 0.3)',
+          fontSize: 12,
+        },
+        buttonClose: {
+          color: 'rgba(255, 255, 255, 0.4)',
+        },
+        spotlight: {
+          borderRadius: 12,
+        },
+      }}
+    />
+  );
+}

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import Joyride, { STATUS, ACTIONS, EVENTS } from 'react-joyride';
+import { Joyride, STATUS, ACTIONS, EVENTS } from 'react-joyride';
 import type { CallBackProps, Step } from 'react-joyride';
 
 const TOUR_COMPLETED_KEY = 'orbis_tour_completed';

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
+import { resetTour } from './GuidedTour';
 import { claimOrbId, getVersions, createVersion, restoreVersion, deleteVersion } from '../api/orbs';
 import type { SnapshotMetadata } from '../api/orbs';
 import { getDocuments, downloadCV } from '../api/cv';
@@ -564,6 +565,22 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                 >
                   <label className="text-xs text-white/45 uppercase tracking-[0.12em] font-medium">Account</label>
                   <p className="text-[11px] text-white/45 mt-0.5">Manage your account and data.</p>
+
+                  <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-3">
+                    <button
+                      onClick={() => {
+                        resetTour();
+                        addToast('Guided tour will restart on next page load', 'info');
+                        onClose();
+                      }}
+                      className="w-full flex items-center gap-2.5 text-xs text-white/60 hover:text-white/90 transition-colors cursor-pointer"
+                    >
+                      <svg className="w-4 h-4 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+                      </svg>
+                      Restart guided tour
+                    </button>
+                  </div>
 
                   {user?.deletion_days_remaining != null ? (
                     /* ── Account pending deletion — show recovery ── */

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -23,6 +23,7 @@ import UserMenu from '../components/UserMenu';
 import { useToastStore } from '../stores/toastStore';
 import { useUndoStore } from '../stores/undoStore';
 import { getDocuments, confirmImport } from '../api/cv';
+import GuidedTour from '../components/GuidedTour';
 import type { DocumentMetadata } from '../api/cv';
 
 const IMPORT_PROGRESS_STEP_LABELS: Record<string, string> = {
@@ -937,12 +938,12 @@ export default function OrbViewPage() {
                 <span className="text-white font-bold text-sm tracking-tight hidden sm:inline">OpenOrbis</span>
               </div>
               <div className="hidden sm:block w-px h-5 bg-white/10" />
-              <span className="text-white text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
+              <span data-tour="node-count" className="text-white text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
 
               {!isPendingDeletion && (
                 <div className="hidden sm:flex items-center gap-1.5 ml-2">
                   {/* Undo / Redo */}
-                  <div className="flex items-center">
+                  <div data-tour="undo-redo" className="flex items-center">
                     <button
                       onClick={handleUndo}
                       disabled={undoStack.length === 0}
@@ -972,14 +973,17 @@ export default function OrbViewPage() {
                       </svg>
                     </button>
                   </div>
-                  <NodeTypeFilter
-                    hiddenTypes={hiddenNodeTypes}
-                    onShowAll={handleShowAllNodeTypes}
-                    onHideAll={handleHideAllNodeTypes}
-                    onSetVisible={handleSetVisibleNodeTypes}
-                  />
+                  <div data-tour="node-types">
+                    <NodeTypeFilter
+                      hiddenTypes={hiddenNodeTypes}
+                      onShowAll={handleShowAllNodeTypes}
+                      onHideAll={handleHideAllNodeTypes}
+                      onSetVisible={handleSetVisibleNodeTypes}
+                    />
+                  </div>
                   <KeywordFilterDropdown />
                   <button
+                    data-tour="export"
                     onClick={() => window.open('/cv-export', '_blank')}
                     className="h-8 leading-none flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg text-white/40 hover:text-amber-400 hover:bg-amber-500/10 transition-all cursor-pointer"
                   >
@@ -987,6 +991,7 @@ export default function OrbViewPage() {
                     <span>Export</span>
                   </button>
                   <label
+                    data-tour="import"
                     className={`h-8 leading-none flex items-center gap-1.5 text-xs sm:text-sm font-medium py-1.5 px-2 sm:px-3 rounded-lg transition-all ${
                       importing
                         ? 'text-purple-300 bg-purple-500/15 cursor-wait'
@@ -1019,15 +1024,17 @@ export default function OrbViewPage() {
 
             <div className="h-8 flex items-center gap-1">
               <ProcessingCounter />
-              <HeaderBtn onClick={() => setShowDrafts(true)} variant="outline">
-                <IconNotes />
-                <span className="hidden sm:inline">Notes</span>
-                {draftNotes.length > 0 && (
-                  <span className="bg-purple-500 text-white text-[10px] font-bold leading-none w-4 h-4 rounded-full flex items-center justify-center">
-                    {draftNotes.length}
-                  </span>
-                )}
-              </HeaderBtn>
+              <div data-tour="notes">
+                <HeaderBtn onClick={() => setShowDrafts(true)} variant="outline">
+                  <IconNotes />
+                  <span className="hidden sm:inline">Notes</span>
+                  {draftNotes.length > 0 && (
+                    <span className="bg-purple-500 text-white text-[10px] font-bold leading-none w-4 h-4 rounded-full flex items-center justify-center">
+                      {draftNotes.length}
+                    </span>
+                  )}
+                </HeaderBtn>
+              </div>
 
               {!isPendingDeletion && (
                 <div className="relative sm:hidden" ref={toolsMenuRef}>
@@ -1151,7 +1158,9 @@ export default function OrbViewPage() {
               )}
 
               <div className="w-px h-5 bg-white/10 mx-1 hidden sm:block" />
-              <UserMenu orbId={data.person.orb_id as string} onOrbIdChanged={fetchOrb} label={(data.person.name as string) || user?.name || 'My Orbis'} />
+              <div data-tour="user-menu">
+                <UserMenu orbId={data.person.orb_id as string} onOrbIdChanged={fetchOrb} label={(data.person.name as string) || user?.name || 'My Orbis'} />
+              </div>
             </div>
           </div>
 
@@ -1201,7 +1210,7 @@ export default function OrbViewPage() {
       )}
 
       {/* ── 3D Graph ── */}
-      <div className={isPendingDeletion ? 'opacity-60 grayscale pointer-events-none' : ''}>
+      <div data-tour="graph" className={isPendingDeletion ? 'opacity-60 grayscale pointer-events-none' : ''}>
         <OrbGraph3D
           data={data}
           onNodeClick={isPendingDeletion ? undefined : handleNodeClick}
@@ -1265,7 +1274,7 @@ export default function OrbViewPage() {
       />}
 
       {/* ── Chat Box ── */}
-      {!isPendingDeletion && <ChatBox
+      {!isPendingDeletion && <div data-tour="chatbox"><ChatBox
         onHighlight={setHighlightedNodeIds}
         onFocusNode={handleFocusNode}
         onClearResults={handleChatClear}
@@ -1275,7 +1284,7 @@ export default function OrbViewPage() {
         onAdd={() => { setEditNode(null); setDraftReferenceText(null); setShowInput(true); }}
         onShare={() => setShowShare(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
-      />}
+      /></div>}
 
       {/* ── Draft Notes ── */}
       <DraftNotes
@@ -1362,6 +1371,9 @@ export default function OrbViewPage() {
           </div>
         </div>
       )}
+
+      {/* ── Guided Tour ── */}
+      <GuidedTour />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #11

Adds an interactive guided tour for first-time users on `/myorbis` using `react-joyride`.

### Tour Steps (9)
1. **3D Graph** — rotate, zoom, click nodes
2. **Node/edge count** — stats display
3. **Undo/redo** — reverse recent changes
4. **Node types** — filter by category
5. **Export** — generate PDF CV
6. **Import** — add documents
7. **Notes** — draft notes with AI enhancement
8. **ChatBox** — search and share
9. **User menu** — settings, CVs, sign out

### Features
- Auto-triggers on first visit to `/myorbis` (if tour not completed)
- Dark-themed tooltips matching the app design
- Skip/dismiss available at every step
- Progress indicator (step N of 9)
- "Restart guided tour" button in Account Settings > Account tab
- Tour completion persisted in `localStorage`
- `data-tour` attributes on key elements for stable targeting

### New dependency
- `react-joyride` (React tour/walkthrough library)

## Documentation

No doc changes needed — frontend-only UI feature.

## Test plan

- [ ] New user: tour auto-starts on first visit to /myorbis
- [ ] Tour highlights each element correctly (spotlight + tooltip)
- [ ] Skip button dismisses the tour at any step
- [ ] After completing/skipping, tour doesn't reappear on refresh
- [ ] Account Settings > "Restart guided tour" resets and tour shows on next page load
- [ ] Mobile: tour works (may skip desktop-only elements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)