### PR TITLE
security: fail-fast config, Fernet hardening, LLM rate limits, schema allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Runtime environment. Anything other than "development" triggers fail-fast
+# on insecure placeholders for JWT_SECRET / ENCRYPTION_KEY / NEO4J_PASSWORD.
+ENV=development
+
 # Neo4j
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
@@ -18,8 +22,12 @@ JWT_SECRET=change-me-to-a-random-secret
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=1440
 
-# Encryption
-ENCRYPTION_KEY=change-me-generate-with-fernet
+# Encryption — generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# In dev, if left empty, a key is auto-generated and persisted at backend/.local_encryption_key (gitignored).
+ENCRYPTION_KEY=
+# Optional historic keys (comma-separated) kept around to decrypt data that was
+# written before a key rotation. Current encryption always uses ENCRYPTION_KEY.
+ENCRYPTION_KEYS_HISTORIC=
 
 # Claude API (for CV refinement)
 ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ frontend/dist/
 .env.local
 .env.*.local
 
+# Dev-only auto-generated Fernet key fallback (see backend/app/graph/encryption.py)
+.local_encryption_key
+backend/.local_encryption_key
+
 # IDE
 .vscode/
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ backend/
     admin/       # Closed-beta admin: invite codes CRUD, beta config toggle, pending users, funnel metrics, insights
     email/       # Transactional email via Resend (activation notifications, invite codes)
     cv/          # CV PDF parsing (PyMuPDF), LLM classification (Ollama/Claude CLI), rule-based fallback
-    graph/       # Neo4j async driver, Cypher queries, Fernet encryption, embeddings (placeholder)
+    graph/       # Neo4j async driver, Cypher queries, Fernet encryption (MultiFernet + historic keys), node-property allowlist, embeddings (placeholder)
     orbs/        # Orb (knowledge graph) CRUD, filter tokens for privacy-aware sharing
     notes/       # LLM-enhanced note-to-node conversion
     search/      # Semantic (vector index) and fuzzy text search
     export/      # Public orb export (JSON, JSON-LD, PDF)
     main.py      # FastAPI app factory, middleware (CORS, SlowAPI), router registration
     config.py    # Pydantic Settings (env-based)
-    rate_limit.py # SlowAPI limiter (30/min on public endpoints)
+    rate_limit.py # SlowAPI limiter keyed on user_id (authenticated) / IP (public). Explicit caps on LLM endpoints: /cv/upload 3/min, /cv/import 3/min, /notes/enhance 10/min.
     dependencies.py # get_db, get_current_user (JWT bearer), require_admin
   mcp_server/    # MCP server exposing orb graph to AI agents (6 tools)
   tests/
@@ -51,7 +51,8 @@ infra/           # Neo4j init script (constraints, indexes, vector indexes)
 - Backend linting: `ruff check .` (rules: E, W, F, I, C4, B, UP, C90, SIM, ARG, PTH; max complexity 12)
 - Frontend linting: `eslint .` (flat config with typescript-eslint + react-hooks + react-refresh)
 - Tests: `cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75`
-- All Person node PII fields (email, phone, address) are Fernet-encrypted at rest
+- All Person node PII fields (email, phone, address) are Fernet-encrypted at rest. `ENV` must be non-`development` in production — the backend refuses to start with placeholder `JWT_SECRET`, `ENCRYPTION_KEY`, or `NEO4J_PASSWORD` (see `backend/app/config.py`).
+- All node writes (`cv._persist_nodes`, `orbs.add_node`, `orbs.update_node`) must route properties through `sanitize_node_properties` from `app.graph.node_schema` before `encrypt_properties` — the allowlist is the single chokepoint against LLM-driven prompt injection poisoning the graph.
 - Environment config: `.env` (both backend and root), see `.env.example` for template
 - No pre-commit hooks — linting enforced via CI only
 - Backend runs directly (not containerized): `cd backend && uv run uvicorn app.main:app --reload`

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,19 @@
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+# Values that must never appear in a non-development environment.
+# Keep in sync with .env.example placeholders.
+_INSECURE_JWT_SECRETS = {"", "change-me", "change-me-to-a-random-secret"}
+_INSECURE_ENCRYPTION_KEYS = {"", "change-me-generate-with-fernet"}
+_INSECURE_NEO4J_PASSWORDS = {"orbis_dev_password"}
 
 
 class Settings(BaseSettings):
+    # Runtime environment. Controls fail-fast behavior on insecure defaults:
+    # anything other than "development" is treated as production and will
+    # refuse to start with placeholder secrets.
+    env: str = "development"
+
     # Neo4j
     neo4j_uri: str = "bolt://localhost:7687"
     neo4j_user: str = "neo4j"
@@ -12,8 +24,10 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 1440
 
-    # Encryption
+    # Encryption — active key + optional comma-separated historic keys
+    # used for decrypting data encrypted with a previous key during rotation.
     encryption_key: str = ""
+    encryption_keys_historic: str = ""
 
     # Claude API
     anthropic_api_key: str = ""
@@ -61,6 +75,27 @@ class Settings(BaseSettings):
         "env_file_encoding": "utf-8",
         "extra": "ignore",
     }
+
+    @model_validator(mode="after")
+    def _refuse_insecure_production_config(self) -> "Settings":
+        if self.env == "development":
+            return self
+        errors: list[str] = []
+        if self.jwt_secret in _INSECURE_JWT_SECRETS:
+            errors.append("JWT_SECRET must be set to a secure random value")
+        if self.encryption_key in _INSECURE_ENCRYPTION_KEYS:
+            errors.append("ENCRYPTION_KEY must be set to a valid Fernet key")
+        if self.neo4j_password in _INSECURE_NEO4J_PASSWORDS:
+            errors.append("NEO4J_PASSWORD must not use the default dev value")
+        if errors:
+            raise RuntimeError(
+                "Insecure configuration detected with ENV="
+                + self.env
+                + ":\n  - "
+                + "\n  - ".join(errors)
+                + "\nRefusing to start. See .env.example for guidance."
+            )
+        return self
 
 
 settings = Settings()

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -8,7 +8,6 @@ from fastapi.responses import Response
 from neo4j import AsyncDriver
 
 from app.config import settings
-from app.rate_limit import limiter
 from app.cv import counter, progress
 from app.cv.docling_extractor import extract_text as pdf_extract
 from app.cv.models import ConfirmRequest, ExtractedData
@@ -24,6 +23,7 @@ from app.cv_storage.storage import (
 from app.dependencies import get_current_user, get_db
 from app.graph.encryption import encrypt_properties, encrypt_value
 from app.graph.llm_usage import record_llm_usage
+from app.graph.node_schema import sanitize_node_properties
 from app.graph.provenance import create_processing_record, ensure_ontology_version
 from app.graph.queries import (
     ADD_NODE,
@@ -34,6 +34,7 @@ from app.graph.queries import (
     NODE_TYPE_RELATIONSHIPS,
     UPDATE_PERSON,
 )
+from app.rate_limit import limiter
 from app.snapshots.service import create_snapshot as create_orb_snapshot
 
 logger = logging.getLogger(__name__)
@@ -449,7 +450,8 @@ async def _persist_nodes(data, current_user, db, *, wipe_existing: bool):  # noq
             label = NODE_TYPE_LABELS[node.node_type]
             rel_type = NODE_TYPE_RELATIONSHIPS[node.node_type]
             uid = str(uuid.uuid4())
-            properties = encrypt_properties(node.properties)
+            safe_props = sanitize_node_properties(node.node_type, node.properties)
+            properties = encrypt_properties(safe_props)
 
             merge_keys = NODE_TYPE_MERGE_KEYS.get(node.node_type)
             if merge_keys:

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import Response
 from neo4j import AsyncDriver
 
 from app.config import settings
+from app.rate_limit import limiter
 from app.cv import counter, progress
 from app.cv.docling_extractor import extract_text as pdf_extract
 from app.cv.models import ConfirmRequest, ExtractedData
@@ -53,7 +54,9 @@ async def _require_consent(current_user: dict, db: AsyncDriver) -> None:
 
 
 @router.post("/upload", response_model=ExtractedData)
+@limiter.limit("3/minute")
 async def upload_cv(
+    request: Request,
     file: UploadFile = File(...),
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
@@ -221,7 +224,9 @@ ALLOWED_EXTENSIONS = {".pdf", ".docx", ".txt", ".text"}
 
 
 @router.post("/import", response_model=ExtractedData)
+@limiter.limit("3/minute")
 async def import_document(
+    request: Request,
     file: UploadFile = File(...),
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),

--- a/backend/app/cv_storage/storage.py
+++ b/backend/app/cv_storage/storage.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.cv_storage import db
-from app.graph.encryption import _get_fernet
+from app.graph.encryption import decrypt_bytes, encrypt_bytes
 
 _CV_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "cv_files"
 
@@ -30,7 +30,7 @@ def save_document(
 ) -> dict:
     """Encrypt and persist a document, then record metadata in SQLite."""
     _CV_DIR.mkdir(parents=True, exist_ok=True)
-    encrypted = _get_fernet().encrypt(pdf_bytes)
+    encrypted = encrypt_bytes(pdf_bytes)
     _doc_path(user_id, document_id).write_bytes(encrypted)
     now = datetime.now(timezone.utc).isoformat()
     return db.insert_document(
@@ -50,7 +50,7 @@ def load_document(user_id: str, document_id: str) -> bytes | None:
     path = _doc_path(user_id, document_id)
     if not path.exists():
         return None
-    return _get_fernet().decrypt(path.read_bytes())
+    return decrypt_bytes(path.read_bytes())
 
 
 def delete_document(user_id: str, document_id: str) -> bool:

--- a/backend/app/graph/encryption.py
+++ b/backend/app/graph/encryption.py
@@ -1,39 +1,106 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, MultiFernet
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-_fernet: Fernet | None = None
+_primary: Fernet | None = None
+_multi: MultiFernet | None = None
+
+# Dev-only persistent fallback. Lives at backend/.local_encryption_key and is
+# gitignored. Persisting instead of regenerating avoids losing access to PII
+# encrypted during a previous run.
+_DEV_KEY_FILE = Path(__file__).resolve().parents[2] / ".local_encryption_key"
 
 
-def _get_fernet() -> Fernet:
-    global _fernet
-    if _fernet is None:
-        key = settings.encryption_key
-        try:
-            _fernet = Fernet(key.encode() if isinstance(key, str) else key)
-        except (ValueError, Exception):
-            logger.warning(
-                "Invalid or missing ENCRYPTION_KEY — using auto-generated key (dev only)"
+def _load_or_generate_dev_key() -> str:
+    if _DEV_KEY_FILE.exists():
+        existing = _DEV_KEY_FILE.read_text().strip()
+        if existing:
+            return existing
+    key = Fernet.generate_key().decode()
+    _DEV_KEY_FILE.write_text(key + "\n")
+    try:
+        _DEV_KEY_FILE.chmod(0o600)
+    except OSError:
+        pass
+    logger.warning(
+        "ENCRYPTION_KEY not set — generated and persisted a dev key at %s. "
+        "Set ENCRYPTION_KEY in .env to override.",
+        _DEV_KEY_FILE,
+    )
+    return key
+
+
+def _init_fernet() -> None:
+    global _primary, _multi
+    if _primary is not None:
+        return
+
+    key = settings.encryption_key
+    if not key:
+        if settings.env == "development":
+            key = _load_or_generate_dev_key()
+        else:
+            raise RuntimeError(
+                "ENCRYPTION_KEY is required when ENV != development. "
+                "Refusing to start without a persistent key — generating an "
+                "ephemeral one would make all encrypted PII unrecoverable."
             )
-            _fernet = Fernet(Fernet.generate_key())
-    return _fernet
+
+    try:
+        primary = Fernet(key.encode() if isinstance(key, str) else key)
+    except Exception as exc:
+        raise RuntimeError(
+            "ENCRYPTION_KEY is not a valid urlsafe-base64 Fernet key: "
+            f"{exc}. Generate one with "
+            "`python -c 'from cryptography.fernet import Fernet; "
+            "print(Fernet.generate_key().decode())'`"
+        ) from exc
+
+    historic: list[Fernet] = []
+    if settings.encryption_keys_historic:
+        for raw in settings.encryption_keys_historic.split(","):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                historic.append(Fernet(raw.encode()))
+            except Exception as exc:
+                logger.warning(
+                    "Ignoring invalid key in ENCRYPTION_KEYS_HISTORIC: %s", exc
+                )
+
+    _primary = primary
+    _multi = MultiFernet([primary, *historic])
+
+
+def _get_primary() -> Fernet:
+    _init_fernet()
+    assert _primary is not None
+    return _primary
+
+
+def _get_multi() -> MultiFernet:
+    _init_fernet()
+    assert _multi is not None
+    return _multi
 
 
 ENCRYPTED_FIELDS = {"email", "phone", "address"}
 
 
 def encrypt_value(value: str) -> str:
-    return _get_fernet().encrypt(value.encode()).decode()
+    return _get_primary().encrypt(value.encode()).decode()
 
 
 def decrypt_value(value: str) -> str:
-    return _get_fernet().decrypt(value.encode()).decode()
+    return _get_multi().decrypt(value.encode()).decode()
 
 
 def encrypt_properties(properties: dict) -> dict:

--- a/backend/app/graph/encryption.py
+++ b/backend/app/graph/encryption.py
@@ -103,6 +103,14 @@ def decrypt_value(value: str) -> str:
     return _get_multi().decrypt(value.encode()).decode()
 
 
+def encrypt_bytes(data: bytes) -> bytes:
+    return _get_primary().encrypt(data)
+
+
+def decrypt_bytes(data: bytes) -> bytes:
+    return _get_multi().decrypt(data)
+
+
 def encrypt_properties(properties: dict) -> dict:
     result = dict(properties)
     for field in ENCRYPTED_FIELDS:

--- a/backend/app/graph/encryption.py
+++ b/backend/app/graph/encryption.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 
@@ -25,10 +26,8 @@ def _load_or_generate_dev_key() -> str:
             return existing
     key = Fernet.generate_key().decode()
     _DEV_KEY_FILE.write_text(key + "\n")
-    try:
+    with contextlib.suppress(OSError):
         _DEV_KEY_FILE.chmod(0o600)
-    except OSError:
-        pass
     logger.warning(
         "ENCRYPTION_KEY not set — generated and persisted a dev key at %s. "
         "Set ENCRYPTION_KEY in .env to override.",

--- a/backend/app/graph/node_schema.py
+++ b/backend/app/graph/node_schema.py
@@ -55,9 +55,7 @@ ALLOWED_NODE_PROPERTIES: dict[str, frozenset[str]] = {
             "credential_url",
         }
     ),
-    "publication": frozenset(
-        {"title", "venue", "date", "doi", "url", "abstract"}
-    ),
+    "publication": frozenset({"title", "venue", "date", "doi", "url", "abstract"}),
     "project": frozenset(
         {"name", "role", "description", "start_date", "end_date", "url"}
     ),

--- a/backend/app/graph/node_schema.py
+++ b/backend/app/graph/node_schema.py
@@ -1,0 +1,117 @@
+"""Strict per-node-type property allowlist.
+
+User-supplied PDFs flow into the LLM prompt and the LLM's JSON output is
+parsed and written to Neo4j. Without an allowlist, a crafted PDF can ask
+the LLM to return arbitrary keys (``is_admin``, ``user_id``, …) and poison
+the graph via the /cv/confirm and /notes write paths. The manual /orbs
+node endpoints are vulnerable to the same shape of abuse from a
+direct API client that bypasses the UI.
+
+``sanitize_node_properties`` is the single chokepoint: every write path
+should filter its payload through it before calling ``encrypt_properties``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.graph.queries import NODE_TYPE_LABELS
+
+logger = logging.getLogger(__name__)
+
+MAX_STRING_LEN = 5000
+
+ALLOWED_NODE_PROPERTIES: dict[str, frozenset[str]] = {
+    "work_experience": frozenset(
+        {
+            "company",
+            "title",
+            "start_date",
+            "end_date",
+            "description",
+            "location",
+            "company_url",
+        }
+    ),
+    "education": frozenset(
+        {
+            "institution",
+            "degree",
+            "field_of_study",
+            "start_date",
+            "end_date",
+            "description",
+            "location",
+        }
+    ),
+    "skill": frozenset({"name", "category", "proficiency"}),
+    "language": frozenset({"name", "proficiency"}),
+    "certification": frozenset(
+        {
+            "name",
+            "issuing_organization",
+            "issue_date",
+            "expiry_date",
+            "credential_url",
+        }
+    ),
+    "publication": frozenset(
+        {"title", "venue", "date", "doi", "url", "abstract"}
+    ),
+    "project": frozenset(
+        {"name", "role", "description", "start_date", "end_date", "url"}
+    ),
+    "patent": frozenset(
+        {
+            "title",
+            "patent_number",
+            "filing_date",
+            "grant_date",
+            "description",
+            "url",
+        }
+    ),
+    "award": frozenset({"name", "issuer", "date", "description"}),
+    "outreach": frozenset({"title", "venue", "date", "description", "url"}),
+}
+
+# Inverse lookup for update paths that only have the Neo4j label.
+LABEL_TO_NODE_TYPE: dict[str, str] = {
+    label: node_type for node_type, label in NODE_TYPE_LABELS.items()
+}
+
+
+def sanitize_node_properties(node_type: str, properties: dict) -> dict:
+    """Drop unknown keys and cap oversize strings before persisting a node.
+
+    Unknown node_types yield an empty dict — the caller is expected to
+    have already rejected the request via the existing NODE_TYPE_LABELS
+    gate, but we double-check here so this helper is safe in isolation.
+    """
+    allowed = ALLOWED_NODE_PROPERTIES.get(node_type)
+    if allowed is None:
+        logger.warning(
+            "sanitize_node_properties: unknown node_type=%s, dropping all keys",
+            node_type,
+        )
+        return {}
+
+    clean: dict = {}
+    dropped: list[str] = []
+    for key, value in properties.items():
+        if key not in allowed:
+            dropped.append(key)
+            continue
+        if isinstance(value, str) and len(value) > MAX_STRING_LEN:
+            value = value[:MAX_STRING_LEN]
+        clean[key] = value
+
+    if dropped:
+        logger.warning(
+            "sanitize_node_properties: dropped %d unauthorized keys from "
+            "node_type=%s: %s",
+            len(dropped),
+            node_type,
+            sorted(dropped),
+        )
+    return clean

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -7,7 +7,7 @@ import logging
 import re
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from neo4j import AsyncDriver
 
 from app.config import settings
@@ -15,6 +15,7 @@ from app.dependencies import get_current_user, get_db
 from app.graph.llm_usage import record_llm_usage
 from app.graph.queries import NODE_TYPE_LABELS
 from app.notes.models import EnhanceNoteRequest, EnhanceNoteResponse
+from app.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +202,9 @@ def _parse_enhance_result(  # noqa: C901
 
 
 @router.post("/enhance", response_model=EnhanceNoteResponse)
+@limiter.limit("10/minute")
 async def enhance_note(
+    request: Request,
     req: EnhanceNoteRequest,
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -15,6 +15,7 @@ from app.config import settings
 from app.dependencies import get_current_user, get_current_user_optional, get_db
 from app.email.service import send_access_grant_email
 from app.graph.encryption import decrypt_properties, encrypt_properties
+from app.graph.node_schema import LABEL_TO_NODE_TYPE, sanitize_node_properties
 from app.graph.queries import (
     ADD_NODE,
     DELETE_NODE,
@@ -290,7 +291,8 @@ async def add_node(
     label = NODE_TYPE_LABELS[data.node_type]
     rel_type = NODE_TYPE_RELATIONSHIPS[data.node_type]
     uid = str(uuid.uuid4())
-    properties = encrypt_properties(data.properties)
+    safe_props = sanitize_node_properties(data.node_type, data.properties)
+    properties = encrypt_properties(safe_props)
 
     query = ADD_NODE.replace("{label}", label).replace("{rel_type}", rel_type)
 
@@ -314,8 +316,25 @@ async def update_node(
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
 ):
-    properties = encrypt_properties(data.properties)
     async with db.session() as session:
+        label_result = await session.run(
+            "MATCH (n {uid: $uid}) RETURN labels(n) AS labels LIMIT 1",
+            uid=uid,
+        )
+        label_record = await label_result.single()
+        if label_record is None:
+            raise HTTPException(status_code=404, detail="Node not found")
+        labels = list(label_record["labels"])
+        node_type = next(
+            (LABEL_TO_NODE_TYPE[lbl] for lbl in labels if lbl in LABEL_TO_NODE_TYPE),
+            None,
+        )
+        if node_type is None:
+            raise HTTPException(
+                status_code=400, detail="Node has no supported type"
+            )
+        safe_props = sanitize_node_properties(node_type, data.properties)
+        properties = encrypt_properties(safe_props)
         result = await session.run(UPDATE_NODE, uid=uid, properties=properties)
         record = await result.single()
         if record is None:

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -330,9 +330,7 @@ async def update_node(
             None,
         )
         if node_type is None:
-            raise HTTPException(
-                status_code=400, detail="Node has no supported type"
-            )
+            raise HTTPException(status_code=400, detail="Node has no supported type")
         safe_props = sanitize_node_properties(node_type, data.properties)
         properties = encrypt_properties(safe_props)
         result = await session.run(UPDATE_NODE, uid=uid, properties=properties)

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -13,9 +13,7 @@ def _user_or_ip(request: Request) -> str:
     can be trivially bypassed by rotating proxies while the same account
     still drains the API budget.
     """
-    auth = request.headers.get("authorization") or request.headers.get(
-        "Authorization"
-    )
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
     if auth and auth.lower().startswith("bearer "):
         token = auth.split(" ", 1)[1]
         try:

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,4 +1,35 @@
+from fastapi import Request
+from jose import JWTError, jwt
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+from app.config import settings
+
+
+def _user_or_ip(request: Request) -> str:
+    """Rate-limit key: authenticated user_id when available, otherwise client IP.
+
+    Per-user keying matters for expensive LLM endpoints — IP-based limits
+    can be trivially bypassed by rotating proxies while the same account
+    still drains the API budget.
+    """
+    auth = request.headers.get("authorization") or request.headers.get(
+        "Authorization"
+    )
+    if auth and auth.lower().startswith("bearer "):
+        token = auth.split(" ", 1)[1]
+        try:
+            payload = jwt.decode(
+                token,
+                settings.jwt_secret,
+                algorithms=[settings.jwt_algorithm],
+            )
+            sub = payload.get("sub")
+            if sub:
+                return f"user:{sub}"
+        except JWTError:
+            pass
+    return get_remote_address(request)
+
+
+limiter = Limiter(key_func=_user_or_ip)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -5,6 +5,16 @@ from fastapi.testclient import TestClient
 
 from app.dependencies import get_current_user, get_db
 from app.main import app
+from app.rate_limit import limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Clear SlowAPI counters between tests so back-to-back requests
+    from the shared TestClient IP don't trip shared per-minute limits."""
+    limiter.reset()
+    yield
+    limiter.reset()
 
 
 class MockNode(dict):

--- a/backend/tests/unit/test_cv_storage_file.py
+++ b/backend/tests/unit/test_cv_storage_file.py
@@ -130,10 +130,10 @@ def test_file_migration_on_save(monkeypatch, tmp_path):
     monkeypatch.setattr(cv_storage, "_CV_DIR", cv_dir)
     cv_dir.mkdir()
     # Simulate old file
-    from app.graph.encryption import _get_fernet
+    from app.graph.encryption import encrypt_bytes
 
     old_path = cv_dir / f"{_USER}.pdf.enc"
-    old_path.write_bytes(_get_fernet().encrypt(_PDF))
+    old_path.write_bytes(encrypt_bytes(_PDF))
 
     # Insert a legacy document record (simulating migration from db layer)
     cv_db.insert_document(

--- a/backend/tests/unit/test_encryption.py
+++ b/backend/tests/unit/test_encryption.py
@@ -22,10 +22,12 @@ TEST_KEY = Fernet.generate_key()
 
 @pytest.fixture(autouse=True)
 def _reset_fernet():
-    """Reset the module-level Fernet singleton before each test."""
-    enc_mod._fernet = None
+    """Reset module-level Fernet singletons before each test."""
+    enc_mod._primary = None
+    enc_mod._multi = None
     yield
-    enc_mod._fernet = None
+    enc_mod._primary = None
+    enc_mod._multi = None
 
 
 @pytest.fixture(autouse=True)
@@ -33,6 +35,8 @@ def _mock_settings():
     """Provide a valid encryption key via settings."""
     with patch.object(enc_mod, "settings") as mock_settings:
         mock_settings.encryption_key = TEST_KEY.decode()
+        mock_settings.encryption_keys_historic = ""
+        mock_settings.env = "development"
         yield
 
 
@@ -97,21 +101,48 @@ class TestEncryptDecryptProperties:
         assert result["name"] == "Dave"
 
 
-# ── _get_fernet fallback ──
+# ── Fernet initialization ──
 
 
-class TestGetFernet:
-    def test_invalid_key_falls_back(self):
-        enc_mod._fernet = None
+class TestFernetInit:
+    def test_singleton_reused(self):
+        f1 = enc_mod._get_primary()
+        f2 = enc_mod._get_primary()
+        assert f1 is f2
+
+    def test_invalid_key_raises(self):
+        enc_mod._primary = None
+        enc_mod._multi = None
         with patch.object(enc_mod, "settings") as mock_settings:
             mock_settings.encryption_key = "not-valid-base64-key"
-            fernet = enc_mod._get_fernet()
-            assert isinstance(fernet, Fernet)
+            mock_settings.encryption_keys_historic = ""
+            mock_settings.env = "development"
+            with pytest.raises(RuntimeError, match="not a valid urlsafe-base64"):
+                enc_mod._get_primary()
 
-    def test_singleton_reused(self):
-        f1 = enc_mod._get_fernet()
-        f2 = enc_mod._get_fernet()
-        assert f1 is f2
+    def test_missing_key_raises_in_production(self):
+        enc_mod._primary = None
+        enc_mod._multi = None
+        with patch.object(enc_mod, "settings") as mock_settings:
+            mock_settings.encryption_key = ""
+            mock_settings.encryption_keys_historic = ""
+            mock_settings.env = "production"
+            with pytest.raises(RuntimeError, match="ENCRYPTION_KEY is required"):
+                enc_mod._get_primary()
+
+    def test_historic_keys_enable_legacy_decrypt(self):
+        """Data encrypted with an old key must still decrypt after rotation."""
+        old_key = Fernet.generate_key()
+        new_key = Fernet.generate_key()
+        ciphertext = Fernet(old_key).encrypt(b"legacy@example.com").decode()
+
+        enc_mod._primary = None
+        enc_mod._multi = None
+        with patch.object(enc_mod, "settings") as mock_settings:
+            mock_settings.encryption_key = new_key.decode()
+            mock_settings.encryption_keys_historic = old_key.decode()
+            mock_settings.env = "development"
+            assert enc_mod.decrypt_value(ciphertext) == "legacy@example.com"
 
 
 # ── ENCRYPTED_FIELDS ──

--- a/backend/tests/unit/test_node_schema.py
+++ b/backend/tests/unit/test_node_schema.py
@@ -1,0 +1,54 @@
+"""Unit tests for app.graph.node_schema.sanitize_node_properties."""
+
+from __future__ import annotations
+
+from app.graph.node_schema import (
+    ALLOWED_NODE_PROPERTIES,
+    LABEL_TO_NODE_TYPE,
+    MAX_STRING_LEN,
+    sanitize_node_properties,
+)
+from app.graph.queries import NODE_TYPE_LABELS
+
+
+class TestSanitizeNodeProperties:
+    def test_allowed_keys_pass_through(self):
+        props = {"company": "Acme", "title": "Engineer"}
+        result = sanitize_node_properties("work_experience", props)
+        assert result == props
+
+    def test_unknown_keys_dropped(self):
+        props = {
+            "company": "Acme",
+            "is_admin": True,
+            "user_id": "victim-123",
+            "uid": "attacker-uid",
+        }
+        result = sanitize_node_properties("work_experience", props)
+        assert result == {"company": "Acme"}
+
+    def test_unknown_node_type_drops_everything(self):
+        result = sanitize_node_properties("definitely_not_a_type", {"name": "X"})
+        assert result == {}
+
+    def test_oversize_string_truncated(self):
+        oversized = "A" * (MAX_STRING_LEN + 100)
+        result = sanitize_node_properties("skill", {"name": oversized})
+        assert len(result["name"]) == MAX_STRING_LEN
+
+    def test_non_string_values_preserved(self):
+        result = sanitize_node_properties("skill", {"name": "Python", "proficiency": None})
+        assert result == {"name": "Python", "proficiency": None}
+
+    def test_empty_properties_returns_empty(self):
+        assert sanitize_node_properties("skill", {}) == {}
+
+    def test_all_node_types_in_allowlist(self):
+        """Every node_type in NODE_TYPE_LABELS must have an allowlist entry,
+        otherwise writes silently break."""
+        for node_type in NODE_TYPE_LABELS:
+            assert node_type in ALLOWED_NODE_PROPERTIES, node_type
+
+    def test_label_to_type_inverse_is_complete(self):
+        for node_type, label in NODE_TYPE_LABELS.items():
+            assert LABEL_TO_NODE_TYPE[label] == node_type

--- a/backend/tests/unit/test_node_schema.py
+++ b/backend/tests/unit/test_node_schema.py
@@ -37,7 +37,9 @@ class TestSanitizeNodeProperties:
         assert len(result["name"]) == MAX_STRING_LEN
 
     def test_non_string_values_preserved(self):
-        result = sanitize_node_properties("skill", {"name": "Python", "proficiency": None})
+        result = sanitize_node_properties(
+            "skill", {"name": "Python", "proficiency": None}
+        )
         assert result == {"name": "Python", "proficiency": None}
 
     def test_empty_properties_returns_empty(self):

--- a/backend/tests/unit/test_orbs_router.py
+++ b/backend/tests/unit/test_orbs_router.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.orbs.router import _sanitize_neo4j_types, _serialize_orb
 from tests.unit.conftest import MockNode
@@ -138,8 +138,14 @@ def test_update_node_success(client, mock_db):
     node_data = {"uid": "node-1", "name": "Updated"}
     node_mock = MockNode(node_data, ["Skill"])
 
-    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
-        AsyncMock(return_value={"n": node_mock})
+    # update_node now does two queries: labels lookup then SET update.
+    label_result = MagicMock()
+    label_result.single = AsyncMock(return_value={"labels": ["Skill"]})
+    update_result = MagicMock()
+    update_result.single = AsyncMock(return_value={"n": node_mock})
+
+    mock_db.session.return_value.__aenter__.return_value.run = AsyncMock(
+        side_effect=[label_result, update_result]
     )
 
     response = client.put(
@@ -147,6 +153,39 @@ def test_update_node_success(client, mock_db):
     )
     assert response.status_code == 200
     assert response.json()["name"] == "Updated"
+
+
+def test_update_node_drops_unauthorized_keys(client, mock_db):
+    """Regression test for C3: update_node must sanitize payload against
+    the node-type allowlist even if the client submits extra fields."""
+    node_data = {"uid": "node-1", "name": "Python"}
+    node_mock = MockNode(node_data, ["Skill"])
+
+    label_result = MagicMock()
+    label_result.single = AsyncMock(return_value={"labels": ["Skill"]})
+    update_result = MagicMock()
+    update_result.single = AsyncMock(return_value={"n": node_mock})
+
+    run_mock = AsyncMock(side_effect=[label_result, update_result])
+    mock_db.session.return_value.__aenter__.return_value.run = run_mock
+
+    response = client.put(
+        "/orbs/me/nodes/node-1",
+        json={
+            "properties": {
+                "name": "Python",
+                "is_admin": True,
+                "user_id": "victim",
+            }
+        },
+    )
+    assert response.status_code == 200
+    # Second run call is the UPDATE — check the sanitized properties.
+    update_call = run_mock.call_args_list[1]
+    sent_props = update_call.kwargs["properties"]
+    assert "is_admin" not in sent_props
+    assert "user_id" not in sent_props
+    assert sent_props == {"name": "Python"}
 
 
 def test_delete_node_success(client, mock_db):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,14 +56,19 @@ All configuration is via environment variables. See `.env.example` for the full 
 
 ### Required for production
 
+> **Fail-fast**: set `ENV` to anything other than `development` in production. The app refuses to start if any of the secrets below are left at their placeholder values — this is enforced by a Pydantic validator in `backend/app/config.py`. The same validator plus `backend/app/graph/encryption.py` also refuses to boot without a persistent `ENCRYPTION_KEY`, because an auto-generated key would make previously encrypted PII unrecoverable on the next restart.
+
 | Variable | Purpose |
 |----------|---------|
+| `ENV` | Must be set to a non-`development` value (e.g. `production`, `staging`) to enable fail-fast |
 | `NEO4J_URI` | Neo4j Bolt connection string |
 | `NEO4J_USER` | Neo4j username |
-| `NEO4J_PASSWORD` | Neo4j password |
-| `JWT_SECRET` | Strong random secret for JWT signing |
-| `ENCRYPTION_KEY` | Fernet key for PII encryption (generate with `Fernet.generate_key()`) |
+| `NEO4J_PASSWORD` | Neo4j password (must not be `orbis_dev_password`) |
+| `JWT_SECRET` | Strong random secret for JWT signing (generate with `python -c "import secrets; print(secrets.token_urlsafe(32))"`) |
+| `ENCRYPTION_KEY` | Fernet key for PII encryption (generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`) |
 | `FRONTEND_URL` | Frontend origin for CORS |
+
+Optional: set `ENCRYPTION_KEYS_HISTORIC` to a comma-separated list of previous Fernet keys when rotating. New writes use `ENCRYPTION_KEY`; reads transparently try the historic keys for legacy ciphertext.
 
 ### Optional
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -21,9 +21,10 @@ cp .env.example .env
 ```
 
 Edit `.env` and set at minimum:
-- `JWT_SECRET` — any random string (change from default `change-me`)
-- `ENCRYPTION_KEY` — generate with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
-- `ANTHROPIC_API_KEY` — if using Claude for CV classification
+- `ENV=development` — controls fail-fast on insecure placeholders (see `docs/deployment.md` for production behavior).
+- `JWT_SECRET` — any random string (change from default `change-me`).
+- `ENCRYPTION_KEY` — optional in development: if left blank, the backend generates a Fernet key on first start and persists it to `backend/.local_encryption_key` (gitignored) so encrypted PII survives restarts. To set one explicitly, generate with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`.
+- `ANTHROPIC_API_KEY` — if using Claude for CV classification.
 
 ### 2. Start infrastructure services
 
@@ -127,10 +128,12 @@ See `.env.example` for the full list. Key variables:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
+| `ENV` | Runtime environment. Non-`development` triggers fail-fast on placeholder secrets. | `development` |
 | `NEO4J_URI` | Neo4j Bolt connection | `bolt://localhost:7687` |
 | `NEO4J_PASSWORD` | Neo4j auth | `orbis_dev_password` |
 | `JWT_SECRET` | JWT signing key | `change-me` |
-| `ENCRYPTION_KEY` | Fernet key for PII encryption | auto-generated |
+| `ENCRYPTION_KEY` | Fernet key for PII encryption. Empty in dev → auto-generated at `backend/.local_encryption_key`. Required in production. | `""` |
+| `ENCRYPTION_KEYS_HISTORIC` | Comma-separated legacy Fernet keys used only for decrypting data written before a rotation. | `""` |
 | `LLM_PROVIDER` | CV classifier: `ollama` or `claude` | `ollama` |
 | `OLLAMA_MODEL` | Ollama model name | `llama3.2:3b` |
 | `CLAUDE_MODEL` | Claude model for CV extraction | `claude-opus-4-6` |


### PR DESCRIPTION
Addresses the 4 **CRITICAL** findings from issue #253.

## Summary

| # | Finding | Fix |
|---|---------|-----|
| C1 | `config.py` shipped permissive defaults (`JWT_SECRET="change-me"`, `ENCRYPTION_KEY=""`, `NEO4J_PASSWORD="orbis_dev_password"`) that silently applied in production. | New `ENV` field + Pydantic `model_validator` that refuses to start in any non-`development` env if a placeholder is detected. |
| C2 | `_get_fernet()` silently auto-generated an ephemeral key when `ENCRYPTION_KEY` was missing or invalid, making previously encrypted PII unrecoverable on the next restart and leaving prod "encrypted" with a throwaway key. | Removed the silent fallback. In dev, persist to `backend/.local_encryption_key` (gitignored). In any other env, fail hard. `MultiFernet` + `ENCRYPTION_KEYS_HISTORIC` seam so a future rotation doesn't need another refactor. |
| C3 | `ExtractedNode.properties` was a free-form `dict`. A crafted PDF can coach the LLM into returning any keys, which flowed straight into Neo4j. Same risk on the manual `/orbs/me/nodes` write paths. | New `app.graph.node_schema.sanitize_node_properties` with per-`node_type` frozen allowlists and a 5000-char cap. Wired into `cv._persist_nodes`, `orbs.add_node`, and `orbs.update_node` (which now fetches the node's label first to infer `node_type`). |
| C4 | `/cv/upload`, `/cv/import`, `/notes/enhance` fan out to Claude/Ollama with per-call cost and no throttling. SlowAPI was IP-keyed, trivially bypassed by rotating proxies. | `_user_or_ip` key function decodes the bearer JWT and keys on `user_id` when available. `@limiter.limit("3/minute")` on CV endpoints, `"10/minute"` on note enhancement. |

## Commits

Four semantically separate commits for easier review:

1. `d6b551c` — **C1**: fail-fast on insecure config in non-dev envs
2. `3a409f4` — **C2**: remove silent Fernet fallback, add key rotation seam
3. `7a7a6a1` — **C4**: per-user rate limits on LLM endpoints (also sweeps up the byte-encryption helpers and test fixtures required by C2)
4. `fc04e3b` — **C3**: strict per-node-type property allowlist on writes
5. `4bd1177` — **docs**: reflect the hardening in CLAUDE.md, onboarding, deployment

## Tests

- `509 passed` on the full backend unit suite
- Coverage: **76%** (above the `--cov-fail-under=75` gate)
- `ruff check` clean on `app/` and touched test files
- New tests:
  - `TestFernetInit::test_invalid_key_raises` / `test_missing_key_raises_in_production` / `test_historic_keys_enable_legacy_decrypt`
  - `test_node_schema.py` covers allowlist behavior, oversize-string cap, and a completeness check that every `NODE_TYPE_LABELS` entry has an allowlist row
  - `test_update_node_drops_unauthorized_keys` is a regression test proving `/orbs/me/nodes/{uid}` PUT drops `is_admin` / `user_id` payloads

## Test plan

- [ ] CI lint + unit suite green
- [ ] Boot the backend locally with `.env` unchanged — dev mode still works, `backend/.local_encryption_key` is generated on first start
- [ ] Delete `.local_encryption_key`, restart → new key generated, no data loss because the file is the source of truth
- [ ] `ENV=production uv run uvicorn app.main:app` with the current `.env` → refuses to start with a clear list of the placeholders that need fixing
- [ ] Upload a CV with an extra property (`{"name": "Python", "is_admin": true}`) and confirm it — check the Neo4j node has only the allowed keys

## Documentation

- `CLAUDE.md` — fail-fast requirement, the `node_schema` allowlist convention, and the new per-user LLM rate limits
- `docs/onboarding.md` — `ENV` default, dev auto-generated encryption key, `ENCRYPTION_KEYS_HISTORIC`
- `docs/deployment.md` — production fail-fast, rotation guidance

## Out of scope (follow-ups tracked on #253)

- `.local_encryption_key` → proper KMS integration (C2 follow-up)
- Key rotation with per-node `encryption_key_id` (C2 follow-up)
- Monthly LLM quota per user (C4 follow-up — scope creep for this PR, rate limiting is the immediate mitigation)
- All HIGH / MEDIUM / LOW findings from issue #253

Closes the CRITICAL section of #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)