### PR TITLE
feat: orb visibility modes and restricted-mode allowlist (#236)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from neo4j import AsyncDriver
@@ -16,27 +16,44 @@ async def get_db() -> AsyncDriver:
     return await get_driver()
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-) -> dict:
+def _decode_jwt(token: str) -> dict | None:
+    """Decode a JWT and return the user dict, or ``None`` if invalid."""
     try:
         payload = jwt.decode(
-            credentials.credentials,
+            token,
             settings.jwt_secret,
             algorithms=[settings.jwt_algorithm],
         )
-        user_id: str | None = payload.get("sub")
-        if user_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token",
-            )
-        return {"user_id": user_id, "email": payload.get("email", "")}
     except JWTError:
+        return None
+    user_id = payload.get("sub")
+    if user_id is None:
+        return None
+    return {"user_id": user_id, "email": payload.get("email", "")}
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict:
+    user = _decode_jwt(credentials.credentials)
+    if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token",
-        ) from None
+        )
+    return user
+
+
+async def get_current_user_optional(request: Request) -> dict | None:
+    """Like ``get_current_user`` but returns ``None`` for missing/invalid auth.
+
+    Used by endpoints that conditionally require auth based on resource
+    state (e.g. restricted orbs require auth, public orbs don't).
+    """
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        return None
+    return _decode_jwt(auth.split(" ", 1)[1])
 
 
 async def require_admin(

--- a/backend/app/email/service.py
+++ b/backend/app/email/service.py
@@ -63,3 +63,15 @@ async def send_invite_code_email(*, to: str, code: str, frontend_url: str) -> bo
         subject="Your OpenOrbis invite code",
         html_body=html,
     )
+
+
+async def send_access_grant_email(*, to: str, owner_name: str, orb_url: str) -> bool:
+    """Notify a recipient that an owner granted them access to a restricted orb."""
+    from app.email.templates import render_access_grant_email
+
+    html = render_access_grant_email(owner_name=owner_name, orb_url=orb_url)
+    return await send_email(
+        to=to,
+        subject=f"{owner_name} shared their Orbis with you",
+        html_body=html,
+    )

--- a/backend/app/email/templates.py
+++ b/backend/app/email/templates.py
@@ -145,6 +145,38 @@ _invite_code_tpl = _env.from_string(
 )
 
 
+# ── Access grant email (orb owner shares restricted orb with a recipient) ──
+
+_ACCESS_GRANT_CONTENT = """\
+<h1 style="margin:0 0 6px;font-size:24px;font-weight:700;color:#1a1025;">
+  {{ owner_name }} shared their Orbis with you.
+</h1>
+<p style="margin:0 0 24px;font-size:14px;color:#7c3aed;font-weight:500;">
+  Restricted access invitation
+</p>
+<p style="margin:0 0 16px;font-size:15px;color:#4a4458;line-height:1.7;">
+  You've been granted access to view {{ owner_name }}'s career
+  knowledge graph on OpenOrbis. Sign in with this email address to
+  open it.
+</p>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px;">
+  <tr>
+    <td style="width:4px;background:linear-gradient(180deg,#a78bfa,#7c3aed);border-radius:4px;"></td>
+    <td style="padding:12px 16px;">
+      <p style="margin:0;font-size:14px;color:#6b5f7d;line-height:1.6;">
+        This invitation is tied to your email. Only people the owner has
+        explicitly invited can view this Orbis.
+      </p>
+    </td>
+  </tr>
+</table>
+""" + _BUTTON.replace("{{ label }}", "Open the Orbis")
+
+_access_grant_tpl = _env.from_string(
+    _LAYOUT.replace("{{ content }}", _ACCESS_GRANT_CONTENT)
+)
+
+
 def render_activation_email(*, activate_url: str) -> str:
     """Render the email sent when an admin activates a user directly."""
     from datetime import datetime, timezone
@@ -162,5 +194,16 @@ def render_invite_code_email(*, code: str, activate_url: str) -> str:
     return _invite_code_tpl.render(
         code=code,
         url=activate_url,
+        year=datetime.now(timezone.utc).year,
+    )
+
+
+def render_access_grant_email(*, owner_name: str, orb_url: str) -> str:
+    """Render the email sent when an owner grants access to their orb."""
+    from datetime import datetime, timezone
+
+    return _access_grant_tpl.render(
+        owner_name=owner_name,
+        url=orb_url,
         year=datetime.now(timezone.utc).year,
     )

--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -9,10 +9,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from neo4j import AsyncDriver
 
-from app.dependencies import get_db
+from app.dependencies import get_current_user_optional, get_db
 from app.graph.encryption import decrypt_properties
 from app.graph.queries import GET_FULL_ORB_PUBLIC
 from app.orbs.share_token import node_matches_filters, validate_share_token
+from app.orbs.visibility import (
+    assert_orb_accessible,
+    assert_user_can_access_restricted,
+    get_orb_visibility,
+)
 from app.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -198,22 +203,37 @@ def _generate_pdf(  # noqa: C901
 
 @router.get("/{orb_id}")
 @limiter.limit("30/minute")
-async def export_orb(
+async def export_orb(  # noqa: C901
     request: Request,
     orb_id: str,
     format: str = Query("json", pattern="^(json|jsonld|pdf)$"),
-    token: str = Query(..., description="Share token required for access"),
+    token: str | None = Query(None, description="Share token (public orbs only)"),
     include_photo: bool = Query(True),
     db: AsyncDriver = Depends(get_db),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    # Validate the share token
-    token_data = await validate_share_token(db, token)
-    if token_data is None:
-        raise HTTPException(status_code=403, detail="Invalid or expired share token.")
-    if token_data["orb_id"] != orb_id:
-        raise HTTPException(
-            status_code=403, detail="Token does not grant access to this orb."
-        )
+    # 1. Visibility gate
+    visibility = await get_orb_visibility(db, orb_id)
+    assert_orb_accessible(visibility)
+
+    # 2. Branch on visibility mode
+    token_data: dict | None = None
+    if visibility == "restricted":
+        await assert_user_can_access_restricted(db, orb_id, current_user)
+    else:
+        if not token:
+            raise HTTPException(
+                status_code=403, detail="Share token required for this orb."
+            )
+        token_data = await validate_share_token(db, token)
+        if token_data is None:
+            raise HTTPException(
+                status_code=403, detail="Invalid or expired share token."
+            )
+        if token_data["orb_id"] != orb_id:
+            raise HTTPException(
+                status_code=403, detail="Token does not grant access to this orb."
+            )
 
     async with db.session() as session:
         try:
@@ -239,9 +259,9 @@ async def export_orb(
             status_code=500, detail="Failed to process orb data"
         ) from None
 
-    # Apply filters from the share token (keywords + hidden node types)
-    active_filters = token_data["keywords"]
-    hidden_types = set(token_data.get("hidden_node_types", []))
+    # Apply filters only when a share token was used (public mode)
+    active_filters = token_data["keywords"] if token_data else []
+    hidden_types = set(token_data.get("hidden_node_types", []) if token_data else [])
     if active_filters or hidden_types:
         nodes = [
             n

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -19,6 +19,7 @@ CREATE (p:Person {
     website_url: '',
     orcid_url: '',
     open_to_work: false,
+    visibility: 'private',
     created_at: datetime(),
     updated_at: datetime()
 })
@@ -28,6 +29,47 @@ RETURN p
 GET_PERSON_BY_USER_ID = """
 MATCH (p:Person {user_id: $user_id})
 RETURN p
+"""
+
+GET_PERSON_VISIBILITY = """
+MATCH (p:Person {orb_id: $orb_id})
+RETURN coalesce(p.visibility, 'private') AS visibility
+"""
+
+# ── Access grants (restricted-mode allowlist) ──
+
+CREATE_ACCESS_GRANT = """
+MATCH (p:Person {user_id: $user_id})
+WHERE p.orb_id IS NOT NULL AND p.orb_id <> ''
+CREATE (p)-[:GRANTED_ACCESS]->(g:AccessGrant {
+    grant_id:   $grant_id,
+    orb_id:     p.orb_id,
+    email:      $email,
+    created_at: datetime(),
+    revoked:    false,
+    revoked_at: null
+})
+RETURN g, p.orb_id AS orb_id, p.name AS owner_name
+"""
+
+LIST_ACCESS_GRANTS = """
+MATCH (p:Person {user_id: $user_id})-[:GRANTED_ACCESS]->(g:AccessGrant)
+WHERE g.revoked = false
+RETURN g
+ORDER BY g.created_at DESC
+"""
+
+REVOKE_ACCESS_GRANT = """
+MATCH (p:Person {user_id: $user_id})-[:GRANTED_ACCESS]->(g:AccessGrant {grant_id: $grant_id})
+SET g.revoked = true, g.revoked_at = datetime()
+RETURN g
+"""
+
+CHECK_ACCESS_GRANT = """
+MATCH (p:Person {orb_id: $orb_id})-[:GRANTED_ACCESS]->(g:AccessGrant {email: $email})
+WHERE g.revoked = false
+RETURN g
+LIMIT 1
 """
 
 GET_PERSON_BY_ORB_ID = """
@@ -58,7 +100,7 @@ RETURN p
 GET_FULL_ORB = """
 MATCH (p:Person {user_id: $user_id})
 OPTIONAL MATCH (p)-[r]->(n)
-WHERE NOT n:ProcessingRecord AND NOT n:OntologyVersion AND NOT n:ShareToken
+WHERE NOT n:ProcessingRecord AND NOT n:OntologyVersion AND NOT n:ShareToken AND NOT n:AccessGrant
 
 WITH p, collect({node: n, rel: type(r), rel_id: id(r)}) AS connections
 OPTIONAL MATCH (p)-[]->(src)-[cr:USED_SKILL]->(tgt:Skill)
@@ -71,7 +113,7 @@ RETURN p, connections, cross_links, cross_skill_nodes
 GET_FULL_ORB_PUBLIC = """
 MATCH (p:Person {orb_id: $orb_id})
 OPTIONAL MATCH (p)-[r]->(n)
-WHERE NOT n:ProcessingRecord AND NOT n:OntologyVersion AND NOT n:ShareToken
+WHERE NOT n:ProcessingRecord AND NOT n:OntologyVersion AND NOT n:ShareToken AND NOT n:AccessGrant
 
 WITH p, collect({node: n, rel: type(r), rel_id: id(r)}) AS connections
 OPTIONAL MATCH (p)-[]->(src)-[cr:USED_SKILL]->(tgt:Skill)

--- a/backend/app/orbs/access_grants.py
+++ b/backend/app/orbs/access_grants.py
@@ -1,0 +1,97 @@
+"""Per-user access grants for restricted orbs.
+
+When an orb's visibility is ``restricted``, only logged-in users whose
+email matches an active ``AccessGrant`` can view it. The owner manages
+the allowlist via dedicated endpoints. Grants are stored as nodes
+parallel to ``ShareToken`` so they support audit trail and future
+extensions (expiry, view tracking).
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from neo4j import AsyncDriver
+from neo4j.time import Date as Neo4jDate
+from neo4j.time import DateTime as Neo4jDateTime
+from neo4j.time import Time as Neo4jTime
+
+from app.graph.queries import (
+    CHECK_ACCESS_GRANT,
+    CREATE_ACCESS_GRANT,
+    LIST_ACCESS_GRANTS,
+    REVOKE_ACCESS_GRANT,
+)
+
+
+def _sanitize(d: dict) -> dict:
+    """Convert Neo4j temporal types to JSON-safe strings."""
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, (Neo4jDateTime, Neo4jDate, Neo4jTime)):
+            result[k] = v.iso_format()
+        else:
+            result[k] = v
+    return result
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+async def create_access_grant(db: AsyncDriver, user_id: str, email: str) -> dict | None:
+    """Create an access grant for the given email on the user's orb.
+
+    Returns ``None`` if the user has no orb_id set.
+    """
+    grant_id = secrets.token_urlsafe(16)
+    normalized = _normalize_email(email)
+
+    async with db.session() as session:
+        result = await session.run(
+            CREATE_ACCESS_GRANT,
+            user_id=user_id,
+            grant_id=grant_id,
+            email=normalized,
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        grant = _sanitize(dict(record["g"]))
+        grant["owner_name"] = record["owner_name"] or ""
+        return grant
+
+
+async def list_access_grants(db: AsyncDriver, user_id: str) -> list[dict]:
+    """List active (non-revoked) grants for the user's orb."""
+    async with db.session() as session:
+        result = await session.run(LIST_ACCESS_GRANTS, user_id=user_id)
+        grants = []
+        async for record in result:
+            grants.append(_sanitize(dict(record["g"])))
+        return grants
+
+
+async def revoke_access_grant(
+    db: AsyncDriver, user_id: str, grant_id: str
+) -> dict | None:
+    """Mark a grant as revoked. Returns the grant dict or ``None``."""
+    async with db.session() as session:
+        result = await session.run(
+            REVOKE_ACCESS_GRANT, user_id=user_id, grant_id=grant_id
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["g"]))
+
+
+async def user_has_access(db: AsyncDriver, orb_id: str, email: str) -> bool:
+    """Return True if the email has an active grant for the orb."""
+    normalized = _normalize_email(email)
+    if not normalized:
+        return False
+    async with db.session() as session:
+        result = await session.run(CHECK_ACCESS_GRANT, orb_id=orb_id, email=normalized)
+        record = await result.single()
+        return record is not None

--- a/backend/app/orbs/models.py
+++ b/backend/app/orbs/models.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
+
+OrbVisibility = Literal["private", "public", "restricted"]
 
 
 class NodeCreate(BaseModel):
@@ -25,10 +28,15 @@ class PersonUpdate(BaseModel):
     scholar_url: str | None = None
     website_url: str | None = None
     open_to_work: bool | None = None
+    visibility: OrbVisibility | None = None
 
 
 class OrbIdUpdate(BaseModel):
     orb_id: str
+
+
+class VisibilityUpdate(BaseModel):
+    visibility: OrbVisibility
 
 
 # ── Share Tokens ──
@@ -56,3 +64,22 @@ class ShareTokenResponse(BaseModel):
 
 class ShareTokenListResponse(BaseModel):
     tokens: list[ShareTokenResponse]
+
+
+# ── Access grants (restricted-mode allowlist) ──
+
+
+class AccessGrantCreate(BaseModel):
+    email: str  # normalized lowercase server-side
+
+
+class AccessGrantResponse(BaseModel):
+    grant_id: str
+    orb_id: str
+    email: str
+    created_at: datetime
+    revoked: bool
+
+
+class AccessGrantListResponse(BaseModel):
+    grants: list[AccessGrantResponse]

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -11,7 +11,9 @@ from neo4j.time import DateTime as Neo4jDateTime
 from neo4j.time import Time as Neo4jTime
 from pydantic import BaseModel
 
-from app.dependencies import get_current_user, get_db
+from app.config import settings
+from app.dependencies import get_current_user, get_current_user_optional, get_db
+from app.email.service import send_access_grant_email
 from app.graph.encryption import decrypt_properties, encrypt_properties
 from app.graph.queries import (
     ADD_NODE,
@@ -27,7 +29,15 @@ from app.graph.queries import (
     UPDATE_ORB_ID,
     UPDATE_PERSON,
 )
+from app.orbs.access_grants import (
+    create_access_grant,
+    list_access_grants,
+    revoke_access_grant,
+)
 from app.orbs.models import (
+    AccessGrantCreate,
+    AccessGrantListResponse,
+    AccessGrantResponse,
     NodeCreate,
     NodeUpdate,
     OrbIdUpdate,
@@ -35,6 +45,7 @@ from app.orbs.models import (
     ShareTokenCreate,
     ShareTokenListResponse,
     ShareTokenResponse,
+    VisibilityUpdate,
 )
 from app.orbs.share_token import (
     create_share_token,
@@ -42,6 +53,11 @@ from app.orbs.share_token import (
     node_matches_filters,
     revoke_share_token,
     validate_share_token,
+)
+from app.orbs.visibility import (
+    assert_orb_accessible,
+    assert_user_can_access_restricted,
+    get_orb_visibility,
 )
 from app.rate_limit import limiter
 from app.snapshots import db as snap_db
@@ -190,6 +206,25 @@ async def claim_orb_id(
             UPDATE_ORB_ID, user_id=current_user["user_id"], orb_id=data.orb_id
         )
         return {"orb_id": data.orb_id}
+
+
+@router.put("/me/visibility")
+async def update_visibility(
+    data: VisibilityUpdate,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Update the visibility of the current user's orb."""
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_PERSON,
+            user_id=current_user["user_id"],
+            properties={"visibility": data.visibility},
+        )
+        record = await result.single()
+        if record is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        return {"visibility": data.visibility}
 
 
 @router.post("/me/profile-image")
@@ -430,26 +465,97 @@ async def revoke_share_token_endpoint(
     return {"status": "revoked"}
 
 
+# ── Access grants (restricted-mode allowlist) ──
+
+
+@router.post("/me/access-grants", response_model=AccessGrantResponse)
+async def create_access_grant_endpoint(
+    data: AccessGrantCreate,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Grant a specific email access to this user's restricted orb.
+
+    Sends a notification email to the recipient. Email failure is
+    swallowed (best-effort) so the grant is still created.
+    """
+    grant = await create_access_grant(
+        db=db, user_id=current_user["user_id"], email=data.email
+    )
+    if grant is None:
+        raise HTTPException(status_code=400, detail="Set an orb ID first")
+
+    orb_url = f"{settings.frontend_url.rstrip('/')}/{grant['orb_id']}"
+    try:
+        await send_access_grant_email(
+            to=grant["email"],
+            owner_name=grant.get("owner_name") or "An OpenOrbis user",
+            orb_url=orb_url,
+        )
+    except Exception:
+        logger.exception("Failed to send access grant email to %s", grant["email"])
+
+    return grant
+
+
+@router.get("/me/access-grants", response_model=AccessGrantListResponse)
+async def list_access_grants_endpoint(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """List active access grants on this user's orb."""
+    grants = await list_access_grants(db, current_user["user_id"])
+    return {"grants": grants}
+
+
+@router.delete("/me/access-grants/{grant_id}")
+async def revoke_access_grant_endpoint(
+    grant_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Revoke an access grant."""
+    result = await revoke_access_grant(db, current_user["user_id"], grant_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Grant not found")
+    return {"status": "revoked"}
+
+
 @router.get("/{orb_id}")
 @limiter.limit("30/minute")
 async def get_public_orb(
     request: Request,
     orb_id: str,
-    token: str = Query(..., description="Share token required for access"),
+    token: str | None = Query(None, description="Share token (public orbs only)"),
     db: AsyncDriver = Depends(get_db),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    # Validate the share token
-    token_data = await validate_share_token(db, token)
-    if token_data is None:
-        raise HTTPException(
-            status_code=403,
-            detail="Invalid or expired share token.",
-        )
-    if token_data["orb_id"] != orb_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Token does not grant access to this orb.",
-        )
+    # 1. Visibility gate
+    visibility = await get_orb_visibility(db, orb_id)
+    assert_orb_accessible(visibility)
+
+    # 2. Branch on visibility mode
+    token_data: dict | None = None
+    if visibility == "restricted":
+        # Require auth + email in allowlist (or owner)
+        await assert_user_can_access_restricted(db, orb_id, current_user)
+    else:
+        # public: require a valid share token
+        if not token:
+            raise HTTPException(
+                status_code=403, detail="Share token required for this orb."
+            )
+        token_data = await validate_share_token(db, token)
+        if token_data is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Invalid or expired share token.",
+            )
+        if token_data["orb_id"] != orb_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Token does not grant access to this orb.",
+            )
 
     async with db.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
@@ -464,9 +570,9 @@ async def get_public_orb(
 
     orb_data = _serialize_orb(record)
 
-    # Apply filters (keywords + hidden node types)
-    keywords = token_data["keywords"]
-    hidden_types = set(token_data.get("hidden_node_types", []))
+    # Apply filters only in public mode (token-based filtering)
+    keywords = token_data["keywords"] if token_data else []
+    hidden_types = set(token_data.get("hidden_node_types", []) if token_data else [])
     if keywords or hidden_types:
         filtered_nodes = []
         filtered_uids = set()
@@ -489,9 +595,9 @@ async def get_public_orb(
 
     client_ip = request.client.host if request.client else "unknown"
     logger.info(
-        "PUBLIC_ACCESS | ip=%s | orb_id=%s | token=%s... | status=200",
+        "PUBLIC_ACCESS | ip=%s | orb_id=%s | mode=%s | status=200",
         client_ip,
         orb_id,
-        token[:8],
+        visibility,
     )
     return orb_data

--- a/backend/app/orbs/visibility.py
+++ b/backend/app/orbs/visibility.py
@@ -1,0 +1,67 @@
+"""Visibility guard for orb access control.
+
+Orbs have three visibility modes:
+- ``private``: only the owner can view (all public access denied)
+- ``public``: share-token gated access works
+- ``restricted``: only logged-in users with an active ``AccessGrant``
+  matching their email can view (managed by the owner via the
+  access-grants endpoints)
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from neo4j import AsyncDriver
+
+from app.graph.queries import GET_PERSON_BY_ORB_ID, GET_PERSON_VISIBILITY
+from app.orbs.access_grants import user_has_access
+
+
+async def get_orb_visibility(db: AsyncDriver, orb_id: str) -> str | None:
+    """Return the visibility setting for an orb, or ``None`` if not found."""
+    async with db.session() as session:
+        result = await session.run(GET_PERSON_VISIBILITY, orb_id=orb_id)
+        record = await result.single()
+        if record is None:
+            return None
+        return record["visibility"]
+
+
+def assert_orb_accessible(visibility: str | None) -> None:
+    """Raise if the orb is private or missing.
+
+    For ``restricted``, the caller must additionally call
+    ``assert_user_can_access_restricted`` to enforce the allowlist.
+    """
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Orb not found")
+    if visibility == "private":
+        raise HTTPException(status_code=403, detail="This orb is private.")
+
+
+async def assert_user_can_access_restricted(
+    db: AsyncDriver, orb_id: str, current_user: dict | None
+) -> None:
+    """Enforce the per-user allowlist on restricted orbs.
+
+    Raises 401 if the caller is not authenticated, 403 if their email is
+    not on the allowlist (and they are not the owner). Owners always
+    have access to their own orb regardless of grants.
+    """
+    if current_user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    email = (current_user.get("email") or "").strip().lower()
+
+    # Owner bypass
+    async with db.session() as session:
+        result = await session.run(GET_PERSON_BY_ORB_ID, orb_id=orb_id)
+        record = await result.single()
+        if record is not None:
+            owner_id = dict(record["p"]).get("user_id")
+            if owner_id == current_user.get("user_id"):
+                return
+
+    if not email:
+        raise HTTPException(status_code=403, detail="No email on your account")
+    if not await user_has_access(db, orb_id, email):
+        raise HTTPException(status_code=403, detail="You don't have access to this orb")

--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -6,9 +6,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from neo4j import AsyncDriver
 from pydantic import BaseModel
 
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_current_user, get_current_user_optional, get_db
 from app.graph.embeddings import generate_embedding
 from app.orbs.share_token import node_matches_filters, validate_share_token
+from app.orbs.visibility import (
+    assert_orb_accessible,
+    assert_user_can_access_restricted,
+    get_orb_visibility,
+)
 from app.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -261,7 +266,7 @@ async def text_search(  # noqa: C901
 class PublicTextSearchRequest(BaseModel):
     query: str
     orb_id: str
-    token: str
+    token: str | None = None
 
 
 @router.post("/text/public")
@@ -270,18 +275,38 @@ async def public_text_search(  # noqa: C901
     request: Request,
     data: PublicTextSearchRequest,
     db: AsyncDriver = Depends(get_db),
+    current_user: dict | None = Depends(get_current_user_optional),
 ):
-    """Fuzzy text search across a public orb's nodes (requires share token)."""
-    # Validate the share token
-    token_data = await validate_share_token(db, data.token)
-    if token_data is None:
-        raise HTTPException(status_code=403, detail="Invalid or expired share token.")
-    if token_data["orb_id"] != data.orb_id:
-        raise HTTPException(
-            status_code=403, detail="Token does not grant access to this orb."
-        )
-    filter_keywords = token_data["keywords"]
-    hidden_types = set(token_data.get("hidden_node_types", []))
+    """Fuzzy text search across a shareable orb's nodes.
+
+    Public orbs require a share token. Restricted orbs require a logged-in
+    user whose email is on the allowlist (or the owner).
+    """
+    # 1. Visibility gate
+    visibility = await get_orb_visibility(db, data.orb_id)
+    assert_orb_accessible(visibility)
+
+    # 2. Branch on visibility
+    token_data: dict | None = None
+    if visibility == "restricted":
+        await assert_user_can_access_restricted(db, data.orb_id, current_user)
+    else:
+        if not data.token:
+            raise HTTPException(
+                status_code=403, detail="Share token required for this orb."
+            )
+        token_data = await validate_share_token(db, data.token)
+        if token_data is None:
+            raise HTTPException(
+                status_code=403, detail="Invalid or expired share token."
+            )
+        if token_data["orb_id"] != data.orb_id:
+            raise HTTPException(
+                status_code=403, detail="Token does not grant access to this orb."
+            )
+
+    filter_keywords = token_data["keywords"] if token_data else []
+    hidden_types = set(token_data.get("hidden_node_types", []) if token_data else [])
 
     raw_term = data.query.strip().lower()
     terms = [t for t in raw_term.split() if len(t) >= 2]

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -7,13 +7,34 @@ from neo4j import AsyncDriver
 from app.graph.encryption import decrypt_properties
 from app.graph.queries import (
     GET_FULL_ORB_PUBLIC,
+    GET_PERSON_VISIBILITY,
     NODE_TYPE_LABELS,
     NODE_TYPE_RELATIONSHIPS,
 )
 
 
+async def _check_visibility(driver: AsyncDriver, orb_id: str) -> dict | None:
+    """Return an error dict if the orb is not publicly accessible, else ``None``.
+
+    The MCP server is anonymous (no user context), so it can only serve
+    ``public`` orbs. ``private`` and ``restricted`` orbs are rejected
+    with a generic message that doesn't leak which mode is in use.
+    """
+    async with driver.session() as session:
+        result = await session.run(GET_PERSON_VISIBILITY, orb_id=orb_id)
+        record = await result.single()
+    if record is None:
+        return {"error": f"Orb '{orb_id}' not found"}
+    if record["visibility"] != "public":
+        return {"error": f"Orb '{orb_id}' is not publicly accessible"}
+    return None
+
+
 async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
     """Get a structured summary of a person's professional profile."""
+    blocked = await _check_visibility(driver, orb_id)
+    if blocked is not None:
+        return blocked
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
         record = await result.single()
@@ -47,6 +68,9 @@ async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
 
 async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
     """Get the complete graph data for an orb."""
+    blocked = await _check_visibility(driver, orb_id)
+    if blocked is not None:
+        return blocked
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
         record = await result.single()
@@ -81,6 +105,10 @@ async def get_nodes_by_type(
             }
         ]
 
+    blocked = await _check_visibility(driver, orb_id)
+    if blocked is not None:
+        return [blocked]
+
     label = NODE_TYPE_LABELS[node_type]
     rel_type = NODE_TYPE_RELATIONSHIPS[node_type]
 
@@ -101,6 +129,9 @@ async def get_nodes_by_type(
 
 async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> dict:
     """Get all relationships for a specific node."""
+    blocked = await _check_visibility(driver, orb_id)
+    if blocked is not None:
+        return blocked
     query = """
     MATCH (n {uid: $node_uid})-[r]-(connected)
     MATCH (p:Person {orb_id: $orb_id})-[*1..2]-(n)
@@ -127,6 +158,9 @@ async def get_skills_for_experience(
     driver: AsyncDriver, orb_id: str, experience_uid: str
 ) -> list[dict]:
     """Get skills associated with a specific work experience or project."""
+    blocked = await _check_visibility(driver, orb_id)
+    if blocked is not None:
+        return [blocked]
     query = """
     MATCH (p:Person {orb_id: $orb_id})-[]->(exp {uid: $experience_uid})
     MATCH (exp)-[:USED_SKILL]->(s:Skill)

--- a/backend/tests/unit/test_access_grants.py
+++ b/backend/tests/unit/test_access_grants.py
@@ -1,0 +1,116 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.orbs.access_grants import (
+    _normalize_email,
+    create_access_grant,
+    list_access_grants,
+    revoke_access_grant,
+    user_has_access,
+)
+
+
+def _mock_driver(single_return=None, async_iter_records=None):
+    driver = MagicMock()
+    session_mock = AsyncMock()
+    driver.session.return_value.__aenter__.return_value = session_mock
+    result_mock = MagicMock()
+    session_mock.run.return_value = result_mock
+    if single_return is not None or async_iter_records is None:
+        result_mock.single = AsyncMock(return_value=single_return)
+    if async_iter_records is not None:
+
+        async def _aiter(*_a, **_kw):
+            for r in async_iter_records:
+                yield r
+
+        result_mock.__aiter__ = _aiter
+    return driver
+
+
+def test_normalize_email_lowercases_and_strips():
+    assert _normalize_email("  Foo@Bar.COM ") == "foo@bar.com"
+    assert _normalize_email("alice@example.com") == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_access_grant_success():
+    grant_record = {
+        "g": {
+            "grant_id": "abc",
+            "orb_id": "test-orb",
+            "email": "alice@x.com",
+            "created_at": "2026-04-11T00:00:00+00:00",
+            "revoked": False,
+            "revoked_at": None,
+        },
+        "orb_id": "test-orb",
+        "owner_name": "Owner Name",
+    }
+    driver = _mock_driver(single_return=grant_record)
+    result = await create_access_grant(driver, "owner-1", "  Alice@X.com ")
+    assert result is not None
+    assert result["email"] == "alice@x.com"  # normalized
+    assert result["owner_name"] == "Owner Name"
+
+
+@pytest.mark.asyncio
+async def test_create_access_grant_no_orb_id_returns_none():
+    driver = _mock_driver(single_return=None)
+    result = await create_access_grant(driver, "owner-1", "alice@x.com")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_access_grants():
+    records = [
+        {"g": {"grant_id": "g1", "email": "a@x.com", "revoked": False}},
+        {"g": {"grant_id": "g2", "email": "b@x.com", "revoked": False}},
+    ]
+    driver = _mock_driver(async_iter_records=records)
+    grants = await list_access_grants(driver, "owner-1")
+    assert len(grants) == 2
+    assert grants[0]["grant_id"] == "g1"
+
+
+@pytest.mark.asyncio
+async def test_revoke_access_grant_success():
+    grant_record = {"g": {"grant_id": "g1", "revoked": True}}
+    driver = _mock_driver(single_return=grant_record)
+    result = await revoke_access_grant(driver, "owner-1", "g1")
+    assert result is not None
+    assert result["revoked"] is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_access_grant_not_found():
+    driver = _mock_driver(single_return=None)
+    result = await revoke_access_grant(driver, "owner-1", "missing")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_user_has_access_true():
+    driver = _mock_driver(single_return={"g": {"grant_id": "g1"}})
+    assert await user_has_access(driver, "test-orb", "alice@x.com") is True
+
+
+@pytest.mark.asyncio
+async def test_user_has_access_false():
+    driver = _mock_driver(single_return=None)
+    assert await user_has_access(driver, "test-orb", "alice@x.com") is False
+
+
+@pytest.mark.asyncio
+async def test_user_has_access_normalizes_email():
+    driver = _mock_driver(single_return={"g": {"grant_id": "g1"}})
+    # Mixed case should still match (check that the function normalizes)
+    assert await user_has_access(driver, "test-orb", "  Alice@X.com ") is True
+
+
+@pytest.mark.asyncio
+async def test_user_has_access_empty_email_returns_false():
+    driver = _mock_driver(single_return={"g": {"grant_id": "g1"}})
+    # Even if the DB would have returned a match, an empty email short-circuits
+    assert await user_has_access(driver, "test-orb", "") is False

--- a/backend/tests/unit/test_dependencies.py
+++ b/backend/tests/unit/test_dependencies.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from jose import jwt
 
 from app.config import settings
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_current_user, get_current_user_optional, get_db
 
 
 async def test_get_db():
@@ -63,3 +63,44 @@ async def test_get_current_user_expired_token():
     with pytest.raises(HTTPException) as exc:
         await get_current_user(credentials)
     assert exc.value.status_code == 401
+
+
+# ── get_current_user_optional ──
+
+
+def _request_with_headers(headers: dict) -> MagicMock:
+    request = MagicMock()
+    request.headers = headers
+    return request
+
+
+async def test_get_current_user_optional_no_header_returns_none():
+    request = _request_with_headers({})
+    assert await get_current_user_optional(request) is None
+
+
+async def test_get_current_user_optional_non_bearer_returns_none():
+    request = _request_with_headers({"authorization": "Basic abc"})
+    assert await get_current_user_optional(request) is None
+
+
+async def test_get_current_user_optional_invalid_token_returns_none():
+    request = _request_with_headers({"authorization": "Bearer not-a-jwt"})
+    assert await get_current_user_optional(request) is None
+
+
+async def test_get_current_user_optional_valid_token_returns_user():
+    payload = {"sub": "user-123", "email": "test@example.com"}
+    token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    request = _request_with_headers({"authorization": f"Bearer {token}"})
+    user = await get_current_user_optional(request)
+    assert user is not None
+    assert user["user_id"] == "user-123"
+    assert user["email"] == "test@example.com"
+
+
+async def test_get_current_user_optional_no_sub_returns_none():
+    payload = {"email": "test@example.com"}
+    token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    request = _request_with_headers({"authorization": f"Bearer {token}"})
+    assert await get_current_user_optional(request) is None

--- a/backend/tests/unit/test_export_router.py
+++ b/backend/tests/unit/test_export_router.py
@@ -36,10 +36,14 @@ def mock_orb_record():
     }
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
-def test_export_orb_json(mock_decrypt, mock_validate, client, mock_db, mock_orb_record):
+def test_export_orb_json(
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db, mock_orb_record
+):
     mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_orb_record)
     )
@@ -52,12 +56,14 @@ def test_export_orb_json(mock_decrypt, mock_validate, client, mock_db, mock_orb_
     assert len(data["nodes"]) == 2
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
 def test_export_orb_jsonld(
-    mock_decrypt, mock_validate, client, mock_db, mock_orb_record
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db, mock_orb_record
 ):
     mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_orb_record)
     )
@@ -70,10 +76,14 @@ def test_export_orb_jsonld(
     assert len(data["orb:nodes"]) == 2
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
-def test_export_orb_pdf(mock_decrypt, mock_validate, client, mock_db, mock_orb_record):
+def test_export_orb_pdf(
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db, mock_orb_record
+):
     mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_orb_record)
     )
@@ -84,10 +94,14 @@ def test_export_orb_pdf(mock_decrypt, mock_validate, client, mock_db, mock_orb_r
     assert len(response.content) > 0
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
-def test_export_orb_not_found(mock_decrypt, mock_validate, client, mock_db):
+def test_export_orb_not_found(
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db
+):
     mock_validate.return_value = {"orb_id": "nonexistent", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=None)
     )
@@ -96,9 +110,27 @@ def test_export_orb_not_found(mock_decrypt, mock_validate, client, mock_db):
     assert response.status_code == 404
 
 
-def test_export_requires_token(client):
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
+@patch("app.export.router.validate_share_token")
+def test_export_private_orb_returns_403(
+    mock_validate, mock_visibility, client, mock_db
+):
+    """Private orbs reject export even with a valid share token."""
+    mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "private"
+
+    response = client.get("/export/test-orb?format=json&token=valid-token")
+    assert response.status_code == 403
+    assert "private" in response.json()["detail"].lower()
+
+
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
+def test_export_requires_token_for_public_orbs(mock_visibility, client, mock_db):
+    """Calling export on a public orb without a share token returns 403."""
+    mock_visibility.return_value = "public"
     response = client.get("/export/test-orb?format=json")
-    assert response.status_code == 422
+    assert response.status_code == 403
+    assert "share token" in response.json()["detail"].lower()
 
 
 @patch("app.export.router.validate_share_token")
@@ -140,12 +172,19 @@ def mock_complex_orb_record():
     return {"p": person_node, "connections": connections}
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
 def test_export_orb_pdf_complex(
-    mock_decrypt, mock_validate, client, mock_db, mock_complex_orb_record
+    mock_decrypt,
+    mock_validate,
+    mock_visibility,
+    client,
+    mock_db,
+    mock_complex_orb_record,
 ):
     mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_complex_orb_record)
     )
@@ -154,12 +193,19 @@ def test_export_orb_pdf_complex(
     assert response.headers["content-type"] == "application/pdf"
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
 def test_export_orb_jsonld_types(
-    mock_decrypt, mock_validate, client, mock_db, mock_complex_orb_record
+    mock_decrypt,
+    mock_validate,
+    mock_visibility,
+    client,
+    mock_db,
+    mock_complex_orb_record,
 ):
     mock_validate.return_value = VALID_TOKEN_DATA
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_complex_orb_record)
     )
@@ -175,13 +221,21 @@ def test_export_orb_jsonld_types(
     assert "Thing" in types  # Patent (unmapped, falls back to Thing)
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
 @patch("app.export.router.node_matches_filters")
 def test_export_orb_with_filters(
-    mock_matches, mock_decrypt, mock_validate, client, mock_db, mock_orb_record
+    mock_matches,
+    mock_decrypt,
+    mock_validate,
+    mock_visibility,
+    client,
+    mock_db,
+    mock_orb_record,
 ):
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": ["python"]}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=mock_orb_record)
     )

--- a/backend/tests/unit/test_orbs_router.py
+++ b/backend/tests/unit/test_orbs_router.py
@@ -159,9 +159,11 @@ def test_delete_node_success(client, mock_db):
     assert response.json()["status"] == "deleted"
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.orbs.router.validate_share_token")
-def test_get_public_orb_success(mock_validate, client, mock_db):
+def test_get_public_orb_success(mock_validate, mock_visibility, client, mock_db):
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "public"
 
     person_node = MockNode({"orb_id": "test-orb", "name": "Test User"}, ["Person"])
     node1 = MockNode({"uid": "node-1", "name": "Python"}, ["Skill"])
@@ -182,9 +184,11 @@ def test_get_public_orb_success(mock_validate, client, mock_db):
     assert response.json()["person"]["name"] == "Test User"
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.orbs.router.validate_share_token")
-def test_get_public_orb_not_found(mock_validate, client, mock_db):
+def test_get_public_orb_not_found(mock_validate, mock_visibility, client, mock_db):
     mock_validate.return_value = {"orb_id": "nonexistent", "keywords": []}
+    mock_visibility.return_value = "public"
 
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=None)
@@ -194,9 +198,15 @@ def test_get_public_orb_not_found(mock_validate, client, mock_db):
     assert response.status_code == 404
 
 
-def test_get_public_orb_no_token(client):
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
+def test_get_public_orb_no_token_public_orb_returns_403(
+    mock_visibility, client, mock_db
+):
+    """Calling a public orb without a share token returns 403."""
+    mock_visibility.return_value = "public"
     response = client.get("/orbs/test-orb")
-    assert response.status_code == 422
+    assert response.status_code == 403
+    assert "share token" in response.json()["detail"].lower()
 
 
 @patch("app.orbs.router.validate_share_token")
@@ -207,6 +217,29 @@ def test_get_public_orb_invalid_token(mock_validate, client, mock_db):
     assert response.status_code == 403
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
+@patch("app.orbs.router.validate_share_token")
+def test_get_public_orb_private_returns_403(
+    mock_validate, mock_visibility, client, mock_db
+):
+    """Private orbs reject access even with a valid share token."""
+    mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "private"
+
+    response = client.get("/orbs/test-orb?token=valid-token")
+    assert response.status_code == 403
+    assert "private" in response.json()["detail"].lower()
+
+
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
+def test_get_restricted_orb_no_auth_returns_401(mock_visibility, client, mock_db):
+    """Restricted orbs reject anonymous requests."""
+    mock_visibility.return_value = "restricted"
+
+    response = client.get("/orbs/test-orb")
+    assert response.status_code == 401
+
+
 def test_add_node_invalid_type(client):
     response = client.post(
         "/orbs/me/nodes", json={"node_type": "invalid", "properties": {}}
@@ -214,12 +247,14 @@ def test_add_node_invalid_type(client):
     assert response.status_code == 400
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.orbs.router.validate_share_token")
 @patch("app.orbs.router.node_matches_filters")
 def test_get_public_orb_with_keyword_filters(
-    mock_matches, mock_validate, client, mock_db
+    mock_matches, mock_validate, mock_visibility, client, mock_db
 ):
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": ["secret"]}
+    mock_visibility.return_value = "public"
 
     person_node = MockNode({"orb_id": "test-orb"}, ["Person"])
     node1 = MockNode({"uid": "node-1", "name": "Python"}, ["Skill"])
@@ -398,3 +433,153 @@ def test_claim_orb_id_conflict(client, mock_db):
     response = client.put("/orbs/me/orb-id", json={"orb_id": "taken-id"})
     assert response.status_code == 409
     assert "already taken" in response.json()["detail"]
+
+
+def test_update_visibility_success(client, mock_db):
+    person_node = MockNode({"user_id": "test-user", "visibility": "public"}, ["Person"])
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value={"p": person_node})
+    )
+
+    response = client.put("/orbs/me/visibility", json={"visibility": "public"})
+    assert response.status_code == 200
+    assert response.json()["visibility"] == "public"
+
+
+def test_update_visibility_user_not_found(client, mock_db):
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value=None)
+    )
+
+    response = client.put("/orbs/me/visibility", json={"visibility": "private"})
+    assert response.status_code == 404
+
+
+def test_update_visibility_invalid_value(client):
+    response = client.put("/orbs/me/visibility", json={"visibility": "invalid"})
+    assert response.status_code == 422
+
+
+# ── Access grants ──
+
+
+@patch("app.orbs.router.send_access_grant_email", new_callable=AsyncMock)
+@patch("app.orbs.router.create_access_grant", new_callable=AsyncMock)
+def test_create_access_grant_success(mock_create, mock_send, client, mock_db):
+    mock_create.return_value = {
+        "grant_id": "g1",
+        "orb_id": "test-orb",
+        "email": "alice@x.com",
+        "created_at": "2026-04-11T00:00:00+00:00",
+        "revoked": False,
+        "owner_name": "Owner",
+    }
+    response = client.post("/orbs/me/access-grants", json={"email": "alice@x.com"})
+    assert response.status_code == 200
+    assert response.json()["grant_id"] == "g1"
+    mock_send.assert_awaited_once()
+
+
+@patch("app.orbs.router.send_access_grant_email", new_callable=AsyncMock)
+@patch("app.orbs.router.create_access_grant", new_callable=AsyncMock)
+def test_create_access_grant_no_orb_id(mock_create, mock_send, client, mock_db):
+    mock_create.return_value = None
+    response = client.post("/orbs/me/access-grants", json={"email": "alice@x.com"})
+    assert response.status_code == 400
+    mock_send.assert_not_called()
+
+
+@patch("app.orbs.router.send_access_grant_email", new_callable=AsyncMock)
+@patch("app.orbs.router.create_access_grant", new_callable=AsyncMock)
+def test_create_access_grant_email_failure_does_not_block(
+    mock_create, mock_send, client, mock_db
+):
+    """If sending the notification email fails, the grant is still returned."""
+    mock_create.return_value = {
+        "grant_id": "g1",
+        "orb_id": "test-orb",
+        "email": "alice@x.com",
+        "created_at": "2026-04-11T00:00:00+00:00",
+        "revoked": False,
+        "owner_name": "Owner",
+    }
+    mock_send.side_effect = Exception("SMTP down")
+    response = client.post("/orbs/me/access-grants", json={"email": "alice@x.com"})
+    assert response.status_code == 200
+    assert response.json()["grant_id"] == "g1"
+
+
+@patch("app.orbs.router.list_access_grants", new_callable=AsyncMock)
+def test_list_access_grants(mock_list, client, mock_db):
+    mock_list.return_value = [
+        {
+            "grant_id": "g1",
+            "orb_id": "test-orb",
+            "email": "alice@x.com",
+            "created_at": "2026-04-11T00:00:00+00:00",
+            "revoked": False,
+        }
+    ]
+    response = client.get("/orbs/me/access-grants")
+    assert response.status_code == 200
+    assert len(response.json()["grants"]) == 1
+
+
+@patch("app.orbs.router.revoke_access_grant", new_callable=AsyncMock)
+def test_revoke_access_grant_success(mock_revoke, client, mock_db):
+    mock_revoke.return_value = {"grant_id": "g1", "revoked": True}
+    response = client.delete("/orbs/me/access-grants/g1")
+    assert response.status_code == 200
+    assert response.json()["status"] == "revoked"
+
+
+@patch("app.orbs.router.revoke_access_grant", new_callable=AsyncMock)
+def test_revoke_access_grant_not_found(mock_revoke, client, mock_db):
+    mock_revoke.return_value = None
+    response = client.delete("/orbs/me/access-grants/missing")
+    assert response.status_code == 404
+
+
+# ── Restricted orb access ──
+
+
+@patch("app.orbs.router.assert_user_can_access_restricted", new_callable=AsyncMock)
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
+def test_get_restricted_orb_authorized_succeeds(
+    mock_visibility, mock_assert_restricted, client, mock_db
+):
+    """When the visibility guard passes for restricted, return the orb."""
+    mock_visibility.return_value = "restricted"
+    mock_assert_restricted.return_value = None  # passes silently
+
+    person_node = MockNode({"orb_id": "test-orb", "name": "Test User"}, ["Person"])
+    record = {
+        "p": person_node,
+        "connections": [],
+        "cross_skill_nodes": [],
+        "cross_links": [],
+    }
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value=record)
+    )
+
+    response = client.get("/orbs/test-orb")
+    assert response.status_code == 200
+    assert response.json()["person"]["name"] == "Test User"
+
+
+@patch("app.orbs.router.assert_user_can_access_restricted", new_callable=AsyncMock)
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
+def test_get_restricted_orb_unauthorized_email_returns_403(
+    mock_visibility, mock_assert_restricted, client, mock_db
+):
+    """When the allowlist check raises 403, the endpoint forwards it."""
+    from fastapi import HTTPException
+
+    mock_visibility.return_value = "restricted"
+    mock_assert_restricted.side_effect = HTTPException(
+        status_code=403, detail="You don't have access to this orb"
+    )
+
+    response = client.get("/orbs/test-orb")
+    assert response.status_code == 403

--- a/backend/tests/unit/test_queries.py
+++ b/backend/tests/unit/test_queries.py
@@ -58,6 +58,26 @@ class TestNodeTypeMappings:
     def test_merge_keys_subset_of_labels(self):
         assert set(NODE_TYPE_MERGE_KEYS.keys()) == set(NODE_TYPE_LABELS.keys())
 
+
+class TestFullOrbExclusions:
+    """Metadata nodes (ShareToken, AccessGrant, ProcessingRecord, OntologyVersion)
+    must be excluded from the full-orb traversal — they aren't part of the
+    professional graph and don't have a ``uid`` field, so leaking them into
+    ``_serialize_orb`` would crash with KeyError.
+    """
+
+    @pytest.mark.parametrize(
+        "label", ["ProcessingRecord", "OntologyVersion", "ShareToken", "AccessGrant"]
+    )
+    def test_get_full_orb_excludes_metadata_label(self, label):
+        assert f"NOT n:{label}" in GET_FULL_ORB
+
+    @pytest.mark.parametrize(
+        "label", ["ProcessingRecord", "OntologyVersion", "ShareToken", "AccessGrant"]
+    )
+    def test_get_full_orb_public_excludes_metadata_label(self, label):
+        assert f"NOT n:{label}" in GET_FULL_ORB_PUBLIC
+
     def test_all_labels_are_capitalized(self):
         for node_type, label in NODE_TYPE_LABELS.items():
             assert label[0].isupper(), (

--- a/backend/tests/unit/test_rate_limit.py
+++ b/backend/tests/unit/test_rate_limit.py
@@ -29,10 +29,12 @@ def _make_orb_record(orb_id="test-orb"):
     }
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.orbs.router.validate_share_token")
-def test_public_orb_rate_limit(mock_validate, client, mock_db):
+def test_public_orb_rate_limit(mock_validate, mock_visibility, client, mock_db):
     """GET /orbs/{orb_id} returns 429 after exceeding 30 requests/minute."""
     mock_validate.return_value = {"orb_id": "rate-limit-orb", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=_make_orb_record("rate-limit-orb"))
     )
@@ -46,10 +48,14 @@ def test_public_orb_rate_limit(mock_validate, client, mock_db):
     assert "Rate limit exceeded" in resp.json()["detail"]
 
 
+@patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.orbs.router.validate_share_token")
-def test_public_orb_access_logging(mock_validate, client, mock_db, caplog):
+def test_public_orb_access_logging(
+    mock_validate, mock_visibility, client, mock_db, caplog
+):
     """GET /orbs/{orb_id} logs access with IP and orb_id."""
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=_make_orb_record("test-orb"))
     )
@@ -64,11 +70,15 @@ def test_public_orb_access_logging(mock_validate, client, mock_db, caplog):
     )
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
-def test_export_orb_rate_limit(mock_decrypt, mock_validate, client, mock_db):
+def test_export_orb_rate_limit(
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db
+):
     """GET /export/{orb_id} returns 429 after exceeding 30 requests/minute."""
     mock_validate.return_value = {"orb_id": "export-orb", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=_make_orb_record("export-orb"))
     )
@@ -82,13 +92,15 @@ def test_export_orb_rate_limit(mock_decrypt, mock_validate, client, mock_db):
     assert "Rate limit exceeded" in resp.json()["detail"]
 
 
+@patch("app.export.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.export.router.validate_share_token")
 @patch("app.export.router.decrypt_properties", side_effect=lambda x: x)
 def test_export_orb_access_logging(
-    mock_decrypt, mock_validate, client, mock_db, caplog
+    mock_decrypt, mock_validate, mock_visibility, client, mock_db, caplog
 ):
     """GET /export/{orb_id} logs access with IP and orb_id."""
     mock_validate.return_value = {"orb_id": "export-log-orb", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
         AsyncMock(return_value=_make_orb_record("export-log-orb"))
     )

--- a/backend/tests/unit/test_search_router.py
+++ b/backend/tests/unit/test_search_router.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -63,9 +63,11 @@ def test_text_search_success(client, mock_db):
     assert data[0]["name"] == "Python"
 
 
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.search.router.validate_share_token")
-def test_public_text_search_success(mock_validate, client, mock_db):
+def test_public_text_search_success(mock_validate, mock_visibility, client, mock_db):
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "public"
 
     node_data = {"uid": "node-1", "name": "Python"}
     node_mock = MockNode(node_data, ["Skill"])
@@ -83,9 +85,27 @@ def test_public_text_search_success(mock_validate, client, mock_db):
     assert len(response.json()) == 1
 
 
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.search.router.validate_share_token")
-def test_public_text_search_fuzzy_trigger(mock_validate, client, mock_db):
+def test_public_text_search_private_returns_403(
+    mock_validate, mock_visibility, client, mock_db
+):
+    """Public text search rejects private orbs."""
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "private"
+
+    payload = {"query": "Python", "orb_id": "test-orb", "token": "valid-token"}
+    response = client.post("/search/text/public", json=payload)
+    assert response.status_code == 403
+
+
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
+@patch("app.search.router.validate_share_token")
+def test_public_text_search_fuzzy_trigger(
+    mock_validate, mock_visibility, client, mock_db
+):
+    mock_validate.return_value = {"orb_id": "test-orb", "keywords": []}
+    mock_visibility.return_value = "public"
 
     node_data = {"uid": "node-fuzzy", "name": "Javascript"}
     node_mock = MockNode(node_data, ["Skill"])
@@ -138,9 +158,13 @@ def test_text_search_short_query(client, mock_db):
     assert response.status_code == 200
 
 
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.search.router.validate_share_token")
-def test_public_text_search_short_query(mock_validate, client, mock_db):
+def test_public_text_search_short_query(
+    mock_validate, mock_visibility, client, mock_db
+):
     mock_validate.return_value = {"orb_id": "test", "keywords": []}
+    mock_visibility.return_value = "public"
 
     async def mock_async_iter_empty(*args, **kwargs):
         if False:
@@ -158,9 +182,13 @@ def test_public_text_search_short_query(mock_validate, client, mock_db):
     assert response.status_code == 200
 
 
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.search.router.validate_share_token")
-def test_public_text_search_query_error(mock_validate, client, mock_db):
+def test_public_text_search_query_error(
+    mock_validate, mock_visibility, client, mock_db
+):
     mock_validate.return_value = {"orb_id": "test", "keywords": []}
+    mock_visibility.return_value = "public"
     mock_db.session.return_value.__aenter__.return_value.run.side_effect = Exception(
         "DB Error"
     )
@@ -233,9 +261,13 @@ def test_text_search_fuzzy_trigger(client, mock_db):
     assert len(response.json()) >= 1
 
 
+@patch("app.search.router.get_orb_visibility", new_callable=AsyncMock)
 @patch("app.search.router.validate_share_token")
-def test_public_text_search_with_keyword_filters(mock_validate, client, mock_db):
+def test_public_text_search_with_keyword_filters(
+    mock_validate, mock_visibility, client, mock_db
+):
     mock_validate.return_value = {"orb_id": "test-orb", "keywords": ["private"]}
+    mock_visibility.return_value = "public"
 
     node_data = {
         "uid": "node-1",

--- a/backend/tests/unit/test_visibility.py
+++ b/backend/tests/unit/test_visibility.py
@@ -1,0 +1,119 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.orbs.visibility import (
+    assert_orb_accessible,
+    assert_user_can_access_restricted,
+    get_orb_visibility,
+)
+from tests.unit.conftest import MockNode
+
+
+def _mock_driver_with_record(record):
+    driver = MagicMock()
+    session_mock = AsyncMock()
+    driver.session.return_value.__aenter__.return_value = session_mock
+    result_mock = AsyncMock()
+    session_mock.run.return_value = result_mock
+    result_mock.single = AsyncMock(return_value=record)
+    return driver
+
+
+@pytest.mark.asyncio
+async def test_get_orb_visibility_returns_value():
+    driver = _mock_driver_with_record({"visibility": "public"})
+    result = await get_orb_visibility(driver, "test-orb")
+    assert result == "public"
+
+
+@pytest.mark.asyncio
+async def test_get_orb_visibility_returns_none_when_not_found():
+    driver = _mock_driver_with_record(None)
+    result = await get_orb_visibility(driver, "missing-orb")
+    assert result is None
+
+
+def test_assert_orb_accessible_private_raises_403():
+    with pytest.raises(HTTPException) as exc:
+        assert_orb_accessible("private")
+    assert exc.value.status_code == 403
+    assert "private" in exc.value.detail.lower()
+
+
+def test_assert_orb_accessible_public_passes():
+    # Should not raise
+    assert_orb_accessible("public")
+
+
+def test_assert_orb_accessible_restricted_passes():
+    # restricted passes the basic gate; allowlist is enforced separately
+    assert_orb_accessible("restricted")
+
+
+def test_assert_orb_accessible_none_raises_404():
+    with pytest.raises(HTTPException) as exc:
+        assert_orb_accessible(None)
+    assert exc.value.status_code == 404
+
+
+# ── Restricted-mode allowlist ──
+
+
+@pytest.mark.asyncio
+async def test_assert_restricted_no_user_raises_401():
+    driver = MagicMock()
+    with pytest.raises(HTTPException) as exc:
+        await assert_user_can_access_restricted(driver, "test-orb", None)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_assert_restricted_owner_passes():
+    """Owner always has access regardless of allowlist."""
+    person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
+    driver = _mock_driver_with_record({"p": person})
+    # Should not raise
+    await assert_user_can_access_restricted(
+        driver, "test-orb", {"user_id": "owner-1", "email": "owner@x.com"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_assert_restricted_no_email_raises_403():
+    """Logged-in user without email on JWT is rejected."""
+    person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
+    driver = _mock_driver_with_record({"p": person})
+    with pytest.raises(HTTPException) as exc:
+        await assert_user_can_access_restricted(
+            driver, "test-orb", {"user_id": "viewer-1", "email": ""}
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@patch("app.orbs.visibility.user_has_access", new_callable=AsyncMock)
+async def test_assert_restricted_allowed_email_passes(mock_has_access):
+    person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
+    driver = _mock_driver_with_record({"p": person})
+    mock_has_access.return_value = True
+    # Should not raise
+    await assert_user_can_access_restricted(
+        driver, "test-orb", {"user_id": "viewer-1", "email": "alice@x.com"}
+    )
+    mock_has_access.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("app.orbs.visibility.user_has_access", new_callable=AsyncMock)
+async def test_assert_restricted_unallowed_email_raises_403(mock_has_access):
+    person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
+    driver = _mock_driver_with_record({"p": person})
+    mock_has_access.return_value = False
+    with pytest.raises(HTTPException) as exc:
+        await assert_user_can_access_restricted(
+            driver, "test-orb", {"user_id": "viewer-1", "email": "bob@x.com"}
+        )
+    assert exc.value.status_code == 403
+    assert "access" in exc.value.detail.lower()

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,11 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | POST | `/orbs/me/link-skill` | JWT | — | Add `USED_SKILL` relationship |
 | POST | `/orbs/me/unlink-skill` | JWT | — | Remove `USED_SKILL` relationship |
 | POST | `/orbs/me/filter-token` | JWT | — | Generate shareable filter token (JWT with keyword exclusions) |
-| GET | `/orbs/{orb_id}` | No | 30/min | Public orb view (supports `?filter_token=`) |
+| PUT | `/orbs/me/visibility` | JWT | — | Set orb visibility: `private` \| `public` \| `restricted` |
+| POST | `/orbs/me/access-grants` | JWT | — | Grant a specific email access to a `restricted` orb (sends notification email) |
+| GET | `/orbs/me/access-grants` | JWT | — | List active access grants on current user's orb |
+| DELETE | `/orbs/me/access-grants/{grant_id}` | JWT | — | Revoke an access grant |
+| GET | `/orbs/{orb_id}` | JWT optional | 30/min | Public orb view. `private` → 403; `public` → requires `?token=` share token; `restricted` → requires auth and email on allowlist (owner bypass) |
 
 ## CV (`/cv`)
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,6 +18,7 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 | `scholar_url` | string | |
 | `website_url` | string | |
 | `open_to_work` | boolean | |
+| `visibility` | string | `private` (default) \| `public` \| `restricted` — gates `GET /orbs/{orb_id}` |
 | `profile_image` | string | Base64 data URI |
 | `gdpr_consent` | boolean | |
 | `gdpr_consent_at` | string | ISO datetime |
@@ -57,6 +58,21 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 
 `title`, `patent_number`, `filing_date`, `grant_date`, `status`, `description`, `url`, `uid`
 
+### AccessGrant (restricted-mode allowlist)
+
+Created when a user grants a specific email permission to view their orb while `visibility = 'restricted'`.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `grant_id` | string | Unique, URL-safe token |
+| `orb_id` | string | Denormalized from Person for fast lookup |
+| `email` | string | Lowercase, trimmed |
+| `created_at` | datetime | |
+| `revoked` | boolean | Soft delete |
+| `revoked_at` | datetime | |
+
+Linked via `(Person)-[:GRANTED_ACCESS]->(AccessGrant)`. Parallel to `ShareToken` — share tokens gate `public` orbs, access grants gate `restricted` orbs.
+
 ## Relationships
 
 | Relationship | From | To | Purpose |
@@ -69,6 +85,7 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 | `HAS_PUBLICATION` | Person | Publication | |
 | `HAS_PROJECT` | Person | Project | |
 | `HAS_PATENT` | Person | Patent | |
+| `GRANTED_ACCESS` | Person | AccessGrant | Allowlist entry for `restricted` orbs |
 | `USED_SKILL` | WorkExperience / Project / Education / Publication | Skill | Cross-entity skill link |
 
 The `USED_SKILL` relationship is the key graph feature — it connects experience nodes directly to Skill nodes, enabling queries like "which skills were used at company X?"
@@ -218,6 +235,9 @@ Defined in `infra/neo4j/init.cypher`:
 - Uniqueness constraint on `ProcessingRecord.record_id`
 - Index on `OntologyVersion.content_hash`
 - Index on `ProcessingRecord.document_id`
+- Uniqueness constraint on `ShareToken.token_id`
+- Uniqueness constraint on `AccessGrant.grant_id`
+- Index on `AccessGrant.email` and on `Person.visibility`
 
 ## Query Patterns
 

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -33,8 +33,11 @@ export async function hasOrbContent(): Promise<boolean> {
   }
 }
 
-export async function getPublicOrb(orbId: string, token: string): Promise<OrbData> {
-  const { data } = await client.get(`/orbs/${orbId}`, { params: { token } });
+export async function getPublicOrb(orbId: string, token?: string | null): Promise<OrbData> {
+  // Token is required only for public orbs. Restricted orbs use the
+  // axios interceptor's Bearer auth instead.
+  const params = token ? { token } : undefined;
+  const { data } = await client.get(`/orbs/${orbId}`, { params });
   return data;
 }
 
@@ -74,6 +77,30 @@ export async function revokeShareToken(tokenId: string): Promise<void> {
   await client.delete(`/orbs/me/share-tokens/${tokenId}`);
 }
 
+// ── Access Grants (restricted-mode allowlist) ──
+
+export interface AccessGrant {
+  grant_id: string;
+  orb_id: string;
+  email: string;
+  created_at: string;
+  revoked: boolean;
+}
+
+export async function createAccessGrant(email: string): Promise<AccessGrant> {
+  const { data } = await client.post('/orbs/me/access-grants', { email });
+  return data;
+}
+
+export async function listAccessGrants(): Promise<{ grants: AccessGrant[] }> {
+  const { data } = await client.get('/orbs/me/access-grants');
+  return data;
+}
+
+export async function revokeAccessGrant(grantId: string): Promise<void> {
+  await client.delete(`/orbs/me/access-grants/${grantId}`);
+}
+
 export async function addNode(nodeType: string, properties: Record<string, unknown>): Promise<OrbNode> {
   const { data } = await client.post('/orbs/me/nodes', { node_type: nodeType, properties });
   return data;
@@ -96,6 +123,12 @@ export async function claimOrbId(orbId: string): Promise<void> {
   await client.put('/orbs/me/orb-id', { orb_id: orbId });
 }
 
+export type OrbVisibility = 'private' | 'public' | 'restricted';
+
+export async function updateVisibility(visibility: OrbVisibility): Promise<void> {
+  await client.put('/orbs/me/visibility', { visibility });
+}
+
 export async function uploadProfileImage(file: File): Promise<void> {
   const formData = new FormData();
   formData.append('file', file);
@@ -113,8 +146,10 @@ export async function textSearch(query: string): Promise<OrbNode[]> {
   return data;
 }
 
-export async function publicTextSearch(query: string, orbId: string, token: string): Promise<OrbNode[]> {
-  const { data } = await client.post('/search/text/public', { query, orb_id: orbId, token });
+export async function publicTextSearch(query: string, orbId: string, token?: string | null): Promise<OrbNode[]> {
+  const payload: { query: string; orb_id: string; token?: string } = { query, orb_id: orbId };
+  if (token) payload.token = token;
+  const { data } = await client.post('/search/text/public', payload);
   return data;
 }
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -215,6 +215,13 @@ export default function LandingPage() {
       setSigningInProvider('google');
       try {
         await loginGoogle(response.code);
+        // If the user landed here from a restricted-orb redirect, send them back.
+        const returnTo = sessionStorage.getItem('orbis_return_to');
+        if (returnTo) {
+          sessionStorage.removeItem('orbis_return_to');
+          navigate(returnTo, { replace: true });
+          return;
+        }
         const hasContent = await hasOrbContent();
         navigate(hasContent ? '/myorbis' : '/create');
       } catch {

--- a/frontend/src/pages/LinkedInCallbackPage.tsx
+++ b/frontend/src/pages/LinkedInCallbackPage.tsx
@@ -21,6 +21,12 @@ export default function LinkedInCallbackPage() {
 
     loginLinkedIn(code)
       .then(async () => {
+        const returnTo = sessionStorage.getItem('orbis_return_to');
+        if (returnTo) {
+          sessionStorage.removeItem('orbis_return_to');
+          navigate(returnTo, { replace: true });
+          return;
+        }
         const hasContent = await hasOrbContent();
         navigate(hasContent ? '/myorbis' : '/create');
       })

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -6,7 +6,15 @@ import { useAuthStore } from '../stores/authStore';
 import { useFilterStore, computeFilteredNodeIds } from '../stores/filterStore';
 import DateRangeSlider from '../components/graph/DateRangeSlider';
 import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
-import { createShareToken, enhanceNote, linkSkill } from '../api/orbs';
+import {
+  createAccessGrant,
+  createShareToken,
+  enhanceNote,
+  linkSkill,
+  listAccessGrants,
+  revokeAccessGrant,
+} from '../api/orbs';
+import type { AccessGrant, OrbVisibility } from '../api/orbs';
 import { QRCodeSVG } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
@@ -44,27 +52,118 @@ function resolveImportStepLabel(step: string | null | undefined, detail: string 
 
 // ── Modals ──
 
-function SharePanel({ orbId, onClose, hiddenNodeTypes }: { orbId: string; onClose: () => void; hiddenNodeTypes: Set<string> }) {
+function SharePanel({
+  orbId,
+  onClose,
+  hiddenNodeTypes,
+  visibility,
+  onVisibilityChange,
+}: {
+  orbId: string;
+  onClose: () => void;
+  hiddenNodeTypes: Set<string>;
+  visibility: OrbVisibility;
+  onVisibilityChange: (v: OrbVisibility) => Promise<void>;
+}) {
   const [copied, setCopied] = useState(false);
   const [shareTokenId, setShareTokenId] = useState<string | null>(null);
   const [generatingToken, setGeneratingToken] = useState(false);
+  const [updatingVisibility, setUpdatingVisibility] = useState(false);
+  const [grants, setGrants] = useState<AccessGrant[]>([]);
+  const [grantsLoading, setGrantsLoading] = useState(false);
+  const [grantEmail, setGrantEmail] = useState('');
+  const [grantError, setGrantError] = useState<string | null>(null);
+  const [grantSubmitting, setGrantSubmitting] = useState(false);
   const { activeKeywords } = useFilterStore();
   const hiddenTypesArray = Array.from(hiddenNodeTypes);
   const hasActiveFilters = activeKeywords.length > 0 || hiddenTypesArray.length > 0;
-  const shareUrl = shareTokenId ? `${window.location.origin}/${orbId}?token=${shareTokenId}` : '';
+  const isPrivate = visibility === 'private';
+  const isRestricted = visibility === 'restricted';
+  const isPublic = visibility === 'public';
+  const bareUrl = `${window.location.origin}/${orbId}`;
+  const shareUrl = isRestricted
+    ? bareUrl
+    : (shareTokenId ? `${bareUrl}?token=${shareTokenId}` : '');
   const mcpUri = `orb://${orbId}`;
 
-  // Generate a share token when the panel opens
+  // Generate a share token only in public mode
   useEffect(() => {
-    if (orbId) {
+    if (orbId && isPublic) {
       setGeneratingToken(true);
       createShareToken(activeKeywords, hiddenTypesArray)
         .then((token) => setShareTokenId(token.token_id))
         .catch(() => setShareTokenId(null))
         .finally(() => setGeneratingToken(false));
+    } else {
+      setShareTokenId(null);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeKeywords, orbId, hiddenNodeTypes.size]);
+  }, [activeKeywords, orbId, hiddenNodeTypes.size, isPublic]);
+
+  // Load access grants when restricted mode is active
+  useEffect(() => {
+    if (!isRestricted) {
+      setGrants([]);
+      return;
+    }
+    setGrantsLoading(true);
+    listAccessGrants()
+      .then((res) => setGrants(res.grants))
+      .catch(() => setGrants([]))
+      .finally(() => setGrantsLoading(false));
+  }, [isRestricted]);
+
+  const handleGrantSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const email = grantEmail.trim();
+    if (!email) return;
+    // Simple email shape check
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setGrantError('Enter a valid email address');
+      return;
+    }
+    setGrantSubmitting(true);
+    setGrantError(null);
+    try {
+      const grant = await createAccessGrant(email);
+      setGrants((prev) => [grant, ...prev]);
+      setGrantEmail('');
+    } catch (err) {
+      const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setGrantError(msg || 'Failed to grant access');
+    } finally {
+      setGrantSubmitting(false);
+    }
+  };
+
+  const handleRevokeGrant = async (grantId: string) => {
+    try {
+      await revokeAccessGrant(grantId);
+      setGrants((prev) => prev.filter((g) => g.grant_id !== grantId));
+    } catch {
+      setGrantError('Failed to revoke access');
+    }
+  };
+
+  const handleVisibilityClick = async (next: OrbVisibility) => {
+    if (next === visibility || updatingVisibility) return;
+    setUpdatingVisibility(true);
+    try {
+      await onVisibilityChange(next);
+    } finally {
+      setUpdatingVisibility(false);
+    }
+  };
+
+  const visibilityOptions: {
+    value: OrbVisibility;
+    label: string;
+    description: string;
+  }[] = [
+    { value: 'private', label: 'Private', description: 'Only you can view your orbis' },
+    { value: 'public', label: 'Public', description: 'Anyone with the link can view' },
+    { value: 'restricted', label: 'Restricted', description: 'Share via invite links' },
+  ];
 
   const copy = (text: string) => {
     navigator.clipboard.writeText(text);
@@ -90,56 +189,165 @@ function SharePanel({ orbId, onClose, hiddenNodeTypes }: { orbId: string; onClos
         className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-y-auto"
       >
         <h2 className="text-white text-lg font-semibold mb-1">Share Your Orbis</h2>
-        <p className="text-gray-400 text-sm mb-5">Share your orbis link or use the MCP identifier to let AI agents access your professional graph.</p>
+        <p className="text-gray-400 text-sm mb-5">Choose who can view your orbis, then share the link or MCP identifier with people or AI agents.</p>
+
+        {/* Visibility selector */}
+        <div className="mb-5">
+          <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility</label>
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            {visibilityOptions.map((opt) => {
+              const selected = visibility === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleVisibilityClick(opt.value)}
+                  disabled={updatingVisibility}
+                  className={`text-left rounded-lg border px-3 py-2 transition-colors disabled:opacity-60 ${
+                    selected
+                      ? 'border-purple-500/70 bg-purple-500/15 text-white'
+                      : 'border-gray-700 bg-gray-800/40 text-gray-300 hover:bg-gray-800'
+                  }`}
+                >
+                  <div className="text-xs font-semibold">{opt.label}</div>
+                  <div className="text-[10px] text-gray-400 mt-0.5 leading-tight">{opt.description}</div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
         {/* QR Code */}
-        <div className="flex justify-center mb-5">
+        <div className={`flex justify-center mb-5 ${isPrivate ? 'opacity-40' : ''}`}>
           <div className="bg-white p-3 rounded-xl">
-            <QRCodeSVG value={shareUrl || `${window.location.origin}/${orbId}`} size={140} level="M" />
+            <QRCodeSVG value={shareUrl || bareUrl} size={140} level="M" />
           </div>
         </div>
 
-        <div className="mb-4">
-          <label className={`text-xs uppercase tracking-wide font-medium ${hasActiveFilters ? 'text-amber-400/80' : 'text-gray-500'}`}>
-            {hasActiveFilters ? 'Filtered Share Link' : 'Share Link'}
-          </label>
-          {hasActiveFilters && (
-            <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
-              This link hides
-              {hiddenTypesArray.length > 0 && (
-                <span> node types: {hiddenTypesArray.map((t, i) => (
-                  <span key={t}>{i > 0 && ', '}<span className="text-amber-400">{t}</span></span>
-                ))}</span>
-              )}
-              {hiddenTypesArray.length > 0 && activeKeywords.length > 0 && ' and'}
-              {activeKeywords.length > 0 && (
-                <span> keywords: {activeKeywords.map((kw, i) => (
-                  <span key={kw}>{i > 0 && ', '}"<span className="text-amber-400">{kw}</span>"</span>
-                ))}</span>
-              )}
-              {' '}from the viewer.
-            </p>
-          )}
-          <div className="mt-1 flex items-center gap-2">
-            {generatingToken ? (
-              <div className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-gray-500 text-sm">Generating link...</div>
-            ) : (
-              <input readOnly value={shareUrl} className={`flex-1 bg-gray-800 border rounded-lg px-3 py-2 text-white text-sm font-mono ${hasActiveFilters ? 'border-amber-600/30' : 'border-gray-600'}`} />
-            )}
-            <button
-              onClick={() => copy(shareUrl)}
-              disabled={!shareTokenId}
-              className={`${hasActiveFilters ? 'bg-amber-600 hover:bg-amber-700' : 'bg-purple-600 hover:bg-purple-700'} disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap`}
-            >
-              {copied ? 'Copied!' : 'Copy'}
-            </button>
+        {isPrivate && (
+          <div className="mb-4 rounded-lg border border-gray-700 bg-gray-800/40 px-3 py-2 text-xs text-gray-400">
+            Your orbis is private. Switch to <span className="text-white">Public</span> or <span className="text-white">Restricted</span> to generate a share link.
           </div>
-        </div>
+        )}
+
+        {/* Public mode: filtered share link with token */}
+        {isPublic && (
+          <div className="mb-4">
+            <label className={`text-xs uppercase tracking-wide font-medium ${hasActiveFilters ? 'text-amber-400/80' : 'text-gray-500'}`}>
+              {hasActiveFilters ? 'Filtered Share Link' : 'Share Link'}
+            </label>
+            {hasActiveFilters && (
+              <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
+                This link hides
+                {hiddenTypesArray.length > 0 && (
+                  <span> node types: {hiddenTypesArray.map((t, i) => (
+                    <span key={t}>{i > 0 && ', '}<span className="text-amber-400">{t}</span></span>
+                  ))}</span>
+                )}
+                {hiddenTypesArray.length > 0 && activeKeywords.length > 0 && ' and'}
+                {activeKeywords.length > 0 && (
+                  <span> keywords: {activeKeywords.map((kw, i) => (
+                    <span key={kw}>{i > 0 && ', '}"<span className="text-amber-400">{kw}</span>"</span>
+                  ))}</span>
+                )}
+                {' '}from the viewer.
+              </p>
+            )}
+            <div className="mt-1 flex items-center gap-2">
+              {generatingToken ? (
+                <div className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-gray-500 text-sm">Generating link...</div>
+              ) : (
+                <input readOnly value={shareUrl} className={`flex-1 bg-gray-800 border rounded-lg px-3 py-2 text-white text-sm font-mono ${hasActiveFilters ? 'border-amber-600/30' : 'border-gray-600'}`} />
+              )}
+              <button
+                onClick={() => copy(shareUrl)}
+                disabled={!shareTokenId}
+                className={`${hasActiveFilters ? 'bg-amber-600 hover:bg-amber-700' : 'bg-purple-600 hover:bg-purple-700'} disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap`}
+              >
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Restricted mode: bare URL + manage allowed users */}
+        {isRestricted && (
+          <>
+            <div className="mb-4">
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Orbis Link</label>
+              <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
+                Anyone you grant access below can open this link after signing in.
+              </p>
+              <div className="mt-1 flex items-center gap-2">
+                <input readOnly value={bareUrl} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                <button
+                  onClick={() => copy(bareUrl)}
+                  className="bg-purple-600 hover:bg-purple-700 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Allowed Users</label>
+              <p className="text-[11px] text-gray-500 mt-0.5 mb-2">
+                Grant access by email. Recipients receive a notification and can view your orbis after signing in.
+              </p>
+              <form onSubmit={handleGrantSubmit} className="flex items-center gap-2">
+                <input
+                  type="email"
+                  value={grantEmail}
+                  onChange={(e) => { setGrantEmail(e.target.value); setGrantError(null); }}
+                  placeholder="name@example.com"
+                  disabled={grantSubmitting}
+                  className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm placeholder-gray-500"
+                />
+                <button
+                  type="submit"
+                  disabled={grantSubmitting || !grantEmail.trim()}
+                  className="bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
+                >
+                  {grantSubmitting ? 'Granting...' : 'Grant'}
+                </button>
+              </form>
+              {grantError && <p className="text-[11px] text-red-400 mt-1">{grantError}</p>}
+
+              <div className="mt-3 max-h-40 overflow-y-auto">
+                {grantsLoading && (
+                  <p className="text-[11px] text-gray-500">Loading...</p>
+                )}
+                {!grantsLoading && grants.length === 0 && (
+                  <p className="text-[11px] text-gray-500">No one has access yet.</p>
+                )}
+                {!grantsLoading && grants.length > 0 && (
+                  <ul className="divide-y divide-gray-800 border border-gray-800 rounded-lg">
+                    {grants.map((g) => (
+                      <li key={g.grant_id} className="flex items-center justify-between px-3 py-2">
+                        <span className="text-xs text-white truncate">{g.email}</span>
+                        <button
+                          onClick={() => handleRevokeGrant(g.grant_id)}
+                          className="text-[10px] text-red-400 hover:text-red-300 ml-2 whitespace-nowrap"
+                        >
+                          Revoke
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="mb-5">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
-          <p className="text-[11px] text-gray-500 mt-0.5 mb-1">Use this ID with the OpenOrbis MCP server to let AI agents query your graph.</p>
-          <div className="flex items-center gap-2">
+          <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
+            {isPublic
+              ? 'Use this ID with the OpenOrbis MCP server to let AI agents query your graph.'
+              : 'MCP access is only available for public orbs.'}
+          </p>
+          <div className={`flex items-center gap-2 ${!isPublic ? 'opacity-40 pointer-events-none' : ''}`}>
             <input readOnly value={mcpUri} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
             <button onClick={() => copy(mcpUri)} className="bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap">Copy</button>
           </div>
@@ -218,7 +426,7 @@ const LABEL_TO_TYPE: Record<string, string> = {
 // ── Page ──
 
 export default function OrbViewPage() {
-  const { data, loading, fetchOrb, addNode, updateNode, deleteNode } = useOrbStore();
+  const { data, loading, fetchOrb, addNode, updateNode, deleteNode, updateVisibility } = useOrbStore();
   const { user } = useAuthStore();
   const addToast = useToastStore((s) => s.addToast);
   const undoStack = useUndoStore((s) => s.undoStack);
@@ -1046,7 +1254,16 @@ export default function OrbViewPage() {
       {/* ── Animated Panels ── */}
       <DiscoverUsesModal open={showDiscoverUses} onClose={() => setShowDiscoverUses(false)} orbId={orbId} />
       <AnimatePresence>
-        {showShare && <SharePanel key="share" orbId={orbId} hiddenNodeTypes={hiddenNodeTypes} onClose={() => setShowShare(false)} />}
+        {showShare && (
+          <SharePanel
+            key="share"
+            orbId={orbId}
+            hiddenNodeTypes={hiddenNodeTypes}
+            visibility={((data?.person?.visibility as OrbVisibility) || 'private')}
+            onVisibilityChange={updateVisibility}
+            onClose={() => setShowShare(false)}
+          />
+        )}
       </AnimatePresence>
 
       {/* ── Import review overlay ── */}

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
 import { useOrbStore } from '../stores/orbStore';
 import { publicTextSearch } from '../api/orbs';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
@@ -15,6 +16,8 @@ export default function SharedOrbPage() {
   const { orbId } = useParams<{ orbId: string }>();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
+  const navigate = useNavigate();
+  const { user } = useAuthStore();
   const { data, loading, error, fetchPublicOrb } = useOrbStore();
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
@@ -49,15 +52,32 @@ export default function SharedOrbPage() {
     setHiddenNodeTypes(new Set(ALL_FILTERABLE_TYPES.filter((t) => !visibleTypes.has(t))));
   }, []);
 
-  // Public search bound to this orb — requires share token
+  const [initialFetchDone, setInitialFetchDone] = useState(false);
+
+  // Search bound to this orb — token for public, Bearer auth for restricted
   const searchFn = useCallback(
-    (query: string) => publicTextSearch(query, orbId || '', token || ''),
+    (query: string) => publicTextSearch(query, orbId || '', token || undefined),
     [orbId, token]
   );
 
   useEffect(() => {
-    if (orbId && token) fetchPublicOrb(orbId, token);
+    if (orbId) {
+      setInitialFetchDone(false);
+      fetchPublicOrb(orbId, token).finally(() => setInitialFetchDone(true));
+    }
   }, [orbId, token, fetchPublicOrb]);
+
+  // 401 → not logged in but the orb is restricted. Save return-to and bounce to landing.
+  const isUnauthorizedError = !!error && (
+    error.includes('401') || error.toLowerCase().includes('authentication required')
+  );
+  useEffect(() => {
+    if (!isUnauthorizedError || !orbId) return;
+    if (!user) {
+      sessionStorage.setItem('orbis_return_to', window.location.pathname + window.location.search);
+      navigate('/', { replace: true });
+    }
+  }, [isUnauthorizedError, orbId, user, navigate]);
 
   useEffect(() => {
     const handleResize = () => setDimensions({ width: window.innerWidth, height: window.innerHeight });
@@ -114,18 +134,8 @@ export default function SharedOrbPage() {
     [data?.nodes, data?.links, rangeStart, rangeEnd, dateBounds],
   );
 
-  if (!token) {
-    return (
-      <div className="min-h-screen bg-black text-white flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
-          <p className="text-gray-400">This orbis requires a valid share link. Ask the owner for a new link.</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (loading) {
+  // Show spinner while the initial fetch is in flight (avoids a catchall flash on first render)
+  if (loading || !initialFetchDone) {
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center">
         <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />
@@ -133,19 +143,38 @@ export default function SharedOrbPage() {
     );
   }
 
+  // 401 → redirect-in-progress: render nothing instead of flashing the catchall
+  if (isUnauthorizedError && !user) {
+    return null;
+  }
+
   if (error || !data) {
-    const isForbidden = error?.includes('403') || error?.includes('share token');
+    const isPrivate = error?.toLowerCase().includes('private');
+    const isNoAccess = error?.toLowerCase().includes("don't have access");
+    const isForbidden = !isPrivate && !isNoAccess && (error?.includes('403') || error?.includes('share token'));
+    let title: string;
+    let message: string;
+    if (isPrivate) {
+      title = 'This Orbis is Private';
+      message = 'The owner has restricted access to their orbis.';
+    } else if (isNoAccess) {
+      title = "You don't have access";
+      message = "The owner hasn't granted you access to this orbis. Ask them to invite your email.";
+    } else if (isForbidden) {
+      title = 'Link Expired or Revoked';
+      message = 'This share link is no longer valid. Ask the owner for a new link.';
+    } else if (isUnauthorizedError) {
+      title = 'Sign in required';
+      message = 'You need to sign in to view this orbis.';
+    } else {
+      title = 'Orbis not found';
+      message = "This orbis doesn't exist or is private.";
+    }
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">
-            {isForbidden ? 'Link Expired or Revoked' : 'Orbis not found'}
-          </h1>
-          <p className="text-gray-400">
-            {isForbidden
-              ? 'This share link is no longer valid. Ask the owner for a new link.'
-              : "This orbis doesn't exist or is private."}
-          </p>
+          <h1 className="text-2xl font-bold mb-2">{title}</h1>
+          <p className="text-gray-400">{message}</p>
         </div>
       </div>
     );

--- a/frontend/src/stores/orbStore.ts
+++ b/frontend/src/stores/orbStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import * as orbsApi from '../api/orbs';
-import type { OrbData, OrbNode } from '../api/orbs';
+import type { OrbData, OrbNode, OrbVisibility } from '../api/orbs';
 import { useToastStore } from './toastStore';
 import { useUndoStore } from './undoStore';
 
@@ -9,10 +9,11 @@ interface OrbState {
   loading: boolean;
   error: string | null;
   fetchOrb: () => Promise<void>;
-  fetchPublicOrb: (orbId: string, token: string) => Promise<void>;
+  fetchPublicOrb: (orbId: string, token?: string | null) => Promise<void>;
   addNode: (nodeType: string, properties: Record<string, unknown>) => Promise<OrbNode>;
   updateNode: (uid: string, properties: Record<string, unknown>) => Promise<void>;
   deleteNode: (uid: string, nodeType?: string, properties?: Record<string, unknown>, relationships?: Array<{ source: string; target: string; type: string }>) => Promise<void>;
+  updateVisibility: (visibility: OrbVisibility) => Promise<void>;
 }
 
 export const useOrbStore = create<OrbState>((set, get) => ({
@@ -30,13 +31,20 @@ export const useOrbStore = create<OrbState>((set, get) => ({
     }
   },
 
-  fetchPublicOrb: async (orbId: string, token: string) => {
+  fetchPublicOrb: async (orbId: string, token?: string | null) => {
     set({ loading: true, error: null });
     try {
       const data = await orbsApi.getPublicOrb(orbId, token);
       set({ data, loading: false });
     } catch (e) {
-      set({ error: (e as Error).message, loading: false });
+      // Prefer FastAPI's detail message so UI can distinguish private vs invalid token
+      const err = e as { response?: { status?: number; data?: { detail?: string } }; message?: string };
+      const detail = err?.response?.data?.detail;
+      const status = err?.response?.status;
+      const message = detail
+        ? `${status ?? ''} ${detail}`.trim()
+        : err?.message ?? 'Failed to load orb';
+      set({ error: message, loading: false });
     }
   },
 
@@ -85,6 +93,17 @@ export const useOrbStore = create<OrbState>((set, get) => ({
       }
     } catch (e) {
       useToastStore.getState().addToast('Failed to delete entry', 'error');
+      throw e;
+    }
+  },
+
+  updateVisibility: async (visibility: OrbVisibility) => {
+    try {
+      await orbsApi.updateVisibility(visibility);
+      await get().fetchOrb();
+      useToastStore.getState().addToast('Visibility updated', 'success');
+    } catch (e) {
+      useToastStore.getState().addToast('Failed to update visibility', 'error');
       throw e;
     }
   },

--- a/infra/neo4j/init.cypher
+++ b/infra/neo4j/init.cypher
@@ -10,6 +10,7 @@ CREATE CONSTRAINT beta_config_singleton IF NOT EXISTS FOR (c:BetaConfig) REQUIRE
 CREATE INDEX person_email IF NOT EXISTS FOR (p:Person) ON (p.email);
 CREATE INDEX person_is_admin IF NOT EXISTS FOR (p:Person) ON (p.is_admin);
 CREATE INDEX person_signup_code IF NOT EXISTS FOR (p:Person) ON (p.signup_code);
+CREATE INDEX person_visibility IF NOT EXISTS FOR (p:Person) ON (p.visibility);
 CREATE INDEX skill_name IF NOT EXISTS FOR (s:Skill) ON (s.name);
 
 // Vector indexes for semantic search
@@ -43,3 +44,7 @@ CREATE INDEX processing_record_document IF NOT EXISTS FOR (pr:ProcessingRecord) 
 
 // Share tokens for controlled public access
 CREATE CONSTRAINT share_token_id IF NOT EXISTS FOR (st:ShareToken) REQUIRE st.token_id IS UNIQUE;
+
+// Access grants for restricted-mode allowlists
+CREATE CONSTRAINT access_grant_id IF NOT EXISTS FOR (g:AccessGrant) REQUIRE g.grant_id IS UNIQUE;
+CREATE INDEX access_grant_email IF NOT EXISTS FOR (g:AccessGrant) ON (g.email);


### PR DESCRIPTION
Closes #236.

## Summary
- Adds three visibility modes to every orb — `private` (default), `public`, `restricted` — stored as `Person.visibility`.
- For `restricted` orbs, the owner manages a per-email allowlist via new `AccessGrant` nodes and dedicated endpoints. Recipients get a notification email when a grant is created.
- The public orb endpoint (`GET /orbs/{orb_id}`) now gates on visibility: `private` → 403, `public` → requires a share token (existing flow), `restricted` → requires auth and a matching active grant (owner always has access). Same guard is propagated to `export`, `search`, and the MCP public tools.

## Scope notes
- Granular per-node permissions and "request access" flows from the issue considerations are **not** in this PR — left as follow-ups. This PR covers the core MUST-HAVE: full-orb visibility control and explicit allowlist.
- The filter-token system for `public` orbs is unchanged.
- Email delivery is best-effort: a failed send does not roll back the grant (logged via `logger.exception`).

## New endpoints
| Method | Path | Description |
|--------|------|-------------|
| `PUT` | `/orbs/me/visibility` | Set visibility (`private` \| `public` \| `restricted`) |
| `POST` | `/orbs/me/access-grants` | Grant email access (sends notification) |
| `GET` | `/orbs/me/access-grants` | List active grants |
| `DELETE` | `/orbs/me/access-grants/{grant_id}` | Revoke a grant |

## Schema
- `Person.visibility` (defaults to `private` on create; indexed)
- New `(Person)-[:GRANTED_ACCESS]->(AccessGrant)` with `grant_id`, `orb_id`, `email`, `created_at`, `revoked`, `revoked_at`
- Unique constraint on `AccessGrant.grant_id`, index on `AccessGrant.email`

## Documentation
- `docs/api.md` — new rows under `/orbs` for visibility + access-grants endpoints, updated public-orb semantics
- `docs/database.md` — `Person.visibility` property, new `AccessGrant` node section, `GRANTED_ACCESS` relationship, constraints/indexes list
