### PR TITLE
feat: text-size-adaptive progress estimation during CV classification

### DIFF
--- a/backend/app/cv/progress.py
+++ b/backend/app/cv/progress.py
@@ -19,8 +19,8 @@ class CVStep(str, Enum):
 
 STEP_PERCENT: dict[CVStep, int] = {
     CVStep.READING_PDF: 5,
-    CVStep.EXTRACTING_TEXT: 15,
-    CVStep.CLASSIFYING: 25,
+    CVStep.EXTRACTING_TEXT: 20,
+    CVStep.CLASSIFYING: 35,
     CVStep.PARSING_RESPONSE: 90,
     CVStep.DONE: 100,
     CVStep.FAILED: 0,
@@ -43,6 +43,7 @@ class CVProgress:
     message: str
     detail: str = ""
     started_at: float = field(default_factory=time.time)
+    text_chars: int = 0  # character count of text being classified
 
 
 _lock = threading.Lock()
@@ -53,16 +54,19 @@ def set_progress(
     user_id: str,
     step: CVStep,
     detail: str = "",
+    text_chars: int = 0,
 ) -> None:
     with _lock:
         existing = _progress.get(user_id)
         started_at = existing.started_at if existing else time.time()
+        chars = text_chars or (existing.text_chars if existing else 0)
         _progress[user_id] = CVProgress(
             step=step,
             percent=STEP_PERCENT[step],
             message=STEP_MESSAGE[step],
             detail=detail,
             started_at=started_at,
+            text_chars=chars,
         )
 
 
@@ -74,10 +78,17 @@ def get_progress(user_id: str) -> CVProgress | None:
         # Simulate progress during classification (the long step)
         if p.step == CVStep.CLASSIFYING:
             elapsed = time.time() - p.started_at
-            # Gradually increase from 25% to 85% over ~5 minutes
-            fraction = min(elapsed / 300, 0.95)
-            simulated = 25 + int(60 * fraction)
-            # Rotate through processing descriptions
+            # Estimate expected duration based on text size:
+            # ~15s for short CVs (2k chars), ~60s for medium (8k), ~120s for long (15k+)
+            # Baseline 15s + ~7ms per character
+            chars = max(p.text_chars, 2000)
+            estimated_duration = min(15 + chars * 0.007, 180)
+            # Progress from 35% to 88% over the estimated duration
+            # Uses ease-out so early progress feels faster
+            fraction = min(elapsed / estimated_duration, 1.0)
+            eased = 1 - (1 - fraction) ** 2  # quadratic ease-out
+            simulated = 35 + int(53 * eased)
+            # Rotate substep labels based on estimated progress sections
             substeps = [
                 "Identifying work experiences...",
                 "Extracting education entries...",
@@ -87,7 +98,9 @@ def get_progress(user_id: str) -> CVProgress | None:
                 "Mapping skill relationships...",
                 "Validating extracted entries...",
             ]
-            detail = substeps[int(elapsed / 12) % len(substeps)]
+            # Advance substep labels proportionally to progress
+            substep_idx = min(int(fraction * len(substeps)), len(substeps) - 1)
+            detail = substeps[substep_idx]
             return CVProgress(
                 step=p.step,
                 percent=simulated,

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -95,6 +95,7 @@ async def upload_cv(
             user_id,
             CVStep.CLASSIFYING,
             f"Analyzing {len(raw_text):,} characters",
+            text_chars=len(raw_text),
         )
         logger.info(
             "Classifying entries with %s (%d chars)",
@@ -249,6 +250,7 @@ async def import_document(
             user_id,
             CVStep.CLASSIFYING,
             f"Analyzing {len(raw_text):,} characters",
+            text_chars=len(raw_text),
         )
         result = await classify_entries(raw_text)
 


### PR DESCRIPTION
## Summary

Closes #221

Instead of a fixed-rate simulation, the classification progress bar now adapts to the actual text size being processed.

## How it works

The backend estimates expected classification duration based on character count:
- **2,000 chars** (short CV) → ~29s estimated
- **8,000 chars** (medium CV) → ~71s estimated  
- **15,000 chars** (long CV) → ~120s estimated
- Formula: `15s baseline + 7ms per character`, capped at 3 minutes

Progress goes from 35% to 88% over that estimated window using a **quadratic ease-out curve** (early progress feels faster, matching user perception).

Substep labels ("Identifying work experiences...", "Extracting education...", etc.) advance proportionally to the estimated completion — so a short CV cycles through them faster than a long one.

## Changes

- **`backend/app/cv/progress.py`**: Added `text_chars` to `CVProgress`, text-size-adaptive duration estimation, proportional substep label advancement
- **`backend/app/cv/router.py`**: Pass `text_chars=len(raw_text)` when entering classification step (both upload and import paths)

No frontend changes needed — the frontend already reads `progress.percent` from the API.

## Documentation

No doc changes needed.

## Test plan

- [ ] Upload a short CV (~1 page) — progress bar moves quickly through classification
- [ ] Upload a long CV (~5 pages) — progress bar moves slower but steadily
- [ ] Substep labels advance proportionally (not just time-based rotation)
- [ ] Progress reaches ~88% before parsing step kicks in at 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)