### PR TITLE
feat: show CV processing metadata in admin user detail

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -74,6 +74,18 @@ class UserResponse(BaseModel):
     created_at: str = ""
 
 
+class ProcessingRecordInfo(BaseModel):
+    document_id: str = ""
+    original_filename: str = ""
+    llm_provider: str = ""
+    llm_model: str = ""
+    extraction_method: str = ""
+    nodes_extracted: int = 0
+    edges_extracted: int = 0
+    ontology_version: int | None = None
+    processed_at: str = ""
+
+
 class UserDetailResponse(UserResponse):
     orb_id: str = ""
     picture: str = ""
@@ -82,6 +94,7 @@ class UserDetailResponse(UserResponse):
     node_count: int = 0
     gdpr_consent: bool = False
     deletion_requested_at: str | None = None
+    processing_records: list[ProcessingRecordInfo] = []
 
 
 class BatchActivateRequest(BaseModel):

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -20,6 +20,7 @@ from app.admin.models import (
     InsightsResponse,
     InviteCodeCounts,
     PendingUser,
+    ProcessingRecordInfo,
     StatsResponse,
     UserDetailResponse,
     UserResponse,
@@ -119,6 +120,9 @@ def _serialize_user_detail(node: dict) -> UserDetailResponse:
             if node.get("deletion_requested_at")
             else None
         ),
+        processing_records=[
+            ProcessingRecordInfo(**pr) for pr in node.get("processing_records", [])
+        ],
     )
 
 

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -38,6 +38,7 @@ from app.graph.queries import (
     GET_BETA_CONFIG,
     GET_PERSON_BY_USER_ID,
     GET_PERSON_DETAIL,
+    GET_USER_PROCESSING_RECORDS,
     GRANT_ADMIN_BY_USER_ID,
     GRAPH_RICHNESS,
     INIT_BETA_CONFIG,
@@ -285,18 +286,56 @@ async def list_all_users(db: AsyncDriver) -> list[dict]:
 
 
 async def get_user_detail(db: AsyncDriver, user_id: str) -> dict | None:
-    """Return a single user with node count and decrypted email."""
+    """Return a single user with node count, decrypted email, and processing records."""
     async with db.session() as session:
         result = await session.run(GET_PERSON_DETAIL, user_id=user_id)
         record = await result.single()
-    if not record:
-        return None
+        if not record:
+            return None
+
+        # Fetch processing records
+        pr_result = await session.run(GET_USER_PROCESSING_RECORDS, user_id=user_id)
+        pr_records = [r async for r in pr_result]
+
     person = dict(record["p"])
     email = person.get("email", "")
     if email:
         with contextlib.suppress(Exception):
             email = decrypt_value(email)
-    return {**person, "email": email, "node_count": int(record["node_count"])}
+
+    # Enrich processing records with document filenames from SQLite
+    from app.cv_storage import db as cv_db
+
+    user_docs = {
+        d["document_id"]: d["original_filename"] for d in cv_db.list_documents(user_id)
+    }
+
+    processing_records = []
+    for r in pr_records:
+        pr = dict(r["pr"])
+        doc_id = pr.get("document_id", "")
+        processing_records.append(
+            {
+                "document_id": doc_id,
+                "original_filename": user_docs.get(doc_id, "deleted"),
+                "llm_provider": pr.get("llm_provider", ""),
+                "llm_model": pr.get("llm_model", ""),
+                "extraction_method": pr.get("extraction_method", ""),
+                "nodes_extracted": int(pr.get("nodes_extracted", 0)),
+                "edges_extracted": int(pr.get("edges_extracted", 0)),
+                "ontology_version": int(r["ontology_version"])
+                if r["ontology_version"] is not None
+                else None,
+                "processed_at": str(pr.get("processed_at", "")),
+            }
+        )
+
+    return {
+        **person,
+        "email": email,
+        "node_count": int(record["node_count"]),
+        "processing_records": processing_records,
+    }
 
 
 async def activate_user_by_admin(

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -569,3 +569,10 @@ MATCH (p:Person {user_id: $user_id})
 MATCH (pr:ProcessingRecord {record_id: $record_id})
 CREATE (p)-[:HAS_PROCESSING_RECORD]->(pr)
 """
+
+GET_USER_PROCESSING_RECORDS = """
+MATCH (p:Person {user_id: $user_id})-[:HAS_PROCESSING_RECORD]->(pr:ProcessingRecord)
+OPTIONAL MATCH (pr)-[:USED_ONTOLOGY]->(ov:OntologyVersion)
+RETURN pr, ov.version_number AS ontology_version
+ORDER BY pr.processed_at DESC
+"""

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -121,6 +121,18 @@ export interface AdminUser {
   created_at: string;
 }
 
+export interface ProcessingRecord {
+  document_id: string;
+  original_filename: string;
+  llm_provider: string;
+  llm_model: string;
+  extraction_method: string;
+  nodes_extracted: number;
+  edges_extracted: number;
+  ontology_version: number | null;
+  processed_at: string;
+}
+
 export interface AdminUserDetail extends AdminUser {
   orb_id: string;
   picture: string;
@@ -129,6 +141,7 @@ export interface AdminUserDetail extends AdminUser {
   node_count: number;
   gdpr_consent: boolean;
   deletion_requested_at: string | null;
+  processing_records: ProcessingRecord[];
 }
 
 export async function listUsers(): Promise<AdminUser[]> {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -20,16 +20,14 @@ import {
   updateBetaConfig,
   getFunnelMetrics,
   getInsights,
+  listIdeas,
+  deleteIdea,
   type AdminStats,
   type AccessCode,
   type PendingUser,
   type AdminUser,
   type AdminUserDetail,
-  listIdeas,
-  deleteIdea,
   type Idea,
-  getFunnelMetrics,
-  getInsights,
   type FunnelMetrics,
   type Insights,
 } from '../api/admin';
@@ -1354,6 +1352,32 @@ export default function AdminPage() {
                   <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 col-span-2">
                     <div className="text-red-400 text-xs uppercase tracking-wider mb-1">Deletion requested</div>
                     <div className="text-red-300 text-xs">{formatDate(userDetail.deletion_requested_at)}</div>
+                  </div>
+                )}
+              </div>
+
+              {/* Processing History */}
+              <div className="mt-5 pt-4 border-t border-white/[0.06]">
+                <p className="text-white/40 text-xs uppercase tracking-wider font-medium mb-3">Processing History</p>
+                {userDetail.processing_records.length === 0 ? (
+                  <p className="text-white/20 text-xs">No processing records.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {userDetail.processing_records.map((pr, i) => (
+                      <div key={i} className="bg-white/[0.03] border border-white/5 rounded-lg p-3 text-xs">
+                        <div className="flex items-center justify-between mb-1.5">
+                          <span className="text-white/70 font-medium truncate">{pr.original_filename}</span>
+                          <span className="text-white/30 flex-shrink-0 ml-2">{formatDate(pr.processed_at)}</span>
+                        </div>
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-white/40">
+                          <span>Model: <span className="text-white/60">{pr.llm_provider}/{pr.llm_model}</span></span>
+                          <span>Method: <span className={pr.extraction_method === 'primary' ? 'text-green-400/70' : 'text-amber-400/70'}>{pr.extraction_method}</span></span>
+                          {pr.ontology_version != null && <span>Ontology: <span className="text-white/60">v{pr.ontology_version}</span></span>}
+                          <span>Nodes: <span className="text-white/60">{pr.nodes_extracted}</span></span>
+                          <span>Edges: <span className="text-white/60">{pr.edges_extracted}</span></span>
+                        </div>
+                      </div>
+                    ))}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Closes #246

Adds a "Processing History" section to the admin user detail modal, showing metadata from each CV import: which LLM model processed it, extraction method, ontology version, nodes/edges extracted, and timestamp.

**Note:** Depends on #233 (provenance tracking) being merged first — processing records are only created after that feature is live.

## Changes

| File | Change |
|------|--------|
| `backend/app/graph/queries.py` | Add `GET_USER_PROCESSING_RECORDS` Cypher query |
| `backend/app/admin/models.py` | Add `ProcessingRecordInfo` model; extend `UserDetailResponse` |
| `backend/app/admin/service.py` | Extend `get_user_detail` to fetch processing records + enrich with document filenames from SQLite |
| `backend/app/admin/router.py` | Import `ProcessingRecordInfo`; serialize processing records in detail response |
| `frontend/src/api/admin.ts` | Add `ProcessingRecord` type to `AdminUserDetail` |
| `frontend/src/pages/AdminPage.tsx` | Add Processing History section in user detail modal; fix duplicate imports |

## Test plan

- [x] 452 backend tests passing, lint clean
- [x] Frontend lint clean
- [ ] Open admin > click user > verify "Processing History" section visible
- [ ] After #233 is merged: import a CV, then check user detail shows processing record with model, method, ontology version, nodes/edges

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)