### PR TITLE
feat: run expired account cleanup on a recurring schedule (#207)

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -14,6 +14,8 @@ class InviteCodeCounts(BaseModel):
 class StatsResponse(BaseModel):
     registered: int
     pending_activation: int
+    pending_deletion: int
+    deleted_accounts: int
     invite_code_required: bool
     invite_codes: InviteCodeCounts
 

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -29,6 +29,8 @@ from app.admin.service import (
     activate_user_by_admin,
     consume_access_code,
     count_access_codes,
+    count_deleted_accounts,
+    count_pending_deletion,
     count_pending_persons,
     count_persons,
     create_access_code,
@@ -138,9 +140,13 @@ async def get_stats(
     registered = await count_persons(db)
     pending = await count_pending_persons(db)
     code_counts = await count_access_codes(db)
+    pending_del = await count_pending_deletion(db)
+    deleted = await count_deleted_accounts(db)
     return StatsResponse(
         registered=registered,
         pending_activation=pending,
+        pending_deletion=pending_del,
+        deleted_accounts=deleted,
         invite_code_required=bool(config.get("invite_code_required", True)),
         invite_codes=InviteCodeCounts(**code_counts),
     )

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -127,6 +127,29 @@ async def count_pending_persons(db: AsyncDriver) -> int:
         return int(record["total"]) if record else 0
 
 
+async def count_pending_deletion(db: AsyncDriver) -> int:
+    """Count accounts in the 30-day deletion grace period."""
+    async with db.session() as session:
+        result = await session.run(
+            "MATCH (p:Person) "
+            "WHERE p.deletion_requested_at IS NOT NULL "
+            "AND datetime(p.deletion_requested_at) >= datetime() - duration('P30D') "
+            "RETURN count(p) AS total"
+        )
+        record = await result.single()
+        return int(record["total"]) if record else 0
+
+
+async def count_deleted_accounts(db: AsyncDriver) -> int:
+    """Count permanently deleted accounts via DeletionRecord nodes."""
+    async with db.session() as session:
+        result = await session.run(
+            "MATCH (d:DeletionRecord) RETURN count(d) AS total"
+        )
+        record = await result.single()
+        return int(record["total"]) if record else 0
+
+
 async def list_pending_persons(db: AsyncDriver) -> list[dict]:
     async with db.session() as session:
         result = await session.run(LIST_PENDING_PERSONS)

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -143,9 +143,7 @@ async def count_pending_deletion(db: AsyncDriver) -> int:
 async def count_deleted_accounts(db: AsyncDriver) -> int:
     """Count permanently deleted accounts via DeletionRecord nodes."""
     async with db.session() as session:
-        result = await session.run(
-            "MATCH (d:DeletionRecord) RETURN count(d) AS total"
-        )
+        result = await session.run("MATCH (d:DeletionRecord) RETURN count(d) AS total")
         record = await result.single()
         return int(record["total"]) if record else 0
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
     # Share token default TTL in days. Set to 0 for no expiry.
     share_token_default_ttl_days: int = 90
 
+    # Account cleanup interval in hours (0 = startup-only, no recurring task)
+    cleanup_interval_hours: int = 24
+
     model_config = {
         "env_file": ["../.env", ".env"],
         "env_file_encoding": "utf-8",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import logging
 from contextlib import asynccontextmanager
 
@@ -50,6 +52,11 @@ async def _cleanup_expired_accounts(driver):
                 "MATCH (p:Person {user_id: $uid}) DETACH DELETE p",
                 uid=user_id,
             )
+            # Audit trail: record the deletion
+            await session.run(
+                "CREATE (:DeletionRecord {user_id: $uid, deleted_at: datetime()})",
+                uid=user_id,
+            )
             logging.getLogger(__name__).info(
                 "Permanently deleted expired account: %s", user_id
             )
@@ -77,6 +84,18 @@ async def _cleanup_expired_accounts(driver):
         logging.getLogger(__name__).info(
             "Cleaned up %d expired account(s)", len(expired)
         )
+    return len(expired)
+
+
+async def _periodic_cleanup(driver, interval_hours: int):
+    """Run expired-account cleanup on a recurring schedule."""
+    log = logging.getLogger(__name__)
+    interval_seconds = interval_hours * 3600
+    while True:
+        await asyncio.sleep(interval_seconds)
+        log.info("Scheduled expired-account cleanup started")
+        count = await _cleanup_expired_accounts(driver)
+        log.info("Scheduled cleanup complete: %d account(s) removed", count)
 
 
 @asynccontextmanager
@@ -87,8 +106,18 @@ async def lifespan(app: FastAPI):
         await session.run("RETURN 1")
     # Clean up expired accounts on startup
     await _cleanup_expired_accounts(driver)
+    # Start recurring cleanup if configured
+    cleanup_task = None
+    if settings.cleanup_interval_hours > 0:
+        cleanup_task = asyncio.create_task(
+            _periodic_cleanup(driver, settings.cleanup_interval_hours)
+        )
     yield
     # Shutdown
+    if cleanup_task is not None:
+        cleanup_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cleanup_task
     await close_driver()
 
 

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -415,9 +415,11 @@ async def test_cleanup_creates_deletion_records():
     mock_session_context.__aexit__ = AsyncMock(return_value=False)
     mock_driver.session.return_value = mock_session_context
 
-    with patch("app.main.delete_stored_cvs"), patch(
-        "app.main.delete_user_drafts"
-    ), patch("app.main.delete_user_snapshots"):
+    with (
+        patch("app.main.delete_stored_cvs"),
+        patch("app.main.delete_user_drafts"),
+        patch("app.main.delete_user_snapshots"),
+    ):
         await _cleanup_expired_accounts(mock_driver)
 
     # Check that a CREATE (d:DeletionRecord ...) query was issued

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -360,3 +360,14 @@ def test_admin_pending_users(admin_client):
     assert response.status_code == 200
     assert len(response.json()) == 1
     assert response.json()[0]["name"] == "Pending User"
+
+
+def test_cleanup_interval_hours_default():
+    from app.config import Settings
+
+    s = Settings(
+        neo4j_uri="bolt://localhost:7687",
+        neo4j_password="test",
+        jwt_secret="test",
+    )
+    assert s.cleanup_interval_hours == 24

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -371,3 +371,57 @@ def test_cleanup_interval_hours_default():
         jwt_secret="test",
     )
     assert s.cleanup_interval_hours == 24
+
+
+@pytest.mark.asyncio
+async def test_cleanup_creates_deletion_records():
+    """Verify _cleanup_expired_accounts creates DeletionRecord nodes."""
+    from unittest.mock import MagicMock
+
+    from app.main import _cleanup_expired_accounts
+
+    mock_session = AsyncMock()
+    # First call: find expired accounts — return one user
+    expired_result = AsyncMock()
+    expired_result.__aiter__ = lambda _self: _aiter_helper(
+        [{"user_id": "expired-user-1"}]
+    )
+    # Subsequent calls: deletion queries + DeletionRecord creation
+    other_result = AsyncMock()
+    other_result.single = AsyncMock(return_value=None)
+
+    call_count = 0
+    queries_seen = []
+
+    async def mock_run(query, **kwargs):
+        nonlocal call_count
+        queries_seen.append(query.strip())
+        call_count += 1
+        if call_count == 1:
+            return expired_result
+        return other_result
+
+    mock_session.run = mock_run
+
+    # Use MagicMock for driver so session() is a sync call returning
+    # an async context manager (matching Neo4j driver behaviour).
+    mock_driver = MagicMock()
+    mock_session_context = MagicMock()
+    mock_session_context.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_context.__aexit__ = AsyncMock(return_value=False)
+    mock_driver.session.return_value = mock_session_context
+
+    with patch("app.main.delete_stored_cvs"), patch(
+        "app.main.delete_user_drafts"
+    ), patch("app.main.delete_user_snapshots"):
+        await _cleanup_expired_accounts(mock_driver)
+
+    # Check that a CREATE (d:DeletionRecord ...) query was issued
+    assert any("DeletionRecord" in q for q in queries_seen), (
+        f"Expected DeletionRecord creation query. Queries: {queries_seen}"
+    )
+
+
+async def _aiter_helper(items):
+    for item in items:
+        yield item

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -251,6 +251,8 @@ def test_admin_stats(admin_client):
             "app.admin.router.count_access_codes",
             AsyncMock(return_value={"total": 200, "used": 47, "available": 153}),
         ),
+        patch("app.admin.router.count_pending_deletion", AsyncMock(return_value=3)),
+        patch("app.admin.router.count_deleted_accounts", AsyncMock(return_value=5)),
     ):
         response = admin_client.get("/admin/stats")
 
@@ -260,6 +262,8 @@ def test_admin_stats(admin_client):
     assert body["pending_activation"] == 12
     assert body["invite_code_required"] is True
     assert body["invite_codes"]["available"] == 153
+    assert body["pending_deletion"] == 3
+    assert body["deleted_accounts"] == 5
 
 
 def test_admin_toggle_invite_code(admin_client):

--- a/docs/database.md
+++ b/docs/database.md
@@ -223,6 +223,19 @@ At `POST /cv/confirm`, the system:
 4. Logs a warning if `prompt_reviewed` is `false` on the active version — this signals that the extraction prompt may not yet be aligned with the updated ontology.
 5. Creates a `ProcessingRecord` node, links it to the active `OntologyVersion` via `USED_ONTOLOGY`, to the `Person` via `HAS_PROCESSING_RECORD`, and to every extracted domain node via `EXTRACTED`.
 
+## Account Deletion Audit
+
+### DeletionRecord
+
+Created by the expired-account cleanup process when a `Person` node is permanently deleted (after the 30-day grace period). Provides an audit trail for admin dashboard metrics.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `user_id` | string | ID of the deleted user |
+| `deleted_at` | datetime | Neo4j datetime of permanent deletion |
+
+These nodes are standalone (no relationships). The cleanup runs on startup and then on a recurring schedule controlled by `CLEANUP_INTERVAL_HOURS` (default: 24h).
+
 ## Constraints and Indexes
 
 Defined in `infra/neo4j/init.cypher`:

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -224,68 +224,6 @@ export async function getFunnelMetrics(
   return data;
 }
 
-// ── LLM Usage ──
-
-export interface LLMUsageRecord {
-  usage_id: string;
-  endpoint: string;
-  llm_provider: string;
-  llm_model: string;
-  cost_usd: number | null;
-  duration_ms: number | null;
-  input_tokens: number | null;
-  output_tokens: number | null;
-  created_at: string;
-}
-
-export interface LLMUsageSummary {
-  total_calls: number;
-  total_cost_usd: number;
-  avg_cost_usd: number;
-  avg_duration_ms: number;
-}
-
-export interface LLMUsageByEndpoint {
-  endpoint: string;
-  count: number;
-  total_cost: number;
-}
-
-export interface LLMUsageByModel {
-  model: string;
-  count: number;
-  total_cost: number;
-}
-
-export interface LLMCostStats {
-  mean: number | null;
-  variance: number | null;
-  min: number | null;
-  max: number | null;
-}
-
-export interface LLMDurationStats {
-  mean_ms: number | null;
-  variance_ms: number | null;
-  min_ms: number | null;
-  max_ms: number | null;
-}
-
-export interface LLMTokenStats {
-  mean: number | null;
-  variance: number | null;
-}
-
-export interface LLMUsageInsights {
-  total_calls: number;
-  total_cost_usd: number;
-  by_endpoint: LLMUsageByEndpoint[];
-  by_model: LLMUsageByModel[];
-  cost_stats: LLMCostStats;
-  duration_stats: LLMDurationStats;
-  token_stats: LLMTokenStats;
-}
-
 // ── Insights ──
 
 export interface ProviderCount {

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -11,6 +11,8 @@ export interface InviteCodeCounts {
 export interface AdminStats {
   registered: number;
   pending_activation: number;
+  pending_deletion: number;
+  deleted_accounts: number;
   invite_code_required: boolean;
   invite_codes: InviteCodeCounts;
 }
@@ -220,6 +222,68 @@ export async function getFunnelMetrics(
 ): Promise<FunnelMetrics> {
   const { data } = await client.get('/admin/funnel', { params: { days } });
   return data;
+}
+
+// ── LLM Usage ──
+
+export interface LLMUsageRecord {
+  usage_id: string;
+  endpoint: string;
+  llm_provider: string;
+  llm_model: string;
+  cost_usd: number | null;
+  duration_ms: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  created_at: string;
+}
+
+export interface LLMUsageSummary {
+  total_calls: number;
+  total_cost_usd: number;
+  avg_cost_usd: number;
+  avg_duration_ms: number;
+}
+
+export interface LLMUsageByEndpoint {
+  endpoint: string;
+  count: number;
+  total_cost: number;
+}
+
+export interface LLMUsageByModel {
+  model: string;
+  count: number;
+  total_cost: number;
+}
+
+export interface LLMCostStats {
+  mean: number | null;
+  variance: number | null;
+  min: number | null;
+  max: number | null;
+}
+
+export interface LLMDurationStats {
+  mean_ms: number | null;
+  variance_ms: number | null;
+  min_ms: number | null;
+  max_ms: number | null;
+}
+
+export interface LLMTokenStats {
+  mean: number | null;
+  variance: number | null;
+}
+
+export interface LLMUsageInsights {
+  total_calls: number;
+  total_cost_usd: number;
+  by_endpoint: LLMUsageByEndpoint[];
+  by_model: LLMUsageByModel[];
+  cost_stats: LLMCostStats;
+  duration_stats: LLMDurationStats;
+  token_stats: LLMTokenStats;
 }
 
 // ── Insights ──

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -603,11 +603,13 @@ export default function AdminPage() {
                 {stats.invite_code_required ? 'Invite code: REQUIRED' : 'Platform: OPEN TO ALL'}
               </button>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               <StatCard label="Registered users" value={stats.registered} />
               <StatCard label="Pending activation" value={stats.pending_activation} />
               <StatCard label="Available codes" value={stats.invite_codes.available} sub={`${stats.invite_codes.used} used of ${stats.invite_codes.total}`} />
               <StatCard label="Total codes" value={stats.invite_codes.total} />
+              <StatCard label="Pending deletion" value={stats.pending_deletion} />
+              <StatCard label="Deleted accounts" value={stats.deleted_accounts} />
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary

- Add configurable recurring background task for expired account cleanup (default: every 24h via `CLEANUP_INTERVAL_HOURS` env var)
- Create `DeletionRecord` Neo4j nodes as audit trail when accounts are permanently deleted
- Surface deletion lifecycle stats on admin dashboard: "Pending deletion" (accounts in 30-day grace period) and "Deleted accounts" (historical count from DeletionRecord nodes)

Closes #207

## Changes

**Backend:**
- `config.py` — new `cleanup_interval_hours` setting (default: 24, env-configurable, 0 = startup-only)
- `main.py` — `DeletionRecord` node creation during cleanup, `_periodic_cleanup` asyncio background task in lifespan, graceful cancellation on shutdown, cleanup function now returns count
- `admin/service.py` — `count_pending_deletion()` and `count_deleted_accounts()` query functions
- `admin/models.py` — `pending_deletion` and `deleted_accounts` fields on `StatsResponse`
- `admin/router.py` — updated `GET /admin/stats` to include new counts

**Frontend:**
- `api/admin.ts` — `pending_deletion` and `deleted_accounts` on `AdminStats` interface
- `AdminPage.tsx` — two new StatCards in stats grid

**Tests:** 2 new tests (config default, DeletionRecord creation). 500 passed, 76.51% coverage.

## Documentation

- `docs/database.md` — added `DeletionRecord` node type documentation

## Test plan

- [x] Backend lint (`ruff check`) passes
- [x] Backend format (`ruff format --check`) passes
- [x] Unit tests: 500 passed, 76.51% coverage (above 75% threshold)
- [x] Frontend lint: 0 errors
- [ ] Manual: verify admin dashboard shows new StatCards
- [ ] Manual: verify cleanup runs on startup (check logs)
- [ ] Manual: verify `CLEANUP_INTERVAL_HOURS=0` disables recurring task

🤖 Generated with [Claude Code](https://claude.com/claude-code)