### PR TITLE
feat: admin user management with batch operations

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -58,3 +58,31 @@ class BetaConfigResponse(BaseModel):
 
 class BetaConfigUpdate(BaseModel):
     invite_code_required: bool | None = None
+
+
+# ── User management ──
+
+
+class UserResponse(BaseModel):
+    user_id: str
+    name: str = ""
+    email: str = ""
+    provider: str = ""
+    is_admin: bool = False
+    signup_code: str | None = None
+    activated_at: str | None = None
+    created_at: str = ""
+
+
+class UserDetailResponse(UserResponse):
+    orb_id: str = ""
+    picture: str = ""
+    headline: str = ""
+    location: str = ""
+    node_count: int = 0
+    gdpr_consent: bool = False
+    deletion_requested_at: str | None = None
+
+
+class BatchActivateRequest(BaseModel):
+    user_ids: list[str] = Field(min_length=1, max_length=100)

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -275,7 +275,9 @@ async def activate_user(
 ):
     """Activate a pending user by generating an admin-assigned code."""
     code = f"admin-{uuid.uuid4().hex[:8]}"
-    await create_access_code(db, code=code, label="admin-grant", created_by=admin["user_id"])
+    await create_access_code(
+        db, code=code, label="admin-grant", created_by=admin["user_id"]
+    )
     user = await activate_user_by_admin(db, user_id, code)
     if user is None:
         raise HTTPException(

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -1,8 +1,9 @@
-"""Admin endpoints for the closed-beta invitation system."""
+"""Admin endpoints for the closed-beta invitation system and user management."""
 
 from __future__ import annotations
 
 import logging
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncDriver
@@ -12,23 +13,33 @@ from app.admin.models import (
     AccessCodeCreate,
     AccessCodeResponse,
     AccessCodeUpdate,
+    BatchActivateRequest,
     BetaConfigResponse,
     BetaConfigUpdate,
     InviteCodeCounts,
     PendingUser,
     StatsResponse,
+    UserDetailResponse,
+    UserResponse,
 )
 from app.admin.service import (
+    activate_user_by_admin,
+    consume_access_code,
     count_access_codes,
     count_pending_persons,
     count_persons,
     create_access_code,
     create_batch_access_codes,
     delete_access_code,
+    delete_user,
     get_access_code,
     get_beta_config,
+    get_user_detail,
+    grant_admin,
     list_access_codes,
+    list_all_users,
     list_pending_persons,
+    revoke_admin,
     set_access_code_active,
     update_beta_config,
 )
@@ -65,6 +76,43 @@ def _serialize_pending_user(node: dict) -> PendingUser:
         email=node.get("email", ""),
         provider=node.get("provider", "") or "",
         created_at=str(node.get("created_at", "")),
+    )
+
+
+def _serialize_user(node: dict) -> UserResponse:
+    return UserResponse(
+        user_id=node.get("user_id", ""),
+        name=node.get("name", "") or "",
+        email=node.get("email", ""),
+        provider=node.get("provider", "") or "",
+        is_admin=bool(node.get("is_admin", False)),
+        signup_code=node.get("signup_code"),
+        activated_at=str(node["activated_at"]) if node.get("activated_at") else None,
+        created_at=str(node.get("created_at", "")),
+    )
+
+
+def _serialize_user_detail(node: dict) -> UserDetailResponse:
+    return UserDetailResponse(
+        user_id=node.get("user_id", ""),
+        name=node.get("name", "") or "",
+        email=node.get("email", ""),
+        provider=node.get("provider", "") or "",
+        is_admin=bool(node.get("is_admin", False)),
+        signup_code=node.get("signup_code"),
+        activated_at=str(node["activated_at"]) if node.get("activated_at") else None,
+        created_at=str(node.get("created_at", "")),
+        orb_id=node.get("orb_id", "") or "",
+        picture=node.get("picture", "") or "",
+        headline=node.get("headline", "") or "",
+        location=node.get("location", "") or "",
+        node_count=node.get("node_count", 0),
+        gdpr_consent=bool(node.get("gdpr_consent", False)),
+        deletion_requested_at=(
+            str(node["deletion_requested_at"])
+            if node.get("deletion_requested_at")
+            else None
+        ),
     )
 
 
@@ -194,3 +242,126 @@ async def get_pending_users(
     db: AsyncDriver = Depends(get_db),
 ):
     return [_serialize_pending_user(p) for p in await list_pending_persons(db)]
+
+
+# ── User Management ──
+
+
+@router.get("/users", response_model=list[UserResponse])
+async def list_users(
+    _admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    return [_serialize_user(u) for u in await list_all_users(db)]
+
+
+@router.get("/users/{user_id}", response_model=UserDetailResponse)
+async def get_user(
+    user_id: str,
+    _admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    user = await get_user_detail(db, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _serialize_user_detail(user)
+
+
+@router.post("/users/{user_id}/activate", response_model=UserResponse)
+async def activate_user(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Activate a pending user by generating an admin-assigned code."""
+    code = f"admin-{uuid.uuid4().hex[:8]}"
+    await create_access_code(db, code=code, label="admin-grant", created_by=admin["user_id"])
+    user = await activate_user_by_admin(db, user_id, code)
+    if user is None:
+        raise HTTPException(
+            status_code=400, detail="User not found or already activated"
+        )
+    await consume_access_code(db, code, user_id)
+    return _serialize_user(user)
+
+
+@router.post("/users/activate-batch", response_model=list[UserResponse])
+async def activate_users_batch(
+    body: BatchActivateRequest,
+    admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Activate multiple pending users at once."""
+    activated = []
+    for uid in body.user_ids:
+        code = f"admin-{uuid.uuid4().hex[:8]}"
+        await create_access_code(
+            db, code=code, label="admin-grant", created_by=admin["user_id"]
+        )
+        user = await activate_user_by_admin(db, uid, code)
+        if user is not None:
+            await consume_access_code(db, code, uid)
+            activated.append(_serialize_user(user))
+    return activated
+
+
+@router.post("/users/{user_id}/promote", response_model=UserResponse)
+async def promote_user(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    if user_id == admin["user_id"]:
+        raise HTTPException(status_code=400, detail="Cannot promote yourself")
+    user = await grant_admin(db, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _serialize_user(user)
+
+
+@router.post("/users/{user_id}/demote", response_model=UserResponse)
+async def demote_user(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    if user_id == admin["user_id"]:
+        raise HTTPException(status_code=400, detail="Cannot demote yourself")
+    user = await revoke_admin(db, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _serialize_user(user)
+
+
+@router.delete("/users/{user_id}", status_code=204)
+async def remove_user(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncDriver = Depends(get_db),
+):
+    if user_id == admin["user_id"]:
+        raise HTTPException(status_code=400, detail="Cannot delete yourself")
+    found = await delete_user(db, user_id)
+    if not found:
+        raise HTTPException(status_code=404, detail="User not found")
+    # Clean up secondary storage
+    _cleanup_secondary_storage(user_id)
+    return None
+
+
+def _cleanup_secondary_storage(user_id: str) -> None:
+    """Best-effort cleanup of CV, drafts and snapshot storage."""
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        from app.cv_storage.storage import delete_all_for_user as delete_cvs
+
+        delete_cvs(user_id)
+    with contextlib.suppress(Exception):
+        from app.drafts.db import delete_all_for_user as delete_drafts
+
+        delete_drafts(user_id)
+    with contextlib.suppress(Exception):
+        from app.snapshots.db import delete_all_for_user as delete_snapshots
+
+        delete_snapshots(user_id)

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -290,9 +290,7 @@ async def activate_user_by_admin(
 ) -> dict | None:
     """Activate a pending user by admin, assigning a code."""
     async with db.session() as session:
-        result = await session.run(
-            ACTIVATE_PERSON_BY_ADMIN, user_id=user_id, code=code
-        )
+        result = await session.run(ACTIVATE_PERSON_BY_ADMIN, user_id=user_id, code=code)
         record = await result.single()
     if not record:
         return None

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -15,19 +15,28 @@ from neo4j import AsyncDriver
 from app.config import settings
 from app.graph.encryption import decrypt_value
 from app.graph.queries import (
+    ACTIVATE_ALL_PENDING,
     ACTIVATE_PERSON,
+    ACTIVATE_PERSON_BY_ADMIN,
     CONSUME_ACCESS_CODE,
     COUNT_ACCESS_CODES,
     COUNT_PENDING_PERSONS,
     COUNT_PERSONS,
     CREATE_ACCESS_CODE,
     DELETE_ACCESS_CODE,
+    DELETE_PERSON_FULL,
+    DELETE_PERSON_NODE,
     GET_ACCESS_CODE,
     GET_BETA_CONFIG,
+    GET_PERSON_BY_USER_ID,
+    GET_PERSON_DETAIL,
+    GRANT_ADMIN_BY_USER_ID,
     INIT_BETA_CONFIG,
     IS_ADMIN,
     LIST_ACCESS_CODES,
+    LIST_ALL_PERSONS,
     LIST_PENDING_PERSONS,
+    REVOKE_ADMIN_BY_USER_ID,
     SET_ACCESS_CODE_ACTIVE,
     UPDATE_BETA_CONFIG,
 )
@@ -59,7 +68,13 @@ async def update_beta_config(db: AsyncDriver, properties: dict) -> dict:
     async with db.session() as session:
         result = await session.run(UPDATE_BETA_CONFIG, properties=properties)
         record = await result.single()
-        return dict(record["c"])
+        config = dict(record["c"])
+
+    # When opening the platform, auto-activate all pending users
+    if properties.get("invite_code_required") is False:
+        await activate_all_pending(db)
+
+    return config
 
 
 async def is_invite_code_required(db: AsyncDriver) -> bool:
@@ -113,6 +128,17 @@ async def list_pending_persons(db: AsyncDriver) -> list[dict]:
 
 
 # ── Activation ──
+
+
+async def activate_all_pending(db: AsyncDriver) -> int:
+    """Auto-activate all pending users (used when platform opens)."""
+    async with db.session() as session:
+        result = await session.run(ACTIVATE_ALL_PENDING, code="open-registration")
+        record = await result.single()
+        count = int(record["activated"]) if record else 0
+    if count:
+        logger.info("Auto-activated %d pending user(s) (platform opened)", count)
+    return count
 
 
 async def activate_person(db: AsyncDriver, user_id: str, code: str) -> bool:
@@ -223,3 +249,100 @@ async def create_batch_access_codes(
             if record:
                 codes.append(dict(record["a"]))
     return codes
+
+
+# ── User management ──
+
+
+async def list_all_users(db: AsyncDriver) -> list[dict]:
+    """Return all registered users with decrypted emails."""
+    async with db.session() as session:
+        result = await session.run(LIST_ALL_PERSONS)
+        records = [r async for r in result]
+    out = []
+    for r in records:
+        person = dict(r["p"])
+        email = person.get("email", "")
+        if email:
+            with contextlib.suppress(Exception):
+                email = decrypt_value(email)
+        out.append({**person, "email": email})
+    return out
+
+
+async def get_user_detail(db: AsyncDriver, user_id: str) -> dict | None:
+    """Return a single user with node count and decrypted email."""
+    async with db.session() as session:
+        result = await session.run(GET_PERSON_DETAIL, user_id=user_id)
+        record = await result.single()
+    if not record:
+        return None
+    person = dict(record["p"])
+    email = person.get("email", "")
+    if email:
+        with contextlib.suppress(Exception):
+            email = decrypt_value(email)
+    return {**person, "email": email, "node_count": int(record["node_count"])}
+
+
+async def activate_user_by_admin(
+    db: AsyncDriver, user_id: str, code: str
+) -> dict | None:
+    """Activate a pending user by admin, assigning a code."""
+    async with db.session() as session:
+        result = await session.run(
+            ACTIVATE_PERSON_BY_ADMIN, user_id=user_id, code=code
+        )
+        record = await result.single()
+    if not record:
+        return None
+    person = dict(record["p"])
+    email = person.get("email", "")
+    if email:
+        with contextlib.suppress(Exception):
+            email = decrypt_value(email)
+    return {**person, "email": email}
+
+
+async def delete_user(db: AsyncDriver, user_id: str) -> bool:
+    """Delete a user and all their graph data. Returns True if user existed."""
+    async with db.session() as session:
+        # Check user exists
+        result = await session.run(GET_PERSON_BY_USER_ID, user_id=user_id)
+        if await result.single() is None:
+            return False
+        # Delete all connected nodes first
+        await session.run(DELETE_PERSON_FULL, user_id=user_id)
+        # Delete the person node
+        await session.run(DELETE_PERSON_NODE, user_id=user_id)
+    return True
+
+
+async def grant_admin(db: AsyncDriver, user_id: str) -> dict | None:
+    """Promote a user to admin."""
+    async with db.session() as session:
+        result = await session.run(GRANT_ADMIN_BY_USER_ID, user_id=user_id)
+        record = await result.single()
+    if not record:
+        return None
+    person = dict(record["p"])
+    email = person.get("email", "")
+    if email:
+        with contextlib.suppress(Exception):
+            email = decrypt_value(email)
+    return {**person, "email": email}
+
+
+async def revoke_admin(db: AsyncDriver, user_id: str) -> dict | None:
+    """Revoke admin from a user."""
+    async with db.session() as session:
+        result = await session.run(REVOKE_ADMIN_BY_USER_ID, user_id=user_id)
+        record = await result.single()
+    if not record:
+        return None
+    person = dict(record["p"])
+    email = person.get("email", "")
+    if email:
+        with contextlib.suppress(Exception):
+            email = decrypt_value(email)
+    return {**person, "email": email}

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -45,11 +45,17 @@ async def _get_or_create_person(
 
     In the new flow, registration always succeeds — the invite code gate
     happens later on the /auth/activate endpoint, not at signup time.
+    If the platform is open (invite code not required), the user is
+    auto-activated with a special signup_code so they stay activated
+    even if the admin later closes the platform.
     """
     async with db.session() as session:
         result = await session.run(GET_PERSON_BY_USER_ID, user_id=user_id)
         if await result.single() is not None:
             return
+
+    invite_required = await is_invite_code_required(db)
+    signup_code = None if invite_required else "open-registration"
 
     orb_id = await generate_orb_id(name, db)
     async with db.session() as session:
@@ -61,7 +67,7 @@ async def _get_or_create_person(
             orb_id=orb_id,
             picture=picture,
             provider=provider,
-            signup_code=None,
+            signup_code=signup_code,
         )
 
 

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -294,3 +294,42 @@ MATCH (p:Person {user_id: $user_id})
 SET p.is_admin = false
 RETURN p
 """
+
+# ── Admin: user management ──
+
+LIST_ALL_PERSONS = """
+MATCH (p:Person)
+RETURN p
+ORDER BY p.created_at DESC
+"""
+
+GET_PERSON_DETAIL = """
+MATCH (p:Person {user_id: $user_id})
+OPTIONAL MATCH (p)-[r]->(n)
+WITH p, count(DISTINCT CASE WHEN NOT n:AccessCode AND NOT n:BetaConfig THEN n END) AS node_count
+RETURN p, node_count
+"""
+
+DELETE_PERSON_FULL = """
+MATCH (p:Person {user_id: $user_id})-[*1..]->(n)
+WITH DISTINCT n DETACH DELETE n
+"""
+
+DELETE_PERSON_NODE = """
+MATCH (p:Person {user_id: $user_id})
+DETACH DELETE p
+"""
+
+ACTIVATE_PERSON_BY_ADMIN = """
+MATCH (p:Person {user_id: $user_id})
+WHERE p.signup_code IS NULL
+SET p.signup_code = $code, p.activated_at = datetime()
+RETURN p
+"""
+
+ACTIVATE_ALL_PENDING = """
+MATCH (p:Person)
+WHERE p.signup_code IS NULL AND coalesce(p.is_admin, false) = false
+SET p.signup_code = $code, p.activated_at = datetime()
+RETURN count(p) AS activated
+"""

--- a/backend/tests/unit/test_admin_users.py
+++ b/backend/tests/unit/test_admin_users.py
@@ -1,0 +1,241 @@
+"""Tests for admin user management endpoints.
+
+Surfaces under test:
+- GET /admin/users — list all users
+- GET /admin/users/{user_id} — user detail
+- POST /admin/users/{user_id}/activate — activate pending user
+- POST /admin/users/activate-batch — batch activate
+- POST /admin/users/{user_id}/promote — grant admin
+- POST /admin/users/{user_id}/demote — revoke admin
+- DELETE /admin/users/{user_id} — delete user
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.dependencies import get_current_user, get_db, require_admin
+from app.main import app
+
+SAMPLE_USER = {
+    "user_id": "google-111",
+    "name": "Alice",
+    "email": "alice@example.com",
+    "provider": "google",
+    "is_admin": False,
+    "signup_code": "invite-abc",
+    "activated_at": "2026-04-01T10:00:00",
+    "created_at": "2026-03-15T08:00:00",
+    "orb_id": "alice",
+    "picture": "",
+    "headline": "Researcher",
+    "location": "Rome",
+    "node_count": 12,
+    "gdpr_consent": True,
+    "deletion_requested_at": None,
+}
+
+PENDING_USER = {
+    "user_id": "google-222",
+    "name": "Bob",
+    "email": "bob@example.com",
+    "provider": "google",
+    "is_admin": False,
+    "signup_code": None,
+    "activated_at": None,
+    "created_at": "2026-04-05T09:00:00",
+}
+
+
+@pytest.fixture
+def admin_client(mock_db, mock_neo4j_driver):
+    from fastapi.testclient import TestClient
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: {
+        "user_id": "admin-user",
+        "email": "admin@example.com",
+    }
+    app.dependency_overrides[require_admin] = lambda: {
+        "user_id": "admin-user",
+        "email": "admin@example.com",
+    }
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── GET /admin/users ──
+
+
+def test_list_users(admin_client):
+    with patch(
+        "app.admin.router.list_all_users",
+        AsyncMock(return_value=[SAMPLE_USER, PENDING_USER]),
+    ):
+        response = admin_client.get("/admin/users")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["user_id"] == "google-111"
+    assert body[1]["signup_code"] is None
+
+
+# ── GET /admin/users/{user_id} ──
+
+
+def test_get_user_detail(admin_client):
+    with patch(
+        "app.admin.router.get_user_detail",
+        AsyncMock(return_value=SAMPLE_USER),
+    ):
+        response = admin_client.get("/admin/users/google-111")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == "google-111"
+    assert body["node_count"] == 12
+    assert body["headline"] == "Researcher"
+
+
+def test_get_user_detail_not_found(admin_client):
+    with patch(
+        "app.admin.router.get_user_detail",
+        AsyncMock(return_value=None),
+    ):
+        response = admin_client.get("/admin/users/nonexistent")
+
+    assert response.status_code == 404
+
+
+# ── POST /admin/users/{user_id}/activate ──
+
+
+def test_activate_user(admin_client):
+    activated = {**PENDING_USER, "signup_code": "admin-abc12345", "activated_at": "2026-04-10T12:00:00"}
+    with (
+        patch("app.admin.router.create_access_code", AsyncMock(return_value={})),
+        patch(
+            "app.admin.router.activate_user_by_admin",
+            AsyncMock(return_value=activated),
+        ),
+        patch("app.admin.router.consume_access_code", AsyncMock(return_value=True)),
+    ):
+        response = admin_client.post("/admin/users/google-222/activate")
+
+    assert response.status_code == 200
+    assert response.json()["signup_code"] is not None
+
+
+def test_activate_already_activated_user(admin_client):
+    with (
+        patch("app.admin.router.create_access_code", AsyncMock(return_value={})),
+        patch(
+            "app.admin.router.activate_user_by_admin",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        response = admin_client.post("/admin/users/google-111/activate")
+
+    assert response.status_code == 400
+
+
+# ── POST /admin/users/activate-batch ──
+
+
+def test_activate_batch(admin_client):
+    activated = {**PENDING_USER, "signup_code": "admin-xyz", "activated_at": "2026-04-10T12:00:00"}
+    with (
+        patch("app.admin.router.create_access_code", AsyncMock(return_value={})),
+        patch(
+            "app.admin.router.activate_user_by_admin",
+            AsyncMock(return_value=activated),
+        ),
+        patch("app.admin.router.consume_access_code", AsyncMock(return_value=True)),
+    ):
+        response = admin_client.post(
+            "/admin/users/activate-batch",
+            json={"user_ids": ["google-222"]},
+        )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+def test_activate_batch_empty_list(admin_client):
+    response = admin_client.post(
+        "/admin/users/activate-batch",
+        json={"user_ids": []},
+    )
+    assert response.status_code == 422
+
+
+# ── POST /admin/users/{user_id}/promote ──
+
+
+def test_promote_user(admin_client):
+    promoted = {**SAMPLE_USER, "is_admin": True}
+    with patch(
+        "app.admin.router.grant_admin",
+        AsyncMock(return_value=promoted),
+    ):
+        response = admin_client.post("/admin/users/google-111/promote")
+
+    assert response.status_code == 200
+    assert response.json()["is_admin"] is True
+
+
+def test_promote_self_rejected(admin_client):
+    response = admin_client.post("/admin/users/admin-user/promote")
+    assert response.status_code == 400
+
+
+def test_promote_nonexistent_user(admin_client):
+    with patch("app.admin.router.grant_admin", AsyncMock(return_value=None)):
+        response = admin_client.post("/admin/users/nonexistent/promote")
+    assert response.status_code == 404
+
+
+# ── POST /admin/users/{user_id}/demote ──
+
+
+def test_demote_user(admin_client):
+    demoted = {**SAMPLE_USER, "is_admin": False}
+    with patch(
+        "app.admin.router.revoke_admin",
+        AsyncMock(return_value=demoted),
+    ):
+        response = admin_client.post("/admin/users/google-111/demote")
+
+    assert response.status_code == 200
+    assert response.json()["is_admin"] is False
+
+
+def test_demote_self_rejected(admin_client):
+    response = admin_client.post("/admin/users/admin-user/demote")
+    assert response.status_code == 400
+
+
+# ── DELETE /admin/users/{user_id} ──
+
+
+def test_delete_user(admin_client):
+    with (
+        patch("app.admin.router.delete_user", AsyncMock(return_value=True)),
+        patch("app.admin.router._cleanup_secondary_storage"),
+    ):
+        response = admin_client.delete("/admin/users/google-111")
+
+    assert response.status_code == 204
+
+
+def test_delete_self_rejected(admin_client):
+    response = admin_client.delete("/admin/users/admin-user")
+    assert response.status_code == 400
+
+
+def test_delete_nonexistent_user(admin_client):
+    with patch("app.admin.router.delete_user", AsyncMock(return_value=False)):
+        response = admin_client.delete("/admin/users/nonexistent")
+    assert response.status_code == 404

--- a/backend/tests/unit/test_admin_users.py
+++ b/backend/tests/unit/test_admin_users.py
@@ -113,7 +113,11 @@ def test_get_user_detail_not_found(admin_client):
 
 
 def test_activate_user(admin_client):
-    activated = {**PENDING_USER, "signup_code": "admin-abc12345", "activated_at": "2026-04-10T12:00:00"}
+    activated = {
+        **PENDING_USER,
+        "signup_code": "admin-abc12345",
+        "activated_at": "2026-04-10T12:00:00",
+    }
     with (
         patch("app.admin.router.create_access_code", AsyncMock(return_value={})),
         patch(
@@ -145,7 +149,11 @@ def test_activate_already_activated_user(admin_client):
 
 
 def test_activate_batch(admin_client):
-    activated = {**PENDING_USER, "signup_code": "admin-xyz", "activated_at": "2026-04-10T12:00:00"}
+    activated = {
+        **PENDING_USER,
+        "signup_code": "admin-xyz",
+        "activated_at": "2026-04-10T12:00:00",
+    }
     with (
         patch("app.admin.router.create_access_code", AsyncMock(return_value={})),
         patch(

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -48,7 +48,13 @@ def test_registration_always_creates_person(client, mock_db, google_oauth_mock):
     """New users are always registered — no code check at signup time."""
     _stub_existing_person(mock_db, exists=False)
 
-    with patch("app.auth.router.generate_orb_id", AsyncMock(return_value="new-user")):
+    with (
+        patch("app.auth.router.generate_orb_id", AsyncMock(return_value="new-user")),
+        patch(
+            "app.auth.router.is_invite_code_required",
+            AsyncMock(return_value=False),
+        ),
+    ):
         response = client.post("/auth/google", json={"code": "fake"})
 
     assert response.status_code == 200

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -107,3 +107,64 @@ export async function listPendingUsers(): Promise<PendingUser[]> {
   const { data } = await client.get('/admin/pending-users');
   return data;
 }
+
+// ── User Management ──
+
+export interface AdminUser {
+  user_id: string;
+  name: string;
+  email: string;
+  provider: string;
+  is_admin: boolean;
+  signup_code: string | null;
+  activated_at: string | null;
+  created_at: string;
+}
+
+export interface AdminUserDetail extends AdminUser {
+  orb_id: string;
+  picture: string;
+  headline: string;
+  location: string;
+  node_count: number;
+  gdpr_consent: boolean;
+  deletion_requested_at: string | null;
+}
+
+export async function listUsers(): Promise<AdminUser[]> {
+  const { data } = await client.get('/admin/users');
+  return data;
+}
+
+export async function getUser(userId: string): Promise<AdminUserDetail> {
+  const { data } = await client.get(`/admin/users/${userId}`);
+  return data;
+}
+
+export async function activateUser(userId: string): Promise<AdminUser> {
+  const { data } = await client.post(`/admin/users/${userId}/activate`);
+  return data;
+}
+
+export async function activateUsersBatch(
+  userIds: string[],
+): Promise<AdminUser[]> {
+  const { data } = await client.post('/admin/users/activate-batch', {
+    user_ids: userIds,
+  });
+  return data;
+}
+
+export async function promoteUser(userId: string): Promise<AdminUser> {
+  const { data } = await client.post(`/admin/users/${userId}/promote`);
+  return data;
+}
+
+export async function demoteUser(userId: string): Promise<AdminUser> {
+  const { data } = await client.post(`/admin/users/${userId}/demote`);
+  return data;
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  await client.delete(`/admin/users/${userId}`);
+}

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -129,10 +129,12 @@ export default function ActivatePage() {
           </motion.div>
         )}
 
-        {/* Info */}
-        <p className="text-white/20 text-xs mb-4">
-          Non hai un codice? Contattaci per richiedere l'accesso.
-        </p>
+        {/* Waitlist info */}
+        <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl px-5 py-4 mb-4 text-left">
+          <p className="text-white/50 text-xs leading-relaxed">
+            Non hai un codice? Nessun problema — registrandoti sei stato aggiunto alla nostra waiting list. Ti contatteremo non appena il tuo accesso sarà abilitato.
+          </p>
+        </div>
 
         {/* Logout link */}
         <button

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import axios from 'axios';
-import { activateAccount } from '../api/auth';
+import { activateAccount, getMe } from '../api/auth';
 import { useAuthStore } from '../stores/authStore';
 import { hasOrbContent } from '../api/orbs';
 
@@ -11,12 +11,36 @@ const ERROR_MESSAGES: Record<string, string> = {
   code_already_used: 'Questo codice di invito è già stato utilizzato. Ogni codice può essere usato una sola volta.',
 };
 
+const POLL_INTERVAL = 5000;
+
 export default function ActivatePage() {
   const navigate = useNavigate();
   const { user, fetchUser, logout } = useAuthStore();
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const navigatingRef = useRef(false);
+
+  const goToApp = useCallback(async () => {
+    if (navigatingRef.current) return;
+    navigatingRef.current = true;
+    await fetchUser();
+    const hasContent = await hasOrbContent();
+    navigate(hasContent ? '/myorbis' : '/create', { replace: true });
+  }, [navigate, fetchUser]);
+
+  // Silent poll: check activation status without touching store/UI
+  useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const me = await getMe();
+        if (me.activated) goToApp();
+      } catch {
+        // ignore — network blips shouldn't break the page
+      }
+    }, POLL_INTERVAL);
+    return () => clearInterval(id);
+  }, [goToApp]);
 
   const handleSubmit = async () => {
     if (!code.trim()) return;
@@ -24,9 +48,7 @@ export default function ActivatePage() {
     setError(null);
     try {
       await activateAccount(code.trim());
-      await fetchUser();
-      const hasContent = await hasOrbContent();
-      navigate(hasContent ? '/myorbis' : '/create', { replace: true });
+      await goToApp();
     } catch (e) {
       if (axios.isAxiosError(e) && e.response?.status === 403) {
         const detail = e.response.data?.detail;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -5,6 +5,13 @@ import {
   getStats,
   listAccessCodes,
   listPendingUsers,
+  listUsers,
+  getUser,
+  activateUser,
+  activateUsersBatch,
+  promoteUser,
+  demoteUser,
+  deleteUser,
   createAccessCode,
   createBatchAccessCodes,
   toggleAccessCode,
@@ -13,6 +20,8 @@ import {
   type AdminStats,
   type AccessCode,
   type PendingUser,
+  type AdminUser,
+  type AdminUserDetail,
 } from '../api/admin';
 
 // ── Helpers ──
@@ -95,8 +104,9 @@ export default function AdminPage() {
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [codes, setCodes] = useState<AccessCode[]>([]);
   const [pendingUsers, setPendingUsers] = useState<PendingUser[]>([]);
+  const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<'codes' | 'pending'>('codes');
+  const [tab, setTab] = useState<'codes' | 'pending' | 'users'>('codes');
   const [error, setError] = useState<string | null>(null);
 
   // Create code form
@@ -124,12 +134,33 @@ export default function AdminPage() {
   // Copy feedback
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
+  // Code selection
+  const [selectedCodes, setSelectedCodes] = useState<Set<string>>(new Set());
+
+  // Users tab state
+  const [userSearch, setUserSearch] = useState('');
+  const [userFilter, setUserFilter] = useState<'all' | 'active' | 'pending' | 'admin'>('all');
+  const [selectedUsers, setSelectedUsers] = useState<Set<string>>(new Set());
+  const [userDetail, setUserDetail] = useState<AdminUserDetail | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+  const [batchReport, setBatchReport] = useState<{
+    title: string;
+    deleted: string[];
+    failed: { name: string; reason: string }[];
+  } | null>(null);
+
   const refresh = useCallback(async () => {
     try {
-      const [s, c, p] = await Promise.all([getStats(), listAccessCodes(), listPendingUsers()]);
+      const [s, c, p, u] = await Promise.all([
+        getStats(),
+        listAccessCodes(),
+        listPendingUsers(),
+        listUsers(),
+      ]);
       setStats(s);
       setCodes(c);
       setPendingUsers(p);
+      setUsers(u);
       setError(null);
     } catch {
       setError('Errore nel caricamento dei dati.');
@@ -197,22 +228,79 @@ export default function AdminPage() {
     }
   };
 
-  const handleToggleCode = async (code: string, active: boolean) => {
-    try {
-      await toggleAccessCode(code, active);
-      await refresh();
-    } catch {
-      setError('Errore nel toggle del codice.');
-    }
+  const handleToggleCode = (code: string, active: boolean) => {
+    setConfirmAction({
+      title: active ? 'Attivare codice?' : 'Disattivare codice?',
+      message: active
+        ? `Il codice "${code}" tornerà utilizzabile.`
+        : `Il codice "${code}" non potrà essere utilizzato finché non verrà riattivato.`,
+      confirmLabel: active ? 'Attiva' : 'Disattiva',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await toggleAccessCode(code, active);
+          await refresh();
+        } catch {
+          setError('Errore nel toggle del codice.');
+        }
+      },
+    });
   };
 
-  const handleDeleteCode = async (code: string) => {
-    try {
-      await deleteAccessCode(code);
-      await refresh();
-    } catch {
-      setError('Errore nella cancellazione del codice.');
-    }
+  const handleDeleteCode = (code: string) => {
+    setConfirmAction({
+      title: 'Eliminare codice?',
+      message: `Il codice "${code}" verrà eliminato permanentemente.`,
+      confirmLabel: 'Elimina',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await deleteAccessCode(code);
+          await refresh();
+        } catch {
+          setError('Errore nella cancellazione del codice.');
+        }
+      },
+    });
+  };
+
+  const handleBatchDeleteCodes = () => {
+    if (selectedCodes.size === 0) return;
+    setConfirmAction({
+      title: `Eliminare ${selectedCodes.size} codici?`,
+      message: 'Tutti i codici selezionati verranno eliminati permanentemente.',
+      confirmLabel: `Elimina ${selectedCodes.size}`,
+      onConfirm: async () => {
+        setConfirmAction(null);
+        const deleted: string[] = [];
+        const failed: { name: string; reason: string }[] = [];
+        for (const code of selectedCodes) {
+          try {
+            await deleteAccessCode(code);
+            deleted.push(code);
+          } catch (err: unknown) {
+            let reason = 'Errore sconosciuto';
+            if (err && typeof err === 'object' && 'response' in err) {
+              const resp = (err as { response?: { data?: { detail?: string } } }).response;
+              if (resp?.data?.detail) reason = resp.data.detail;
+            }
+            failed.push({ name: code, reason });
+          }
+        }
+        setSelectedCodes(new Set());
+        await refresh();
+        setBatchReport({ title: 'Risultato eliminazione codici', deleted, failed });
+      },
+    });
+  };
+
+  const toggleCodeSelection = (code: string) => {
+    setSelectedCodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
   };
 
   const handleCopy = (code: string) => {
@@ -220,6 +308,176 @@ export default function AdminPage() {
     setCopiedCode(code);
     setTimeout(() => setCopiedCode((prev) => (prev === code ? null : prev)), 1500);
   };
+
+  // ── User management handlers ──
+
+  const handleActivateUser = (userId: string, userName: string) => {
+    setConfirmAction({
+      title: 'Attivare utente?',
+      message: `Verrà generato un codice invito e assegnato automaticamente a ${userName || userId}.`,
+      confirmLabel: 'Attiva',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await activateUser(userId);
+          await refresh();
+        } catch {
+          setError("Errore nell'attivazione dell'utente.");
+        }
+      },
+    });
+  };
+
+  const handleBatchActivate = () => {
+    const pending = Array.from(selectedUsers).filter((id) =>
+      users.find((u) => u.user_id === id && !u.signup_code && !u.is_admin),
+    );
+    if (pending.length === 0) return;
+    setConfirmAction({
+      title: `Attivare ${pending.length} utenti?`,
+      message: 'Verrà generato un codice invito per ciascun utente selezionato.',
+      confirmLabel: `Attiva ${pending.length}`,
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await activateUsersBatch(pending);
+          setSelectedUsers(new Set());
+          await refresh();
+        } catch {
+          setError("Errore nell'attivazione batch.");
+        }
+      },
+    });
+  };
+
+  const handleBatchDelete = () => {
+    if (selectedUsers.size === 0) return;
+    setConfirmAction({
+      title: `Eliminare ${selectedUsers.size} utenti?`,
+      message: 'Tutti gli account selezionati e i loro dati verranno eliminati permanentemente. Questa azione è irreversibile.',
+      confirmLabel: `Elimina ${selectedUsers.size}`,
+      onConfirm: async () => {
+        setConfirmAction(null);
+        const deleted: string[] = [];
+        const failed: { name: string; reason: string }[] = [];
+        for (const uid of selectedUsers) {
+          const user = users.find((u) => u.user_id === uid);
+          const name = user?.name || uid;
+          try {
+            await deleteUser(uid);
+            deleted.push(name);
+          } catch (err: unknown) {
+            let reason = 'Errore sconosciuto';
+            if (err && typeof err === 'object' && 'response' in err) {
+              const resp = (err as { response?: { data?: { detail?: string } } }).response;
+              if (resp?.data?.detail) {
+                reason = resp.data.detail === 'Cannot delete yourself'
+                  ? 'Non puoi eliminare te stesso'
+                  : resp.data.detail;
+              }
+            }
+            failed.push({ name, reason });
+          }
+        }
+        setSelectedUsers(new Set());
+        await refresh();
+        setBatchReport({
+          title: 'Risultato eliminazione',
+          deleted,
+          failed,
+        });
+      },
+    });
+  };
+
+  const handlePromoteUser = (userId: string, userName: string) => {
+    setConfirmAction({
+      title: 'Promuovere ad admin?',
+      message: `${userName || userId} avrà accesso completo alla dashboard di amministrazione.`,
+      confirmLabel: 'Promuovi',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await promoteUser(userId);
+          await refresh();
+        } catch {
+          setError('Errore nella promozione.');
+        }
+      },
+    });
+  };
+
+  const handleDemoteUser = (userId: string, userName: string) => {
+    setConfirmAction({
+      title: 'Revocare admin?',
+      message: `${userName || userId} perderà i privilegi di amministrazione.`,
+      confirmLabel: 'Revoca',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await demoteUser(userId);
+          await refresh();
+        } catch {
+          setError('Errore nella revoca.');
+        }
+      },
+    });
+  };
+
+  const handleDeleteUser = (userId: string, userName: string) => {
+    setConfirmAction({
+      title: 'Eliminare utente?',
+      message: `L'account di ${userName || userId} e tutti i suoi dati verranno eliminati permanentemente. Questa azione è irreversibile.`,
+      confirmLabel: 'Elimina definitivamente',
+      onConfirm: async () => {
+        setConfirmAction(null);
+        try {
+          await deleteUser(userId);
+          setShowDetail(false);
+          setUserDetail(null);
+          await refresh();
+        } catch {
+          setError("Errore nell'eliminazione dell'utente.");
+        }
+      },
+    });
+  };
+
+  const handleShowDetail = async (userId: string) => {
+    try {
+      const detail = await getUser(userId);
+      setUserDetail(detail);
+      setShowDetail(true);
+    } catch {
+      setError('Errore nel caricamento dei dettagli utente.');
+    }
+  };
+
+  const toggleUserSelection = (userId: string) => {
+    setSelectedUsers((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const hasPendingSelected = Array.from(selectedUsers).some((id) =>
+    users.find((u) => u.user_id === id && !u.signup_code && !u.is_admin),
+  );
+
+  const filteredUsers = users.filter((u) => {
+    const matchesSearch =
+      !userSearch ||
+      u.name.toLowerCase().includes(userSearch.toLowerCase()) ||
+      u.email.toLowerCase().includes(userSearch.toLowerCase()) ||
+      u.user_id.toLowerCase().includes(userSearch.toLowerCase());
+    if (!matchesSearch) return false;
+    if (userFilter === 'active') return u.signup_code !== null || u.is_admin;
+    if (userFilter === 'pending') return u.signup_code === null && !u.is_admin;
+    if (userFilter === 'admin') return u.is_admin;
+    return true;
+  });
 
   const filteredCodes = codes.filter((c) => {
     if (codeFilter === 'available') return c.used_at === null && c.active;
@@ -292,7 +550,15 @@ export default function AdminPage() {
               tab === 'pending' ? 'bg-purple-600 text-white' : 'text-white/40 hover:text-white/60'
             }`}
           >
-            Utenti in attesa ({pendingUsers.length})
+            Waiting List ({pendingUsers.length})
+          </button>
+          <button
+            onClick={() => setTab('users')}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              tab === 'users' ? 'bg-purple-600 text-white' : 'text-white/40 hover:text-white/60'
+            }`}
+          >
+            Utenti ({users.length})
           </button>
         </div>
 
@@ -335,6 +601,17 @@ export default function AdminPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-white/[0.06]">
+                      <th className="w-8 px-4 py-2.5">
+                        <input
+                          type="checkbox"
+                          checked={filteredCodes.length > 0 && filteredCodes.every((c) => selectedCodes.has(c.code))}
+                          onChange={() => {
+                            const allSelected = filteredCodes.every((c) => selectedCodes.has(c.code));
+                            setSelectedCodes(allSelected ? new Set() : new Set(filteredCodes.map((c) => c.code)));
+                          }}
+                          className="w-3.5 h-3.5 rounded border-white/20 bg-white/5 accent-purple-500"
+                        />
+                      </th>
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Codice</th>
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Label</th>
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Stato</th>
@@ -342,13 +619,36 @@ export default function AdminPage() {
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Creato</th>
                       <th className="text-right text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Azioni</th>
                     </tr>
+                    {selectedCodes.size > 0 && (
+                      <tr className="border-b border-purple-500/20 bg-purple-500/[0.06]">
+                        <td colSpan={7} className="px-4 py-2">
+                          <div className="flex items-center gap-3">
+                            <span className="text-sm text-purple-300">{selectedCodes.size} selezionati</span>
+                            <button
+                              onClick={handleBatchDeleteCodes}
+                              className="text-xs bg-red-600 hover:bg-red-500 text-white font-medium px-3 py-1 rounded-md transition-colors"
+                            >
+                              Elimina selezionati
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
                   </thead>
                   <tbody>
                     {filteredCodes.length === 0 && (
-                      <tr><td colSpan={6} className="text-center text-white/20 py-8">Nessun codice trovato.</td></tr>
+                      <tr><td colSpan={7} className="text-center text-white/20 py-8">Nessun codice trovato.</td></tr>
                     )}
                     {filteredCodes.map((c) => (
                       <tr key={c.code} className="border-b border-white/[0.03] hover:bg-white/[0.02]">
+                        <td className="px-4 py-2.5">
+                          <input
+                            type="checkbox"
+                            checked={selectedCodes.has(c.code)}
+                            onChange={() => toggleCodeSelection(c.code)}
+                            className="w-3.5 h-3.5 rounded border-white/20 bg-white/5 accent-purple-500"
+                          />
+                        </td>
                         <td className="px-4 py-2.5 font-mono text-xs text-purple-300">
                           <button onClick={() => handleCopy(c.code)} title="Copia codice" className="hover:text-purple-200 transition-colors">
                             {copiedCode === c.code ? <span className="text-green-400">Copiato!</span> : c.code}
@@ -371,9 +671,7 @@ export default function AdminPage() {
                             {!c.used_at && (
                               <button onClick={() => handleToggleCode(c.code, !c.active)} className="text-xs text-white/30 hover:text-white/60 px-2 py-1 rounded transition-colors">{c.active ? 'Disattiva' : 'Attiva'}</button>
                             )}
-                            {!c.used_at && (
-                              <button onClick={() => handleDeleteCode(c.code)} className="text-xs text-red-400/50 hover:text-red-400 px-2 py-1 rounded transition-colors">Elimina</button>
-                            )}
+                            <button onClick={() => handleDeleteCode(c.code)} className="text-xs text-red-400/50 hover:text-red-400 px-2 py-1 rounded transition-colors">Elimina</button>
                           </div>
                         </td>
                       </tr>
@@ -397,11 +695,12 @@ export default function AdminPage() {
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Email</th>
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Provider</th>
                       <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Registrato il</th>
+                      <th className="text-right text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Azioni</th>
                     </tr>
                   </thead>
                   <tbody>
                     {pendingUsers.length === 0 && (
-                      <tr><td colSpan={4} className="text-center text-white/20 py-8">Nessun utente in attesa di attivazione.</td></tr>
+                      <tr><td colSpan={5} className="text-center text-white/20 py-8">Nessun utente in attesa di attivazione.</td></tr>
                     )}
                     {pendingUsers.map((u) => (
                       <tr key={u.user_id} className="border-b border-white/[0.03] hover:bg-white/[0.02]">
@@ -409,6 +708,12 @@ export default function AdminPage() {
                         <td className="px-4 py-2.5 text-white/50 text-xs">{u.email || '—'}</td>
                         <td className="px-4 py-2.5 text-white/40 text-xs">{u.provider}</td>
                         <td className="px-4 py-2.5 text-white/30 text-xs">{formatDate(u.created_at)}</td>
+                        <td className="px-4 py-2.5 text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            <button onClick={() => handleActivateUser(u.user_id, u.name)} className="text-xs text-green-400/70 hover:text-green-400 px-2 py-1 rounded transition-colors">Attiva</button>
+                            <button onClick={() => handleDeleteUser(u.user_id, u.name)} className="text-xs text-red-400/50 hover:text-red-400 px-2 py-1 rounded transition-colors">Elimina</button>
+                          </div>
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -417,7 +722,345 @@ export default function AdminPage() {
             </div>
           </motion.div>
         )}
+
+        {/* ── Users Tab ── */}
+        {tab === 'users' && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            {/* Search + Filter */}
+            <div className="flex flex-col sm:flex-row gap-3 mb-4">
+              <input
+                type="text"
+                value={userSearch}
+                onChange={(e) => setUserSearch(e.target.value)}
+                placeholder="Cerca per nome, email o ID..."
+                className="flex-1 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20"
+              />
+              <div className="flex gap-2">
+                {(['all', 'active', 'pending', 'admin'] as const).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setUserFilter(f)}
+                    className={`text-xs px-3 py-1.5 rounded-md border transition-colors whitespace-nowrap ${
+                      userFilter === f
+                        ? 'bg-white/[0.08] border-white/[0.15] text-white'
+                        : 'border-white/[0.06] text-white/30 hover:text-white/50'
+                    }`}
+                  >
+                    {f === 'all' ? 'Tutti' : f === 'active' ? 'Attivi' : f === 'pending' ? 'In attesa' : 'Admin'}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Users Table */}
+            <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-white/[0.06]">
+                      <th className="w-8 px-4 py-2.5">
+                        <input
+                          type="checkbox"
+                          checked={filteredUsers.length > 0 && filteredUsers.every((u) => selectedUsers.has(u.user_id))}
+                          onChange={() => {
+                            const allSelected = filteredUsers.every((u) => selectedUsers.has(u.user_id));
+                            setSelectedUsers(allSelected ? new Set() : new Set(filteredUsers.map((u) => u.user_id)));
+                          }}
+                          className="w-3.5 h-3.5 rounded border-white/20 bg-white/5 accent-purple-500"
+                        />
+                      </th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Nome</th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Email</th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Stato</th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Codice</th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Provider</th>
+                      <th className="text-left text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Registrato</th>
+                      <th className="text-right text-white/40 font-medium px-4 py-2.5 text-xs uppercase tracking-wider">Azioni</th>
+                    </tr>
+                    {selectedUsers.size > 0 && (
+                      <tr className="border-b border-purple-500/20 bg-purple-500/[0.06]">
+                        <td colSpan={8} className="px-4 py-2">
+                          <div className="flex items-center gap-3">
+                            <span className="text-sm text-purple-300">{selectedUsers.size} selezionati</span>
+                            {hasPendingSelected && (
+                              <button
+                                onClick={handleBatchActivate}
+                                className="text-xs bg-green-600 hover:bg-green-500 text-white font-medium px-3 py-1 rounded-md transition-colors"
+                              >
+                                Attiva selezionati
+                              </button>
+                            )}
+                            <button
+                              onClick={handleBatchDelete}
+                              className="text-xs bg-red-600 hover:bg-red-500 text-white font-medium px-3 py-1 rounded-md transition-colors"
+                            >
+                              Elimina selezionati
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </thead>
+                  <tbody>
+                    {filteredUsers.length === 0 && (
+                      <tr><td colSpan={8} className="text-center text-white/20 py-8">Nessun utente trovato.</td></tr>
+                    )}
+                    {filteredUsers.map((u) => {
+                      const isPending = !u.signup_code && !u.is_admin;
+                      return (
+                        <tr key={u.user_id} className="border-b border-white/[0.03] hover:bg-white/[0.02]">
+                          <td className="px-4 py-2.5">
+                            <input
+                              type="checkbox"
+                              checked={selectedUsers.has(u.user_id)}
+                              onChange={() => toggleUserSelection(u.user_id)}
+                              className="w-3.5 h-3.5 rounded border-white/20 bg-white/5 accent-purple-500"
+                            />
+                          </td>
+                          <td className="px-4 py-2.5">
+                            <button
+                              onClick={() => handleShowDetail(u.user_id)}
+                              className="text-white/70 hover:text-purple-300 transition-colors text-left"
+                            >
+                              {u.name || '—'}
+                            </button>
+                          </td>
+                          <td className="px-4 py-2.5 text-white/50 text-xs">{u.email || '—'}</td>
+                          <td className="px-4 py-2.5">
+                            {u.is_admin ? (
+                              <span className="text-xs bg-purple-500/15 text-purple-400 px-2 py-0.5 rounded-md">admin</span>
+                            ) : u.signup_code ? (
+                              <span className="text-xs bg-green-500/10 text-green-400 px-2 py-0.5 rounded-md">attivo</span>
+                            ) : (
+                              <span className="text-xs bg-amber-500/10 text-amber-400 px-2 py-0.5 rounded-md">in attesa</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2.5 text-white/30 font-mono text-xs">{u.signup_code || '—'}</td>
+                          <td className="px-4 py-2.5 text-white/40 text-xs">{u.provider}</td>
+                          <td className="px-4 py-2.5 text-white/30 text-xs">{formatDate(u.created_at)}</td>
+                          <td className="px-4 py-2.5 text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              {isPending && (
+                                <button onClick={() => handleActivateUser(u.user_id, u.name)} className="text-xs text-green-400/70 hover:text-green-400 px-2 py-1 rounded transition-colors">Attiva</button>
+                              )}
+                              {!u.is_admin ? (
+                                <button onClick={() => handlePromoteUser(u.user_id, u.name)} className="text-xs text-purple-400/70 hover:text-purple-400 px-2 py-1 rounded transition-colors">Admin</button>
+                              ) : (
+                                <button onClick={() => handleDemoteUser(u.user_id, u.name)} className="text-xs text-amber-400/70 hover:text-amber-400 px-2 py-1 rounded transition-colors">Revoca</button>
+                              )}
+                              <button onClick={() => handleDeleteUser(u.user_id, u.name)} className="text-xs text-red-400/50 hover:text-red-400 px-2 py-1 rounded transition-colors">Elimina</button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </motion.div>
+        )}
       </div>
+
+      {/* ── User Detail Dialog ── */}
+      <AnimatePresence>
+        {showDetail && userDetail && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/60"
+              onClick={() => { setShowDetail(false); setUserDetail(null); }}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 10 }}
+              className="relative bg-neutral-950 border border-white/10 rounded-xl p-6 max-w-lg w-full mx-4 shadow-2xl max-h-[80vh] overflow-y-auto"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <div>
+                  <h3 className="text-white font-semibold text-lg">{userDetail.name || '—'}</h3>
+                  <p className="text-white/40 text-sm">{userDetail.email}</p>
+                </div>
+                <button
+                  onClick={() => { setShowDetail(false); setUserDetail(null); }}
+                  className="text-white/30 hover:text-white/60 text-lg"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">User ID</div>
+                  <div className="text-white/70 font-mono text-xs break-all">{userDetail.user_id}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Orb ID</div>
+                  <div className="text-white/70 font-mono text-xs">{userDetail.orb_id || '—'}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Provider</div>
+                  <div className="text-white/70">{userDetail.provider}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Stato</div>
+                  <div>
+                    {userDetail.is_admin ? (
+                      <span className="text-xs bg-purple-500/15 text-purple-400 px-2 py-0.5 rounded-md">admin</span>
+                    ) : userDetail.signup_code ? (
+                      <span className="text-xs bg-green-500/10 text-green-400 px-2 py-0.5 rounded-md">attivo</span>
+                    ) : (
+                      <span className="text-xs bg-amber-500/10 text-amber-400 px-2 py-0.5 rounded-md">in attesa</span>
+                    )}
+                  </div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Nodi nel grafo</div>
+                  <div className="text-white text-lg font-bold">{userDetail.node_count}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">GDPR</div>
+                  <div className="text-white/70">{userDetail.gdpr_consent ? 'Consenso dato' : 'Non dato'}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Registrato</div>
+                  <div className="text-white/70 text-xs">{formatDate(userDetail.created_at)}</div>
+                </div>
+                <div className="bg-white/[0.03] rounded-lg p-3">
+                  <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Attivato</div>
+                  <div className="text-white/70 text-xs">{formatDate(userDetail.activated_at)}</div>
+                </div>
+                {userDetail.signup_code && (
+                  <div className="bg-white/[0.03] rounded-lg p-3 col-span-2">
+                    <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Codice usato</div>
+                    <div className="text-purple-300 font-mono text-xs">{userDetail.signup_code}</div>
+                  </div>
+                )}
+                {userDetail.headline && (
+                  <div className="bg-white/[0.03] rounded-lg p-3 col-span-2">
+                    <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Headline</div>
+                    <div className="text-white/70">{userDetail.headline}</div>
+                  </div>
+                )}
+                {userDetail.location && (
+                  <div className="bg-white/[0.03] rounded-lg p-3">
+                    <div className="text-white/40 text-xs uppercase tracking-wider mb-1">Location</div>
+                    <div className="text-white/70">{userDetail.location}</div>
+                  </div>
+                )}
+                {userDetail.deletion_requested_at && (
+                  <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 col-span-2">
+                    <div className="text-red-400 text-xs uppercase tracking-wider mb-1">Cancellazione richiesta</div>
+                    <div className="text-red-300 text-xs">{formatDate(userDetail.deletion_requested_at)}</div>
+                  </div>
+                )}
+              </div>
+
+              {/* Actions */}
+              <div className="flex gap-2 mt-5 pt-4 border-t border-white/[0.06]">
+                {!userDetail.signup_code && !userDetail.is_admin && (
+                  <button
+                    onClick={() => { setShowDetail(false); handleActivateUser(userDetail.user_id, userDetail.name); }}
+                    className="text-xs bg-green-600 hover:bg-green-500 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+                  >
+                    Attiva
+                  </button>
+                )}
+                {!userDetail.is_admin ? (
+                  <button
+                    onClick={() => { setShowDetail(false); handlePromoteUser(userDetail.user_id, userDetail.name); }}
+                    className="text-xs bg-purple-600 hover:bg-purple-500 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+                  >
+                    Promuovi admin
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => { setShowDetail(false); handleDemoteUser(userDetail.user_id, userDetail.name); }}
+                    className="text-xs bg-amber-600 hover:bg-amber-500 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+                  >
+                    Revoca admin
+                  </button>
+                )}
+                <button
+                  onClick={() => { setShowDetail(false); handleDeleteUser(userDetail.user_id, userDetail.name); }}
+                  className="text-xs bg-red-600 hover:bg-red-500 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+                >
+                  Elimina utente
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+
+      {/* ── Batch Report Dialog ── */}
+      <AnimatePresence>
+        {batchReport && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/60"
+              onClick={() => setBatchReport(null)}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 10 }}
+              className="relative bg-neutral-950 border border-white/10 rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl"
+            >
+              <h3 className="text-white font-semibold mb-4">{batchReport.title}</h3>
+
+              {batchReport.deleted.length > 0 && (
+                <div className="mb-4">
+                  <div className="text-green-400 text-xs uppercase tracking-wider font-medium mb-2">
+                    Eliminati ({batchReport.deleted.length})
+                  </div>
+                  <ul className="space-y-1">
+                    {batchReport.deleted.map((name) => (
+                      <li key={name} className="text-white/60 text-sm flex items-center gap-2">
+                        <span className="text-green-400 text-xs">&#10003;</span> {name}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {batchReport.failed.length > 0 && (
+                <div className="mb-4">
+                  <div className="text-red-400 text-xs uppercase tracking-wider font-medium mb-2">
+                    Non eliminati ({batchReport.failed.length})
+                  </div>
+                  <ul className="space-y-1">
+                    {batchReport.failed.map((f) => (
+                      <li key={f.name} className="text-sm flex items-start gap-2">
+                        <span className="text-red-400 text-xs mt-0.5">&#10007;</span>
+                        <span>
+                          <span className="text-white/60">{f.name}</span>
+                          <span className="text-white/30"> — {f.reason}</span>
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="flex justify-end mt-4">
+                <button
+                  onClick={() => setBatchReport(null)}
+                  className="text-sm bg-white/[0.06] hover:bg-white/[0.1] text-white/70 font-medium px-4 py-2 rounded-lg transition-colors"
+                >
+                  Chiudi
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
 
       {/* ── Confirmation Dialog ── */}
       <AnimatePresence>


### PR DESCRIPTION
## Summary
- **User management tab**: list, search, filter (all/active/pending/admin), detail dialog, activate, promote/demote admin, delete users
- **Batch operations**: select-all checkbox in table headers, batch activate and batch delete with per-item error report dialog
- **Invite codes**: multi-select, batch delete, confirmation on all destructive actions, delete used codes
- **Activation edge cases**: auto-activate users when platform opens, auto-assign `signup_code` on open-platform registration, silent polling on ActivatePage for admin-granted activation
- **15 new unit tests** for all user management endpoints (417 total, 75.97% coverage)
