### PR TITLE
feat: add recenter button and persist camera zoom level

### DIFF
--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -23,6 +23,7 @@ interface ChatBoxProps {
   placeholder?: string;
   searchFn?: (query: string) => Promise<OrbNode[]>;
   interactionHint?: string;
+  onRecenter?: () => void;
 }
 
 export type { ChatMessage };
@@ -88,6 +89,7 @@ export default function ChatBox({
   placeholder = 'Query your orbis...',
   searchFn = textSearch,
   interactionHint = 'Zoom: mouse wheel · Pan: right-drag · Rotate: left-drag',
+  onRecenter,
 }: ChatBoxProps) {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -398,8 +400,20 @@ export default function ChatBox({
         </div>
       )}
 
-      {/* Bottom bar — chat input + action buttons */}
+      {/* Bottom bar — recenter + chat input + action buttons */}
       <div className="flex items-center gap-2">
+        {onRecenter && (
+          <button
+            type="button"
+            onClick={onRecenter}
+            className="w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-white/10 hover:bg-white/20 border border-white/15 hover:border-white/25 text-white/50 hover:text-white transition-all backdrop-blur-sm flex-shrink-0"
+            title="Recenter graph"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+            </svg>
+          </button>
+        )}
         {/* Chat input */}
         <form onSubmit={handleSubmit} className="flex-1">
           <div

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -21,6 +21,7 @@ interface OrbGraph3DProps {
   cameraDistance?: number;
   focusNodeId?: string | null;
   focusNodeToken?: number;
+  onCameraDistanceChange?: (distance: number) => void;
 }
 
 function getNodeName(node: any): string {
@@ -63,6 +64,7 @@ export default function OrbGraph3D({
   cameraDistance = 400,
   focusNodeId = null,
   focusNodeToken = 0,
+  onCameraDistanceChange,
 }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
@@ -125,6 +127,24 @@ export default function OrbGraph3D({
       el.removeEventListener('mousedown', blockRightMouse, { capture: true } as EventListenerOptions);
     };
   }, [enableZoom, enablePan, data]);
+
+  // Track camera distance changes (debounced) for zoom persistence
+  useEffect(() => {
+    if (!onCameraDistanceChange) return;
+    let lastReported = cameraDistance;
+    const interval = setInterval(() => {
+      const fg = fgRef.current;
+      if (!fg) return;
+      const pos = fg.cameraPosition();
+      if (!pos) return;
+      const dist = Math.round(Math.sqrt(pos.x * pos.x + pos.y * pos.y + pos.z * pos.z));
+      if (Math.abs(dist - lastReported) > 10) {
+        lastReported = dist;
+        onCameraDistanceChange(dist);
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [onCameraDistanceChange, cameraDistance]);
 
   const graphData = useMemo(() => {
     const personId = (data.person.user_id || data.person.orb_id) as string;

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -490,7 +490,19 @@ function HeaderBtn({ onClick, children, variant = 'ghost' }: {
 // ── Constants ──
 
 const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach'];
-const MY_ORBIS_CAMERA_DISTANCE = 200;
+const DEFAULT_CAMERA_DISTANCE = 200;
+const CAMERA_DISTANCE_KEY = 'orbis_camera_distance';
+
+function getSavedCameraDistance(): number {
+  try {
+    const saved = localStorage.getItem(CAMERA_DISTANCE_KEY);
+    if (saved) {
+      const val = parseInt(saved, 10);
+      if (val > 50 && val < 2000) return val;
+    }
+  } catch { /* ignore */ }
+  return DEFAULT_CAMERA_DISTANCE;
+}
 
 const LABEL_TO_TYPE: Record<string, string> = {
   Education: 'education',
@@ -520,6 +532,11 @@ export default function OrbViewPage() {
   const [showShare, setShowShare] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showDrafts, setShowDrafts] = useState(false);
+  const [cameraDistance] = useState(getSavedCameraDistance);
+
+  const handleCameraDistanceChange = useCallback((dist: number) => {
+    try { localStorage.setItem(CAMERA_DISTANCE_KEY, String(dist)); } catch { /* ignore */ }
+  }, []);
   const [tourRunning, setTourRunning] = useState(false);
   const [editNode, setEditNode] = useState<{ type: string; values: Record<string, unknown> } | null>(null);
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
@@ -1223,9 +1240,10 @@ export default function OrbViewPage() {
           hiddenNodeTypes={hiddenNodeTypes}
           width={dimensions.width}
           height={dimensions.height}
-          cameraDistance={MY_ORBIS_CAMERA_DISTANCE}
+          cameraDistance={cameraDistance}
           focusNodeId={focusRequest?.nodeUid || null}
           focusNodeToken={focusRequest?.seq ?? 0}
+          onCameraDistanceChange={handleCameraDistanceChange}
         />
       </div>
 
@@ -1285,6 +1303,7 @@ export default function OrbViewPage() {
         onAdd={() => { setEditNode(null); setDraftReferenceText(null); setShowInput(true); }}
         onShare={() => setShowShare(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
+        onRecenter={() => handleFocusNode(personNodeId)}
       /></div>}
 
       {/* ── Draft Notes ── */}

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -236,6 +236,7 @@ export default function SharedOrbPage() {
         placeholder={`Query ${personName}'s orbis...`}
         searchFn={searchFn}
         onFocusNode={handleFocusNode}
+        onRecenter={() => handleFocusNode(personNodeId)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #223

### Recenter button
- Crosshair icon button placed inline to the left of the ChatBox search input
- Available on both `/myorbis` and `/:orbId`
- Clicking it centers the camera on the Person (central) node
- Styled to match the share/add buttons (rounded, backdrop blur)
- Added as `onRecenter` prop to ChatBox component

### Persistent camera zoom (myorbis only)
- Camera zoom distance saved to `localStorage` (`orbis_camera_distance`)
- Persists across sessions (browser restarts, page refreshes)
- Tracked via `onCameraDistanceChange` callback on OrbGraph3D (checked every 2s, debounced by 10 units)
- Restored on page load with bounds check (50-2000, default 200)
- Only for authenticated `/myorbis`, not shared orb views

## Documentation

No doc changes needed.

## Test plan

- [ ] Recenter button visible to the left of chatbox on `/myorbis`
- [ ] Recenter button visible to the left of chatbox on `/:orbId`
- [ ] Click recenter → camera centers on Person node
- [ ] Zoom in/out on `/myorbis` → refresh → zoom level preserved
- [ ] Close browser → reopen `/myorbis` → zoom level still preserved
- [ ] Clear localStorage → refresh → default zoom (200) used

🤖 Generated with [Claude Code](https://claude.com/claude-code)