### PR TITLE
Add 'Back to My Orbis' button on orb not-found page

### DIFF
--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -174,7 +174,13 @@ export default function SharedOrbPage() {
       <div className="min-h-screen bg-black text-white flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-2">{title}</h1>
-          <p className="text-gray-400">{message}</p>
+          <p className="text-gray-400 mb-6">{message}</p>
+          <button
+            onClick={() => navigate(user ? '/myorbis' : '/')}
+            className="px-5 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium transition-colors"
+          >
+            {user ? 'Back to My Orbis' : 'Go to Home'}
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Adds a navigation button below the error message on the SharedOrb not-found page
- Authenticated users see "Back to My Orbis" → navigates to `/myorbis`
- Unauthenticated users see "Go to Home" → navigates to `/` (landing page)

Closes #255

## Documentation
No doc changes needed

## Test plan
- [ ] Navigate to a non-existent shared orb URL (e.g., `/doesnotexist`)
- [ ] Verify the "Orbis not found" message shows with the button below it
- [ ] While logged in: click button → should go to `/myorbis`
- [ ] While logged out: click button → should go to `/` (landing page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)