### PR TITLE
fix: remove stray closing div causing JSX parse error

### DIFF
--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1325,7 +1325,7 @@ export default function OrbViewPage() {
         onShare={() => setShowShare(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
         onRecenter={() => handleFocusNode(personNodeId)}
-      /></div>}
+      />}
 
       {/* ── Draft Notes ── */}
       <DraftNotes


### PR DESCRIPTION
## Summary

Fixes a Vite build/parse error introduced during the merge of PR #224:

```
[PARSE_ERROR] Unterminated regular expression
src/pages/OrbViewPage.tsx:1328
```

A stray `</div>` was left over from when the `data-tour="chatbox"` wrapper div was removed but its closing tag remained.

## Test plan

- [x] `npm run dev` starts without parse errors
- [x] `/myorbis` page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)