### PR TITLE
feat: guided tour, snapshot fix, and onboarding improvements

### DIFF
--- a/backend/app/snapshots/service.py
+++ b/backend/app/snapshots/service.py
@@ -132,6 +132,19 @@ async def create_snapshot(
 
     data = serialize_orb_raw(record)
     node_count, edge_count = count_from_serialized(data)
+
+    # Skip snapshot if orb is empty (nothing to preserve)
+    if node_count == 0:
+        return {
+            "snapshot_id": None,
+            "user_id": user_id,
+            "trigger": trigger,
+            "label": label,
+            "node_count": 0,
+            "edge_count": 0,
+            "skipped": True,
+        }
+
     snapshot_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat()
 

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Joyride, STATUS, ACTIONS, EVENTS } from 'react-joyride';
+import { Joyride } from 'react-joyride';
 import type { CallBackProps, Step } from 'react-joyride';
 
 const TOUR_COMPLETED_KEY = 'orbis_tour_completed';
@@ -87,16 +87,13 @@ export default function GuidedTour({ run: runOverride, onFinish }: GuidedTourPro
   }, [runOverride]);
 
   const handleCallback = useCallback((data: CallBackProps) => {
-    const { status, action, type } = data;
+    const { status, action } = data;
 
-    if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
-      markTourCompleted();
-      setRun(false);
-      onFinish?.();
-    }
+    // Use string values directly — the named exports may be undefined in ESM
+    const isFinished = status === 'finished' || status === 'skipped';
+    const isClosed = action === 'close';
 
-    // Close on overlay click
-    if (type === EVENTS.STEP_AFTER && action === ACTIONS.CLOSE) {
+    if (isFinished || isClosed) {
       markTourCompleted();
       setRun(false);
       onFinish?.();

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,6 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Joyride } from 'react-joyride';
-import type { CallBackProps, Step } from 'react-joyride';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 
 const TOUR_COMPLETED_KEY = 'orbis_tour_completed';
 
@@ -16,7 +14,19 @@ export function resetTour(): void {
   localStorage.removeItem(TOUR_COMPLETED_KEY);
 }
 
-const STEPS: Step[] = [
+// Lazy-load react-joyride to avoid ESM import issues with Vite
+const LazyJoyride = lazy(() =>
+  import('react-joyride').then((mod) => ({ default: mod.Joyride }))
+);
+
+interface TourStep {
+  target: string;
+  content: string;
+  placement?: string;
+  disableBeacon?: boolean;
+}
+
+const STEPS: TourStep[] = [
   {
     target: '[data-tour="graph"]',
     content: 'This is your Orbis — a 3D knowledge graph of your professional profile. Rotate by dragging, zoom with scroll, and click any node to view or edit it.',
@@ -78,91 +88,89 @@ export default function GuidedTour({ run: runOverride, onFinish }: GuidedTourPro
       setRun(runOverride);
       return;
     }
-    // Auto-start for new users who haven't completed the tour
     if (!isTourCompleted()) {
-      // Small delay to let the page render and elements mount
       const timer = setTimeout(() => setRun(true), 1500);
       return () => clearTimeout(timer);
     }
   }, [runOverride]);
 
-  const handleCallback = useCallback((data: CallBackProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleCallback = useCallback((data: any) => {
     const { status, action } = data;
-
-    // Use string values directly — the named exports may be undefined in ESM
-    const isFinished = status === 'finished' || status === 'skipped';
-    const isClosed = action === 'close';
-
-    if (isFinished || isClosed) {
+    if (status === 'finished' || status === 'skipped' || action === 'close') {
       markTourCompleted();
       setRun(false);
       onFinish?.();
     }
   }, [onFinish]);
 
+  if (!run) return null;
+
   return (
-    <Joyride
-      steps={STEPS}
-      run={run}
-      continuous
-      showSkipButton
-      showProgress
-      disableOverlayClose={false}
-      callback={handleCallback}
-      locale={{
-        back: 'Back',
-        close: 'Got it',
-        last: 'Finish',
-        next: 'Next',
-        skip: 'Skip tour',
-      }}
-      styles={{
-        options: {
-          arrowColor: 'rgb(23, 23, 23)',
-          backgroundColor: 'rgb(23, 23, 23)',
-          overlayColor: 'rgba(0, 0, 0, 0.75)',
-          primaryColor: '#a855f6',
-          textColor: 'rgba(255, 255, 255, 0.85)',
-          zIndex: 10000,
-        },
-        tooltip: {
-          borderRadius: 16,
-          padding: '20px 24px',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
-          boxShadow: '0 25px 50px rgba(0, 0, 0, 0.5)',
-        },
-        tooltipContent: {
-          fontSize: 14,
-          lineHeight: '1.6',
-          padding: '8px 0',
-        },
-        tooltipTitle: {
-          fontSize: 16,
-          fontWeight: 600,
-        },
-        buttonNext: {
-          backgroundColor: '#a855f6',
-          borderRadius: 8,
-          fontSize: 13,
-          fontWeight: 600,
-          padding: '8px 16px',
-        },
-        buttonBack: {
-          color: 'rgba(255, 255, 255, 0.5)',
-          fontSize: 13,
-          marginRight: 8,
-        },
-        buttonSkip: {
-          color: 'rgba(255, 255, 255, 0.3)',
-          fontSize: 12,
-        },
-        buttonClose: {
-          color: 'rgba(255, 255, 255, 0.4)',
-        },
-        spotlight: {
-          borderRadius: 12,
-        },
-      }}
-    />
+    <Suspense fallback={null}>
+      <LazyJoyride
+        steps={STEPS}
+        run={run}
+        continuous
+        showSkipButton
+        showProgress
+        disableOverlayClose={false}
+        callback={handleCallback}
+        locale={{
+          back: 'Back',
+          close: 'Got it',
+          last: 'Finish',
+          next: 'Next',
+          skip: 'Skip tour',
+        }}
+        styles={{
+          options: {
+            arrowColor: 'rgb(23, 23, 23)',
+            backgroundColor: 'rgb(23, 23, 23)',
+            overlayColor: 'rgba(0, 0, 0, 0.75)',
+            primaryColor: '#a855f6',
+            textColor: 'rgba(255, 255, 255, 0.85)',
+            zIndex: 10000,
+          },
+          tooltip: {
+            borderRadius: 16,
+            padding: '20px 24px',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            boxShadow: '0 25px 50px rgba(0, 0, 0, 0.5)',
+          },
+          tooltipContent: {
+            fontSize: 14,
+            lineHeight: '1.6',
+            padding: '8px 0',
+          },
+          tooltipTitle: {
+            fontSize: 16,
+            fontWeight: 600,
+          },
+          buttonNext: {
+            backgroundColor: '#a855f6',
+            borderRadius: 8,
+            fontSize: 13,
+            fontWeight: 600,
+            padding: '8px 16px',
+          },
+          buttonBack: {
+            color: 'rgba(255, 255, 255, 0.5)',
+            fontSize: 13,
+            marginRight: 8,
+          },
+          buttonSkip: {
+            color: 'rgba(255, 255, 255, 0.3)',
+            fontSize: 12,
+          },
+          buttonClose: {
+            color: 'rgba(255, 255, 255, 0.4)',
+          },
+          spotlight: {
+            borderRadius: 12,
+          },
+        }}
+      />
+    </Suspense>
   );
 }

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -426,7 +426,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
           </div>
 
           {/* Tab content */}
-          <div className="flex-1 p-4 sm:p-6 overflow-hidden flex flex-col min-h-0 bg-black/10">
+          <div className="flex-1 p-4 sm:p-6 overflow-y-auto flex flex-col min-h-0 bg-black/10">
             <AnimatePresence mode="wait">
               {/* ── Orbis ID tab ── */}
               {activeTab === 'orb-id' && (
@@ -566,7 +566,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -8 }}
                   transition={{ duration: 0.15, ease: 'easeInOut' }}
-                  className="space-y-3"
+                  className="space-y-3 overflow-y-auto"
                 >
                   <label className="text-xs text-white/45 uppercase tracking-[0.12em] font-medium">Account</label>
                   <p className="text-[11px] text-white/45 mt-0.5">Manage your account and data.</p>

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -423,6 +423,21 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                 {tab.label}
               </button>
             ))}
+            <div className="mt-auto pt-3 border-t border-white/5">
+              <button
+                onClick={() => {
+                  resetTour();
+                  addToast('Guided tour will restart on next page load', 'info');
+                  onClose();
+                }}
+                className="flex items-center gap-2.5 text-left px-3 py-2.5 rounded-lg text-sm text-white/40 hover:text-white/70 hover:bg-white/5 transition-colors cursor-pointer w-full"
+              >
+                <svg className="w-4 h-4 text-purple-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+                </svg>
+                Guided tour
+              </button>
+            </div>
           </div>
 
           {/* Tab content */}
@@ -570,22 +585,6 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
                 >
                   <label className="text-xs text-white/45 uppercase tracking-[0.12em] font-medium">Account</label>
                   <p className="text-[11px] text-white/45 mt-0.5">Manage your account and data.</p>
-
-                  <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-3">
-                    <button
-                      onClick={() => {
-                        resetTour();
-                        addToast('Guided tour will restart on next page load', 'info');
-                        onClose();
-                      }}
-                      className="w-full flex items-center gap-2.5 text-xs text-white/60 hover:text-white/90 transition-colors cursor-pointer"
-                    >
-                      <svg className="w-4 h-4 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
-                      </svg>
-                      Restart guided tour
-                    </button>
-                  </div>
 
                   {user?.deletion_days_remaining != null ? (
                     /* ── Account pending deletion — show recovery ── */

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -5,7 +5,6 @@ import { createPortal } from 'react-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
-import { resetTour } from './GuidedTour';
 import { claimOrbId, getVersions, createVersion, restoreVersion, deleteVersion } from '../api/orbs';
 import type { SnapshotMetadata } from '../api/orbs';
 import { getDocuments, downloadCV } from '../api/cv';
@@ -16,9 +15,10 @@ interface UserMenuProps {
   onOrbIdChanged?: () => void;
   /** Display name next to avatar — makes the whole thing a clickable pill */
   label?: string;
+  onStartTour?: () => void;
 }
 
-export default function UserMenu({ orbId, onOrbIdChanged, label }: UserMenuProps) {
+export default function UserMenu({ orbId, onOrbIdChanged, label, onStartTour }: UserMenuProps) {
   const { user, logout } = useAuthStore();
   const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
@@ -219,6 +219,7 @@ export default function UserMenu({ orbId, onOrbIdChanged, label }: UserMenuProps
             orbId={orbId}
             onOrbIdChanged={onOrbIdChanged}
             onClose={() => setShowAccountSettings(false)}
+            onStartTour={onStartTour}
           />
         </AnimatePresence>,
         document.body,
@@ -229,10 +230,11 @@ export default function UserMenu({ orbId, onOrbIdChanged, label }: UserMenuProps
 
 // ── Account Settings Modal ──
 
-function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
+function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
   orbId?: string;
   onOrbIdChanged?: () => void;
   onClose: () => void;
+  onStartTour?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState<'orb-id' | 'versions' | 'account'>('orb-id');
   const { user, logout } = useAuthStore();
@@ -426,9 +428,8 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose }: {
             <div className="mt-auto pt-3 border-t border-white/5">
               <button
                 onClick={() => {
-                  resetTour();
-                  addToast('Guided tour will restart on next page load', 'info');
                   onClose();
+                  onStartTour?.();
                 }}
                 className="flex items-center gap-2.5 text-left px-3 py-2.5 rounded-lg text-sm text-white/40 hover:text-white/70 hover:bg-white/5 transition-colors cursor-pointer w-full"
               >

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { uploadCV, getCVProgress, getDocuments } from '../../api/cv';
 import type { ExtractedData, ExtractedRelationship, CVProgressData } from '../../api/cv';
 import { useAuthStore } from '../../stores/authStore';
@@ -6,12 +7,17 @@ import { loadDraftNotes, saveDraftNotes } from '../drafts/DraftNotes';
 import ExtractedDataReview from './ExtractedDataReview';
 
 export default function CVUploadOnboarding() {
+  const navigate = useNavigate();
   const { user } = useAuthStore();
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState('');
+  const [errorDetails, setErrorDetails] = useState('');
+  const [showTechDetails, setShowTechDetails] = useState(false);
+  const [lastFile, setLastFile] = useState<File | null>(null);
   const [progressData, setProgressData] = useState<CVProgressData | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Poll progress while uploading
   useEffect(() => {
@@ -50,6 +56,8 @@ export default function CVUploadOnboarding() {
   const doUpload = useCallback(async (file: File) => {
     setUploading(true);
     setError('');
+    setErrorDetails('');
+    setShowTechDetails(false);
     try {
       const data = await uploadCV(file);
 
@@ -82,17 +90,20 @@ export default function CVUploadOnboarding() {
           pageCount: null,
         });
       }
-    } catch {
+    } catch (e) {
       setError('Failed to parse CV. Please try again or use manual entry.');
+      setErrorDetails(e instanceof Error ? e.message : 'Unknown upload error');
     } finally {
       setUploading(false);
     }
   }, [user]);
 
   const handleFile = useCallback(async (file: File) => {
+    setLastFile(file);
     const ext = file.name.split('.').pop()?.toLowerCase();
     if (ext !== 'pdf') {
       setError('Please upload a PDF file.');
+      setErrorDetails(`Unsupported file extension: .${ext || 'unknown'}`);
       return;
     }
 
@@ -124,6 +135,11 @@ export default function CVUploadOnboarding() {
     }
   }, [pendingFile, doUpload]);
 
+  const handleRetry = useCallback(async () => {
+    if (!lastFile || uploading) return;
+    await doUpload(lastFile);
+  }, [lastFile, uploading, doUpload]);
+
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
@@ -152,22 +168,48 @@ export default function CVUploadOnboarding() {
         originalFilename={extractedData.originalFilename}
         fileSizeBytes={extractedData.fileSizeBytes}
         pageCount={extractedData.pageCount}
-      />
+      >
+        <div className="mt-4">
+          <OnboardingStages current="review" />
+        </div>
+      </ExtractedDataReview>
     );
   }
 
   // ── Upload mode ──
   return (
-    <div className="min-h-screen bg-black flex flex-col items-center justify-center px-3 sm:px-4">
-      <div className="w-full max-w-[95vw] sm:max-w-lg">
-        <div className="text-center mb-8">
+    <div className="min-h-screen bg-black flex flex-col items-center px-3 sm:px-4 py-8 pb-28">
+      <div className="w-full max-w-[95vw] sm:max-w-xl">
+        <OnboardingStages current={uploading ? 'process' : 'upload'} />
+
+        <div className="text-center mt-6 mb-6">
           <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-blue-500/15 border border-blue-500/25 flex items-center justify-center">
             <svg className="w-6 h-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
           </div>
           <h2 className="text-white text-xl font-semibold">Import from your CV</h2>
-          <p className="text-white/30 text-sm mt-1">Upload a PDF and we'll extract your entries automatically.</p>
+          <p className="text-white/30 text-sm mt-1">Upload a CV and review extracted entries before publishing to your orbis.</p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
+          <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2.5">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-white/55 mb-1">Import behavior</p>
+            <p className="text-xs text-white/35 leading-relaxed">
+              Entries are reviewed first, then merged into your orbis when you confirm.
+            </p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2.5">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-white/55 mb-1">Storage policy</p>
+            <p className="text-xs text-white/35 leading-relaxed">
+              If you already have 3 documents, we ask confirmation before replacing the oldest one.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-200">You can continue later</span>
+          <span className="rounded-full border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-[11px] text-blue-200">Processing can continue in background</span>
         </div>
 
         {/* Dropzone */}
@@ -188,21 +230,25 @@ export default function CVUploadOnboarding() {
               <svg className="w-10 h-10 mx-auto text-white/15 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
               </svg>
-              <p className="text-white/50 text-sm mb-1">
-                <span className="text-purple-400 font-medium">Click to browse</span> or drag & drop
+              <p className="text-white/70 text-sm mb-1 font-medium">
+                Click to browse or drag and drop your CV
               </p>
-              <p className="text-white/20 text-xs">PDF only, up to 10MB</p>
+              <div className="flex items-center justify-center gap-2 text-[11px] text-white/35">
+                <span className="rounded-full border border-white/10 px-2 py-0.5">Format: PDF</span>
+                <span className="rounded-full border border-white/10 px-2 py-0.5">Size: up to 10MB</span>
+              </div>
               <div className="mt-4 pt-3 border-t border-white/5 flex items-center justify-center gap-2">
                 <svg className="w-8 h-8 text-[#0A66C2] flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
                 </svg>
-                <span className="text-white/30 text-[11px] leading-snug">
-                  Tip: If your LinkedIn profile is up to date, you can export it as a PDF. Go to <span className="text-white/50">View my profile</span> &rarr; <span className="text-white/50">Resources</span> &rarr; <span className="text-white/50">Save as PDF</span>, then upload it here.
+                <span className="text-white/30 text-[11px] leading-snug text-left">
+                  Tip: Export your LinkedIn profile as PDF: <span className="text-white/50">View profile</span> → <span className="text-white/50">Resources</span> → <span className="text-white/50">Save as PDF</span>.
                 </span>
               </div>
             </>
           )}
           <input
+            ref={fileInputRef}
             type="file"
             accept=".pdf"
             onChange={handleFileInput}
@@ -211,7 +257,40 @@ export default function CVUploadOnboarding() {
           />
         </label>
 
-        {error && <p className="text-red-400 text-sm text-center mt-4">{error}</p>}
+        {error && (
+          <div className="mt-4 rounded-xl border border-red-500/35 bg-red-500/10 px-3 py-3">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-red-300 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <div className="flex-1">
+                <p className="text-red-200 text-sm font-medium">{error}</p>
+                <div className="mt-2 flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleRetry}
+                    disabled={!lastFile || uploading}
+                    className="rounded-md border border-red-400/40 bg-red-500/20 px-2.5 py-1 text-xs text-red-100 disabled:opacity-40"
+                  >
+                    Retry
+                  </button>
+                  {errorDetails && (
+                    <button
+                      type="button"
+                      onClick={() => setShowTechDetails((prev) => !prev)}
+                      className="text-xs text-red-200/80 hover:text-red-100"
+                    >
+                      {showTechDetails ? 'Hide technical details' : 'Show technical details'}
+                    </button>
+                  )}
+                </div>
+                {showTechDetails && errorDetails && (
+                  <pre className="mt-2 text-[11px] text-red-100/80 bg-black/30 border border-red-400/20 rounded p-2 overflow-x-auto">{errorDetails}</pre>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
 
         {showLimitWarning && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm px-4">
@@ -250,11 +329,72 @@ export default function CVUploadOnboarding() {
           </div>
         )}
       </div>
+
+      {/* Sticky actions */}
+      <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-white/10 bg-black/90 backdrop-blur px-3 py-3">
+        <div className="w-full max-w-[95vw] sm:max-w-xl mx-auto flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/create')}
+            className="border border-white/15 hover:border-white/30 text-white/65 hover:text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white text-sm font-semibold py-2 px-4 rounded-lg transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
 
 // ── Progress steps display ──
+
+const STAGES = [
+  { key: 'upload', label: 'Upload' },
+  { key: 'process', label: 'Process' },
+  { key: 'review', label: 'Review' },
+  { key: 'publish', label: 'Publish' },
+];
+
+function OnboardingStages({ current }: { current: 'upload' | 'process' | 'review' | 'publish' }) {
+  const currentIdx = STAGES.findIndex((s) => s.key === current);
+  return (
+    <div className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
+      <div className="flex items-center gap-2 sm:gap-3 overflow-x-auto">
+        {STAGES.map((stage, idx) => {
+          const done = idx < currentIdx;
+          const active = idx === currentIdx;
+          return (
+            <div key={stage.key} className="flex items-center gap-2 shrink-0">
+              <div
+                className={`w-5 h-5 rounded-full border text-[10px] font-semibold flex items-center justify-center ${
+                  done
+                    ? 'bg-green-500/20 border-green-500/40 text-green-300'
+                    : active
+                      ? 'bg-purple-500/20 border-purple-500/40 text-purple-200'
+                      : 'bg-white/[0.03] border-white/15 text-white/40'
+                }`}
+              >
+                {done ? '✓' : idx + 1}
+              </div>
+              <span className={`text-xs ${active ? 'text-white' : done ? 'text-white/70' : 'text-white/35'}`}>
+                {stage.label}
+              </span>
+              {idx < STAGES.length - 1 && <span className="text-white/15">→</span>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 const STEPS = [
   { key: 'reading_pdf', label: 'Reading PDF' },
@@ -266,18 +406,22 @@ const STEPS = [
 function ProgressSteps({ progress }: { progress: CVProgressData | null }) {
   const currentStep = progress?.step || 'reading_pdf';
   const percent = progress?.percent || 5;
-  const detail = progress?.detail || '';
-  const elapsed = progress?.elapsed_seconds || 0;
+  const detail = progress?.detail || progress?.message || '';
 
   const currentIdx = STEPS.findIndex((s) => s.key === currentStep);
-
-  const formatTime = (secs: number) => {
-    if (secs < 60) return `${secs}s`;
-    return `${Math.floor(secs / 60)}m ${secs % 60}s`;
-  };
+  const completedChecks = currentStep === 'done'
+    ? STEPS.length
+    : currentIdx >= 0
+      ? currentIdx
+      : 0;
 
   return (
     <div className="flex flex-col items-center gap-4 py-2">
+      <div className="w-full max-w-xs flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-wide text-white/45">Processing state</span>
+        <span className="text-[11px] text-purple-300 font-medium">{detail || 'Working...'}</span>
+      </div>
+
       {/* Steps */}
       <div className="w-full max-w-xs space-y-2">
         {STEPS.map((step, i) => {
@@ -327,14 +471,9 @@ function ProgressSteps({ progress }: { progress: CVProgressData | null }) {
         </div>
         <div className="flex justify-between mt-1.5">
           <span className="text-white/20 text-[10px]">{percent}%</span>
-          <span className="text-white/20 text-[10px]">{formatTime(elapsed)}</span>
+          <span className="text-white/20 text-[10px]">{completedChecks}/{STEPS.length} checks completed</span>
         </div>
       </div>
-
-      {/* Detail */}
-      {detail && (
-        <p className="text-white/30 text-xs text-center">{detail}</p>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -9,6 +9,40 @@ import NodeForm from '../editor/NodeForm';
 import { useAuthStore } from '../../stores/authStore';
 import { useToastStore } from '../../stores/toastStore';
 
+const REVIEW_REQUIRED_FIELDS: Record<string, string[]> = {
+  skill: ['name'],
+  language: ['name'],
+  work_experience: ['company', 'title'],
+  education: ['institution', 'degree'],
+  certification: ['name', 'issuing_organization'],
+  publication: ['title'],
+  project: ['name'],
+  patent: ['title'],
+  award: ['name'],
+  outreach: ['title', 'venue'],
+};
+
+function normalizeNodeType(type: string) {
+  return type.toLowerCase();
+}
+
+function getMissingFields(nodeType: string, props: Record<string, unknown>): string[] {
+  const required = REVIEW_REQUIRED_FIELDS[normalizeNodeType(nodeType)] || [];
+  return required.filter((field) => !String(props[field] ?? '').trim());
+}
+
+function parseConfidence(props: Record<string, unknown>): number | null {
+  const raw = props.confidence;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw <= 1 ? raw : raw / 100;
+  }
+  if (typeof raw === 'string') {
+    const num = Number(raw.trim());
+    if (Number.isFinite(num)) return num <= 1 ? num : num / 100;
+  }
+  return null;
+}
+
 interface ExtractedDataReviewProps {
   initialNodes: ExtractedData['nodes'];
   initialRelationships: ExtractedRelationship[];
@@ -60,6 +94,7 @@ export default function ExtractedDataReview({
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'ready' | 'missing' | 'low'>('all');
   const [existingNodeCount, setExistingNodeCount] = useState<number | null>(null);
   const [showReplaceWarning, setShowReplaceWarning] = useState(false);
   const isReplaceMode = !onConfirmOverride;
@@ -125,10 +160,52 @@ export default function ExtractedDataReview({
     }
   };
 
-  const grouped = extractedNodes.reduce<Record<string, Array<{ index: number; props: Record<string, unknown> }>>>((acc, node, i) => {
-    const type = node.node_type;
-    if (!acc[type]) acc[type] = [];
-    acc[type].push({ index: i, props: node.properties });
+  const reviewed = extractedNodes.map((node, i) => {
+    const missingFields = getMissingFields(node.node_type, node.properties);
+    const confidence = parseConfidence(node.properties);
+    const lowConfidence = confidence !== null && confidence < 0.6;
+    return {
+      index: i,
+      type: node.node_type,
+      props: node.properties,
+      missingFields,
+      confidence,
+      lowConfidence,
+      ready: missingFields.length === 0 && !lowConfidence,
+    };
+  });
+
+  const readyCount = reviewed.filter((r) => r.ready).length;
+  const missingCount = reviewed.filter((r) => r.missingFields.length > 0).length;
+  const lowCount = reviewed.filter((r) => r.lowConfidence).length;
+  const edgesCount = relationships.length;
+
+  const groupedConfidence = reviewed.reduce<Record<string, { sum: number; count: number }>>((acc, row) => {
+    if (row.confidence === null) return acc;
+    const key = normalizeNodeType(row.type);
+    if (!acc[key]) acc[key] = { sum: 0, count: 0 };
+    acc[key].sum += row.confidence;
+    acc[key].count += 1;
+    return acc;
+  }, {});
+
+  const filteredReviewed = reviewed.filter((row) => {
+    if (statusFilter === 'ready') return row.ready;
+    if (statusFilter === 'missing') return row.missingFields.length > 0;
+    if (statusFilter === 'low') return row.lowConfidence;
+    return true;
+  });
+
+  const grouped = filteredReviewed.reduce<Record<string, Array<{
+    index: number;
+    props: Record<string, unknown>;
+    missingFields: string[];
+    confidence: number | null;
+    lowConfidence: boolean;
+    ready: boolean;
+  }>>>((acc, row) => {
+    if (!acc[row.type]) acc[row.type] = [];
+    acc[row.type].push(row);
     return acc;
   }, {});
 
@@ -160,10 +237,63 @@ export default function ExtractedDataReview({
               {skippedCount} entr{skippedCount === 1 ? 'y was' : 'ies were'} skipped due to missing required fields or unknown types.
             </p>
           )}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-4 text-left">
+            <StatusTile label="Nodes" value={String(extractedNodes.length)} tone="neutral" />
+            <StatusTile label="Edges" value={String(edgesCount)} tone="neutral" />
+            <StatusTile label="Ready" value={String(readyCount)} tone="success" />
+            <StatusTile label="Needs Attention" value={String(missingCount + lowCount)} tone="warn" />
+          </div>
+          {Object.keys(groupedConfidence).length > 0 && (
+            <div className="mt-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-left">
+              <p className="text-[10px] uppercase tracking-wide text-white/45 mb-1">Section Confidence</p>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(groupedConfidence).map(([type, data]) => {
+                  const label = NODE_TYPE_LABELS[type] || type;
+                  const avg = Math.round((data.sum / data.count) * 100);
+                  return (
+                    <span key={type} className="text-xs text-white/65 border border-white/10 rounded-full px-2 py-0.5">
+                      {label}: {avg}%
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          <div className="flex flex-wrap justify-center gap-1.5 mt-3">
+            {[
+              { key: 'all', label: `All (${reviewed.length})` },
+              { key: 'ready', label: `Ready (${readyCount})` },
+              { key: 'missing', label: `Missing required (${missingCount})` },
+              { key: 'low', label: `Low confidence (${lowCount})` },
+            ].map((filter) => (
+              <button
+                key={filter.key}
+                type="button"
+                onClick={() => setStatusFilter(filter.key as 'all' | 'ready' | 'missing' | 'low')}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  statusFilter === filter.key
+                    ? 'border-purple-400/50 bg-purple-500/15 text-purple-200'
+                    : 'border-white/15 text-white/45 hover:text-white/70 hover:border-white/30'
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+          {statusFilter !== 'all' && (
+            <p className="text-[11px] text-white/35 mt-2">
+              Showing {filteredReviewed.length} of {reviewed.length} entries.
+            </p>
+          )}
           {children}
         </div>
 
         <div className="space-y-6 mb-8">
+          {Object.keys(grouped).length === 0 && (
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-center">
+              <p className="text-white/55 text-sm">No entries match the selected filter.</p>
+            </div>
+          )}
           {Object.entries(grouped).map(([type, items]) => {
             const color = NODE_TYPE_COLORS[type] || '#8b5cf6';
             const label = NODE_TYPE_LABELS[type] || type;
@@ -175,7 +305,7 @@ export default function ExtractedDataReview({
                   <span className="text-white/20 text-xs">({items.length})</span>
                 </div>
                 <div className="space-y-2">
-                  {items.map(({ index, props }) => {
+                  {items.map(({ index, props, missingFields, confidence, lowConfidence, ready }) => {
                     if (editingIndex === index) {
                       return (
                         <motion.div
@@ -197,7 +327,7 @@ export default function ExtractedDataReview({
                             onCancel={() => setEditingIndex(null)}
                             onEnhance={async (text) => {
                               const existingSkills = extractedNodes
-                                .filter(n => n.node_type === 'Skill' && n.properties.name)
+                                .filter(n => normalizeNodeType(n.node_type) === 'skill' && n.properties.name)
                                 .map((n, i) => ({ uid: `cv-${i}`, name: n.properties.name as string }));
                               const targetLang = localStorage.getItem('orbis_note_target_lang') || 'en';
                               const result = await enhanceNote(text, targetLang, existingSkills);
@@ -216,9 +346,36 @@ export default function ExtractedDataReview({
                         className="flex items-center gap-2 sm:gap-3 bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 group"
                       >
                         <div className="flex-1 min-w-0">
+                          <div className="flex flex-wrap items-center gap-1.5 mb-1">
+                            {ready && (
+                              <span className="text-[10px] rounded-full px-1.5 py-0.5 border border-emerald-500/35 bg-emerald-500/10 text-emerald-200">
+                                Ready
+                              </span>
+                            )}
+                            {missingFields.length > 0 && (
+                              <span className="text-[10px] rounded-full px-1.5 py-0.5 border border-red-500/35 bg-red-500/10 text-red-200">
+                                Missing required
+                              </span>
+                            )}
+                            {lowConfidence && (
+                              <span className="text-[10px] rounded-full px-1.5 py-0.5 border border-amber-500/35 bg-amber-500/10 text-amber-200">
+                                Low confidence
+                              </span>
+                            )}
+                            {confidence !== null && (
+                              <span className="text-[10px] rounded-full px-1.5 py-0.5 border border-white/15 bg-white/[0.03] text-white/55">
+                                {(confidence * 100).toFixed(0)}%
+                              </span>
+                            )}
+                          </div>
                           <div className="text-white/80 text-sm font-medium truncate">{title}</div>
                           {subtitle && subtitle !== title && (
                             <div className="text-white/30 text-xs truncate">{subtitle}</div>
+                          )}
+                          {missingFields.length > 0 && (
+                            <div className="text-red-300/80 text-[11px] mt-1">
+                              Missing: {missingFields.map((f) => f.replace(/_/g, ' ')).join(', ')}
+                            </div>
                           )}
                         </div>
                         <button
@@ -326,6 +483,21 @@ export default function ExtractedDataReview({
           </motion.div>
         )}
       </AnimatePresence>
+    </div>
+  );
+}
+
+function StatusTile({ label, value, tone }: { label: string; value: string; tone: 'neutral' | 'success' | 'warn' }) {
+  const toneClass = tone === 'success'
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+    : tone === 'warn'
+      ? 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+      : 'border-white/10 bg-white/[0.03] text-white/65';
+
+  return (
+    <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
+      <p className="text-[10px] uppercase tracking-wide opacity-80">{label}</p>
+      <p className="text-sm font-semibold mt-0.5">{value}</p>
     </div>
   );
 }

--- a/frontend/src/pages/CreateOrbPage.tsx
+++ b/frontend/src/pages/CreateOrbPage.tsx
@@ -20,44 +20,6 @@ const SUGGESTED_ORDER = [
   { type: 'publication', prompt: 'Any publications?' },
 ];
 
-// ── Path selector card ──
-
-function PathCard({ title, description, icon, onClick, color, recommended }: {
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-  onClick: () => void;
-  color: string;
-  recommended?: boolean;
-}) {
-  return (
-    <div className="flex flex-col items-center">
-      <motion.button
-        whileHover={{ scale: 1.03 }}
-        whileTap={{ scale: 0.98 }}
-        onClick={onClick}
-        className={`bg-white/[0.03] rounded-2xl p-4 sm:p-6 text-left hover:bg-white/[0.06] transition-all group w-full ${
-          recommended
-            ? 'border-2 border-amber-500/50 hover:border-amber-400/70'
-            : 'border border-white/[0.08] hover:border-white/15'
-        }`}
-      >
-        <div
-          className="w-12 h-12 rounded-xl flex items-center justify-center mb-4 transition-transform group-hover:scale-110"
-          style={{ backgroundColor: `${color}15`, border: `1px solid ${color}30` }}
-        >
-          {icon}
-        </div>
-        <h3 className="text-white text-base font-semibold mb-1.5">{title}</h3>
-        <p className="text-white/35 text-sm leading-relaxed">{description}</p>
-      </motion.button>
-      {recommended && (
-        <span className="mt-2 text-xs font-medium text-amber-400/80 uppercase tracking-widest">recommended</span>
-      )}
-    </div>
-  );
-}
-
 export default function CreateOrbPage() {
   const navigate = useNavigate();
   const { data, loading, fetchOrb, addNode } = useOrbStore();
@@ -121,14 +83,14 @@ export default function CreateOrbPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-10"
+          className="text-center mb-8 w-full max-w-2xl"
         >
           <h1 className="text-3xl sm:text-4xl font-bold text-white mb-3">
             How do you want to build your{' '}
             <span className="bg-gradient-to-r from-purple-400 to-indigo-400 bg-clip-text text-transparent">orbis</span>?
           </h1>
           <p className="text-white/35 text-base max-w-md mx-auto">
-            Choose how you'd like to add your professional information. You can always add more later.
+            Choose your starting path. You can always add or edit entries later.
           </p>
         </motion.div>
 
@@ -136,31 +98,29 @@ export default function CreateOrbPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.6 }}
-          className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-2xl"
+          className="w-full max-w-xl rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-5"
         >
-          <PathCard
-            title="Build from your CV"
-            description="Upload a PDF file. We'll parse it and extract your experiences, skills, and education."
-            color="#3b82f6"
-            recommended
+          <div className="space-y-3 mb-4">
+            <h2 className="text-white font-semibold text-base">What will happen next</h2>
+            <ul className="space-y-1.5 text-sm text-white/45">
+              <li>1. Upload your CV and review extracted entries.</li>
+              <li>2. Edit or remove anything before adding to your orbis.</li>
+              <li>3. Publish to see your graph and keep enriching it.</li>
+            </ul>
+          </div>
+
+          <button
             onClick={() => setSelectedPath('upload')}
-            icon={
-              <svg className="w-6 h-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-              </svg>
-            }
-          />
-          <PathCard
-            title="Build from scratch"
-            description="Start with an empty orbis and add entries one by one. Full control over every detail."
-            color="#10b981"
+            className="w-full rounded-xl bg-purple-600 hover:bg-purple-500 text-white font-semibold py-3 px-4 transition-colors"
+          >
+            Build from your CV
+          </button>
+          <button
             onClick={() => navigate('/myorbis', { state: { allowEmpty: true } })}
-            icon={
-              <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            }
-          />
+            className="w-full mt-2 rounded-xl border border-white/15 hover:border-white/30 text-white/70 hover:text-white py-3 px-4 transition-colors"
+          >
+            Build from scratch
+          </button>
         </motion.div>
         </div>
       </ConsentGate>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -520,6 +520,7 @@ export default function OrbViewPage() {
   const [showShare, setShowShare] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showDrafts, setShowDrafts] = useState(false);
+  const [tourRunning, setTourRunning] = useState(false);
   const [editNode, setEditNode] = useState<{ type: string; values: Record<string, unknown> } | null>(null);
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
   const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set());
@@ -1159,7 +1160,7 @@ export default function OrbViewPage() {
 
               <div className="w-px h-5 bg-white/10 mx-1 hidden sm:block" />
               <div data-tour="user-menu">
-                <UserMenu orbId={data.person.orb_id as string} onOrbIdChanged={fetchOrb} label={(data.person.name as string) || user?.name || 'My Orbis'} />
+                <UserMenu orbId={data.person.orb_id as string} onOrbIdChanged={fetchOrb} label={(data.person.name as string) || user?.name || 'My Orbis'} onStartTour={() => setTourRunning(true)} />
               </div>
             </div>
           </div>
@@ -1373,7 +1374,7 @@ export default function OrbViewPage() {
       )}
 
       {/* ── Guided Tour ── */}
-      <GuidedTour />
+      <GuidedTour run={tourRunning} onFinish={() => setTourRunning(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #11, closes #214

### Guided Tour (#11)
- Interactive 9-step guided tour for new users using `react-joyride` (lazy-loaded for Vite ESM compat)
- Steps cover: 3D graph, node count, undo/redo, node types, export, import, notes, chatbox, user menu
- Auto-triggers on first visit to `/myorbis`; persists completion in localStorage
- "Guided tour" button in Account Settings sidebar starts tour immediately on click
- `data-tour` attributes on key UI elements for stable targeting

### Snapshot Fix (#214)
- Auto-snapshot before CV import now skips if orb has 0 nodes (avoids confusing "0 nodes · 0 edges" for new users)
- Account settings content area scrollable so all content is accessible

### Onboarding Improvements
- CV import flow clarity and review triage improvements

## Documentation

No doc changes needed — frontend UI features.

## Test plan

- [ ] New user: tour auto-starts on first visit to /myorbis
- [ ] Tour highlights each element with spotlight + tooltip
- [ ] Skip/finish tour → doesn't restart on refresh
- [ ] Settings sidebar > "Guided tour" → starts tour immediately
- [ ] First CV import: no empty "0 nodes" snapshot created
- [ ] Account tab content fully visible (scrollable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)