### PR TITLE
feat: add QR download to Orbis share modal

### DIFF
--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -219,7 +219,9 @@ async def export_orb(  # noqa: C901
     # 2. Branch on visibility mode
     token_data: dict | None = None
     if visibility == "restricted":
-        await assert_user_can_access_restricted(db, orb_id, current_user)
+        token_data = await assert_user_can_access_restricted(db, orb_id, current_user)
+        if token_data is None:
+            token_data = {"keywords": [], "hidden_node_types": []}
     else:
         if not token:
             raise HTTPException(
@@ -259,7 +261,7 @@ async def export_orb(  # noqa: C901
             status_code=500, detail="Failed to process orb data"
         ) from None
 
-    # Apply filters only when a share token was used (public mode)
+    # Apply filters in public mode (share token) and restricted mode (per-grant scope)
     active_filters = token_data["keywords"] if token_data else []
     hidden_types = set(token_data.get("hidden_node_types", []) if token_data else [])
     if active_filters or hidden_types:

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -19,7 +19,7 @@ CREATE (p:Person {
     website_url: '',
     orcid_url: '',
     open_to_work: false,
-    visibility: 'private',
+    visibility: 'public',
     created_at: datetime(),
     updated_at: datetime()
 })
@@ -33,7 +33,7 @@ RETURN p
 
 GET_PERSON_VISIBILITY = """
 MATCH (p:Person {orb_id: $orb_id})
-RETURN coalesce(p.visibility, 'private') AS visibility
+RETURN coalesce(p.visibility, 'public') AS visibility
 """
 
 # ── Access grants (restricted-mode allowlist) ──

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -41,10 +41,15 @@ RETURN coalesce(p.visibility, 'public') AS visibility
 CREATE_ACCESS_GRANT = """
 MATCH (p:Person {user_id: $user_id})
 WHERE p.orb_id IS NOT NULL AND p.orb_id <> ''
+OPTIONAL MATCH (p)-[:GRANTED_ACCESS]->(old:AccessGrant {email: $email})
+WHERE old.revoked = false
+SET old.revoked = true, old.revoked_at = datetime()
 CREATE (p)-[:GRANTED_ACCESS]->(g:AccessGrant {
     grant_id:   $grant_id,
     orb_id:     p.orb_id,
     email:      $email,
+    keywords:   $keywords,
+    hidden_node_types: $hidden_node_types,
     created_at: datetime(),
     revoked:    false,
     revoked_at: null
@@ -69,7 +74,17 @@ CHECK_ACCESS_GRANT = """
 MATCH (p:Person {orb_id: $orb_id})-[:GRANTED_ACCESS]->(g:AccessGrant {email: $email})
 WHERE g.revoked = false
 RETURN g
+ORDER BY g.created_at DESC
 LIMIT 1
+"""
+
+UPDATE_ACCESS_GRANT_FILTERS = """
+MATCH (p:Person {user_id: $user_id})-[:GRANTED_ACCESS]->(g:AccessGrant {grant_id: $grant_id})
+WHERE g.revoked = false
+SET g.keywords = $keywords,
+    g.hidden_node_types = $hidden_node_types,
+    g.filters_updated_at = datetime()
+RETURN g
 """
 
 GET_PERSON_BY_ORB_ID = """

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -744,3 +744,45 @@ RETURN u.llm_model AS model,
        sum(CASE WHEN u.cost_usd IS NOT NULL THEN u.cost_usd ELSE 0 END) AS total_cost
 ORDER BY count DESC
 """
+
+# ── Connection Requests ──
+
+CREATE_CONNECTION_REQUEST = """
+MATCH (p:Person {orb_id: $orb_id})
+WHERE p.visibility = 'restricted'
+OPTIONAL MATCH (p)-[:HAS_CONNECTION_REQUEST]->(existing:ConnectionRequest {
+    requester_user_id: $requester_user_id, status: 'pending'
+})
+WITH p, existing
+WHERE existing IS NULL
+CREATE (p)-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {
+    request_id: $request_id,
+    requester_user_id: $requester_user_id,
+    requester_email: $requester_email,
+    requester_name: $requester_name,
+    status: 'pending',
+    created_at: datetime(),
+    resolved_at: null
+})
+RETURN cr, p.user_id AS owner_user_id
+"""
+
+GET_CONNECTION_REQUEST_BY_REQUESTER = """
+MATCH (p:Person {orb_id: $orb_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {
+    requester_user_id: $requester_user_id, status: 'pending'
+})
+RETURN cr
+"""
+
+LIST_PENDING_CONNECTION_REQUESTS = """
+MATCH (p:Person {user_id: $user_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {status: 'pending'})
+RETURN cr
+ORDER BY cr.created_at DESC
+"""
+
+UPDATE_CONNECTION_REQUEST_STATUS = """
+MATCH (p:Person {user_id: $user_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {request_id: $request_id})
+WHERE cr.status = 'pending'
+SET cr.status = $status, cr.resolved_at = datetime()
+RETURN cr
+"""

--- a/backend/app/orbs/access_grants.py
+++ b/backend/app/orbs/access_grants.py
@@ -21,6 +21,7 @@ from app.graph.queries import (
     CREATE_ACCESS_GRANT,
     LIST_ACCESS_GRANTS,
     REVOKE_ACCESS_GRANT,
+    UPDATE_ACCESS_GRANT_FILTERS,
 )
 
 
@@ -39,13 +40,37 @@ def _normalize_email(email: str) -> str:
     return email.strip().lower()
 
 
-async def create_access_grant(db: AsyncDriver, user_id: str, email: str) -> dict | None:
+def _normalize_keywords(keywords: list[str] | None) -> list[str]:
+    normalized = [kw.strip().lower() for kw in (keywords or []) if kw.strip()]
+    return list(dict.fromkeys(normalized))
+
+
+def _normalize_hidden_types(hidden_node_types: list[str] | None) -> list[str]:
+    normalized = [node_type.strip() for node_type in (hidden_node_types or []) if node_type.strip()]
+    return list(dict.fromkeys(normalized))
+
+
+def _apply_filter_defaults(grant: dict) -> dict:
+    grant["keywords"] = list(grant.get("keywords") or [])
+    grant["hidden_node_types"] = list(grant.get("hidden_node_types") or [])
+    return grant
+
+
+async def create_access_grant(
+    db: AsyncDriver,
+    user_id: str,
+    email: str,
+    keywords: list[str] | None = None,
+    hidden_node_types: list[str] | None = None,
+) -> dict | None:
     """Create an access grant for the given email on the user's orb.
 
     Returns ``None`` if the user has no orb_id set.
     """
     grant_id = secrets.token_urlsafe(16)
     normalized = _normalize_email(email)
+    normalized_keywords = _normalize_keywords(keywords)
+    normalized_hidden_types = _normalize_hidden_types(hidden_node_types)
 
     async with db.session() as session:
         result = await session.run(
@@ -53,11 +78,13 @@ async def create_access_grant(db: AsyncDriver, user_id: str, email: str) -> dict
             user_id=user_id,
             grant_id=grant_id,
             email=normalized,
+            keywords=normalized_keywords,
+            hidden_node_types=normalized_hidden_types,
         )
         record = await result.single()
         if record is None:
             return None
-        grant = _sanitize(dict(record["g"]))
+        grant = _apply_filter_defaults(_sanitize(dict(record["g"])))
         grant["owner_name"] = record["owner_name"] or ""
         return grant
 
@@ -68,7 +95,7 @@ async def list_access_grants(db: AsyncDriver, user_id: str) -> list[dict]:
         result = await session.run(LIST_ACCESS_GRANTS, user_id=user_id)
         grants = []
         async for record in result:
-            grants.append(_sanitize(dict(record["g"])))
+            grants.append(_apply_filter_defaults(_sanitize(dict(record["g"]))))
         return grants
 
 
@@ -83,15 +110,48 @@ async def revoke_access_grant(
         record = await result.single()
         if record is None:
             return None
-        return _sanitize(dict(record["g"]))
+        return _apply_filter_defaults(_sanitize(dict(record["g"])))
+
+
+async def update_access_grant_filters(
+    db: AsyncDriver,
+    user_id: str,
+    grant_id: str,
+    keywords: list[str] | None,
+    hidden_node_types: list[str] | None,
+) -> dict | None:
+    """Update filter scope for an existing active access grant."""
+    normalized_keywords = _normalize_keywords(keywords)
+    normalized_hidden_types = _normalize_hidden_types(hidden_node_types)
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_ACCESS_GRANT_FILTERS,
+            user_id=user_id,
+            grant_id=grant_id,
+            keywords=normalized_keywords,
+            hidden_node_types=normalized_hidden_types,
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _apply_filter_defaults(_sanitize(dict(record["g"])))
+
+
+async def get_access_grant_for_user(
+    db: AsyncDriver, orb_id: str, email: str
+) -> dict | None:
+    """Return the active grant for this orb/email, or None."""
+    normalized = _normalize_email(email)
+    if not normalized:
+        return None
+    async with db.session() as session:
+        result = await session.run(CHECK_ACCESS_GRANT, orb_id=orb_id, email=normalized)
+        record = await result.single()
+        if record is None:
+            return None
+        return _apply_filter_defaults(_sanitize(dict(record["g"])))
 
 
 async def user_has_access(db: AsyncDriver, orb_id: str, email: str) -> bool:
     """Return True if the email has an active grant for the orb."""
-    normalized = _normalize_email(email)
-    if not normalized:
-        return False
-    async with db.session() as session:
-        result = await session.run(CHECK_ACCESS_GRANT, orb_id=orb_id, email=normalized)
-        record = await result.single()
-        return record is not None
+    return await get_access_grant_for_user(db, orb_id, email) is not None

--- a/backend/app/orbs/access_grants.py
+++ b/backend/app/orbs/access_grants.py
@@ -46,7 +46,11 @@ def _normalize_keywords(keywords: list[str] | None) -> list[str]:
 
 
 def _normalize_hidden_types(hidden_node_types: list[str] | None) -> list[str]:
-    normalized = [node_type.strip() for node_type in (hidden_node_types or []) if node_type.strip()]
+    normalized = [
+        node_type.strip()
+        for node_type in (hidden_node_types or [])
+        if node_type.strip()
+    ]
     return list(dict.fromkeys(normalized))
 
 

--- a/backend/app/orbs/connection_requests.py
+++ b/backend/app/orbs/connection_requests.py
@@ -1,0 +1,132 @@
+"""Connection request service for restricted orbs."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from neo4j import AsyncDriver
+from neo4j.time import DateTime as Neo4jDateTime
+
+from app.graph.queries import (
+    CREATE_CONNECTION_REQUEST,
+    GET_CONNECTION_REQUEST_BY_REQUESTER,
+    LIST_PENDING_CONNECTION_REQUESTS,
+    UPDATE_CONNECTION_REQUEST_STATUS,
+)
+from app.orbs.access_grants import create_access_grant
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize(d: dict) -> dict:
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, Neo4jDateTime):
+            result[k] = v.iso_format()
+        else:
+            result[k] = v
+    return result
+
+
+async def create_connection_request(
+    db: AsyncDriver,
+    orb_id: str,
+    user: dict,
+) -> dict | None:
+    """Create a pending connection request. Returns None if duplicate."""
+    request_id = str(uuid.uuid4())
+    async with db.session() as session:
+        result = await session.run(
+            CREATE_CONNECTION_REQUEST,
+            request_id=request_id,
+            orb_id=orb_id,
+            requester_user_id=user["user_id"],
+            requester_email=(user.get("email") or "").strip().lower(),
+            requester_name=user.get("name") or "",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))
+
+
+async def get_my_connection_request(
+    db: AsyncDriver,
+    orb_id: str,
+    user_id: str,
+) -> dict | None:
+    """Get the current user's pending request for an orb."""
+    async with db.session() as session:
+        result = await session.run(
+            GET_CONNECTION_REQUEST_BY_REQUESTER,
+            orb_id=orb_id,
+            requester_user_id=user_id,
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))
+
+
+async def list_pending_requests(
+    db: AsyncDriver,
+    user_id: str,
+) -> list[dict]:
+    """List all pending connection requests for the owner's orb."""
+    async with db.session() as session:
+        result = await session.run(
+            LIST_PENDING_CONNECTION_REQUESTS,
+            user_id=user_id,
+        )
+        return [_sanitize(dict(r["cr"])) async for r in result]
+
+
+async def accept_request(
+    db: AsyncDriver,
+    user_id: str,
+    request_id: str,
+    keywords: list[str] | None = None,
+    hidden_node_types: list[str] | None = None,
+) -> dict | None:
+    """Accept a request: update status and create an AccessGrant."""
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_CONNECTION_REQUEST_STATUS,
+            user_id=user_id,
+            request_id=request_id,
+            status="accepted",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        cr = _sanitize(dict(record["cr"]))
+
+    # Create AccessGrant for the requester
+    grant = await create_access_grant(
+        db=db,
+        user_id=user_id,
+        email=cr["requester_email"],
+        keywords=keywords,
+        hidden_node_types=hidden_node_types,
+    )
+    return grant
+
+
+async def reject_request(
+    db: AsyncDriver,
+    user_id: str,
+    request_id: str,
+) -> dict | None:
+    """Reject a connection request."""
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_CONNECTION_REQUEST_STATUS,
+            user_id=user_id,
+            request_id=request_id,
+            status="rejected",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))

--- a/backend/app/orbs/models.py
+++ b/backend/app/orbs/models.py
@@ -71,15 +71,24 @@ class ShareTokenListResponse(BaseModel):
 
 class AccessGrantCreate(BaseModel):
     email: str  # normalized lowercase server-side
+    keywords: list[str] = []  # empty = no keyword exclusions
+    hidden_node_types: list[str] = []  # labels to exclude (e.g. ["Skill"])
 
 
 class AccessGrantResponse(BaseModel):
     grant_id: str
     orb_id: str
     email: str
+    keywords: list[str] = []
+    hidden_node_types: list[str] = []
     created_at: datetime
     revoked: bool
 
 
 class AccessGrantListResponse(BaseModel):
     grants: list[AccessGrantResponse]
+
+
+class AccessGrantFiltersUpdate(BaseModel):
+    keywords: list[str] = []
+    hidden_node_types: list[str] = []

--- a/backend/app/orbs/models.py
+++ b/backend/app/orbs/models.py
@@ -92,3 +92,25 @@ class AccessGrantListResponse(BaseModel):
 class AccessGrantFiltersUpdate(BaseModel):
     keywords: list[str] = []
     hidden_node_types: list[str] = []
+
+
+# ── Connection Requests ──
+
+
+class ConnectionRequestResponse(BaseModel):
+    request_id: str
+    requester_user_id: str
+    requester_email: str
+    requester_name: str
+    status: str
+    created_at: str
+    resolved_at: str | None = None
+
+
+class ConnectionRequestListResponse(BaseModel):
+    requests: list[ConnectionRequestResponse]
+
+
+class AcceptConnectionRequestBody(BaseModel):
+    keywords: list[str] = []
+    hidden_node_types: list[str] = []

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -33,9 +33,11 @@ from app.orbs.access_grants import (
     create_access_grant,
     list_access_grants,
     revoke_access_grant,
+    update_access_grant_filters,
 )
 from app.orbs.models import (
     AccessGrantCreate,
+    AccessGrantFiltersUpdate,
     AccessGrantListResponse,
     AccessGrantResponse,
     NodeCreate,
@@ -480,7 +482,11 @@ async def create_access_grant_endpoint(
     swallowed (best-effort) so the grant is still created.
     """
     grant = await create_access_grant(
-        db=db, user_id=current_user["user_id"], email=data.email
+        db=db,
+        user_id=current_user["user_id"],
+        email=data.email,
+        keywords=data.keywords,
+        hidden_node_types=data.hidden_node_types,
     )
     if grant is None:
         raise HTTPException(status_code=400, detail="Set an orb ID first")
@@ -521,6 +527,26 @@ async def revoke_access_grant_endpoint(
     return {"status": "revoked"}
 
 
+@router.put("/me/access-grants/{grant_id}/filters", response_model=AccessGrantResponse)
+async def update_access_grant_filters_endpoint(
+    grant_id: str,
+    data: AccessGrantFiltersUpdate,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Update filter scope for a specific access grant."""
+    grant = await update_access_grant_filters(
+        db=db,
+        user_id=current_user["user_id"],
+        grant_id=grant_id,
+        keywords=data.keywords,
+        hidden_node_types=data.hidden_node_types,
+    )
+    if grant is None:
+        raise HTTPException(status_code=404, detail="Grant not found")
+    return grant
+
+
 @router.get("/{orb_id}")
 @limiter.limit("30/minute")
 async def get_public_orb(
@@ -538,7 +564,9 @@ async def get_public_orb(
     token_data: dict | None = None
     if visibility == "restricted":
         # Require auth + email in allowlist (or owner)
-        await assert_user_can_access_restricted(db, orb_id, current_user)
+        token_data = await assert_user_can_access_restricted(db, orb_id, current_user)
+        if token_data is None:
+            token_data = {"keywords": [], "hidden_node_types": []}
     else:
         # public: require a valid share token
         if not token:
@@ -570,7 +598,7 @@ async def get_public_orb(
 
     orb_data = _serialize_orb(record)
 
-    # Apply filters only in public mode (token-based filtering)
+    # Apply filters in public mode (share token) and restricted mode (per-grant scope)
     keywords = token_data["keywords"] if token_data else []
     hidden_types = set(token_data.get("hidden_node_types", []) if token_data else [])
     if keywords or hidden_types:

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -109,11 +109,12 @@ def _serialize_orb(record) -> dict:
             continue
         node_data = _sanitize_neo4j_types(dict(conn["node"]))
         uid = node_data.get("uid")
-        # Deduplicate nodes
-        if uid and uid in seen_node_uids:
+        if not uid:
             continue
-        if uid:
-            seen_node_uids.add(uid)
+        # Deduplicate nodes
+        if uid in seen_node_uids:
+            continue
+        seen_node_uids.add(uid)
         node_data = decrypt_properties(node_data)
         # Remove embedding from response (too large)
         node_data.pop("embedding", None)
@@ -122,7 +123,7 @@ def _serialize_orb(record) -> dict:
         links.append(
             {
                 "source": person.get("user_id") or person.get("orb_id"),
-                "target": node_data["uid"],
+                "target": uid,
                 "type": conn["rel"],
             }
         )

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -35,11 +35,21 @@ from app.orbs.access_grants import (
     revoke_access_grant,
     update_access_grant_filters,
 )
+from app.orbs.connection_requests import (
+    accept_request,
+    create_connection_request,
+    get_my_connection_request,
+    list_pending_requests,
+    reject_request,
+)
 from app.orbs.models import (
+    AcceptConnectionRequestBody,
     AccessGrantCreate,
     AccessGrantFiltersUpdate,
     AccessGrantListResponse,
     AccessGrantResponse,
+    ConnectionRequestListResponse,
+    ConnectionRequestResponse,
     NodeCreate,
     NodeUpdate,
     OrbIdUpdate,
@@ -545,6 +555,98 @@ async def update_access_grant_filters_endpoint(
     if grant is None:
         raise HTTPException(status_code=404, detail="Grant not found")
     return grant
+
+
+# ── Connection Requests ──
+
+
+@router.post(
+    "/{orb_id}/connection-requests",
+    response_model=ConnectionRequestResponse,
+    status_code=201,
+)
+async def request_access(
+    orb_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Request access to a restricted orb."""
+    result = await create_connection_request(db=db, orb_id=orb_id, user=current_user)
+    if result is None:
+        raise HTTPException(
+            status_code=409, detail="Request already pending or orb not restricted"
+        )
+    return result
+
+
+@router.get(
+    "/{orb_id}/connection-requests/me",
+    response_model=ConnectionRequestResponse,
+)
+async def get_my_request(
+    orb_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Check if the current user has a pending request for this orb."""
+    result = await get_my_connection_request(
+        db=db, orb_id=orb_id, user_id=current_user["user_id"]
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="No pending request")
+    return result
+
+
+@router.get("/me/connection-requests", response_model=ConnectionRequestListResponse)
+async def list_my_connection_requests(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """List pending connection requests for the current user's orb."""
+    requests = await list_pending_requests(db=db, user_id=current_user["user_id"])
+    return {"requests": requests}
+
+
+@router.post(
+    "/me/connection-requests/{request_id}/accept",
+    response_model=AccessGrantResponse,
+)
+async def accept_connection_request(
+    request_id: str,
+    data: AcceptConnectionRequestBody,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Accept a connection request and create an access grant with optional filters."""
+    grant = await accept_request(
+        db=db,
+        user_id=current_user["user_id"],
+        request_id=request_id,
+        keywords=data.keywords,
+        hidden_node_types=data.hidden_node_types,
+    )
+    if grant is None:
+        raise HTTPException(
+            status_code=404, detail="Request not found or already resolved"
+        )
+    return grant
+
+
+@router.post("/me/connection-requests/{request_id}/reject")
+async def reject_connection_request(
+    request_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Reject a connection request."""
+    result = await reject_request(
+        db=db, user_id=current_user["user_id"], request_id=request_id
+    )
+    if result is None:
+        raise HTTPException(
+            status_code=404, detail="Request not found or already resolved"
+        )
+    return {"status": "rejected"}
 
 
 @router.get("/{orb_id}")

--- a/backend/app/orbs/visibility.py
+++ b/backend/app/orbs/visibility.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException
 from neo4j import AsyncDriver
 
 from app.graph.queries import GET_PERSON_BY_ORB_ID, GET_PERSON_VISIBILITY
-from app.orbs.access_grants import user_has_access
+from app.orbs.access_grants import get_access_grant_for_user
 
 
 async def get_orb_visibility(db: AsyncDriver, orb_id: str) -> str | None:
@@ -41,7 +41,7 @@ def assert_orb_accessible(visibility: str | None) -> None:
 
 async def assert_user_can_access_restricted(
     db: AsyncDriver, orb_id: str, current_user: dict | None
-) -> None:
+) -> dict[str, list[str]]:
     """Enforce the per-user allowlist on restricted orbs.
 
     Raises 401 if the caller is not authenticated, 403 if their email is
@@ -59,9 +59,14 @@ async def assert_user_can_access_restricted(
         if record is not None:
             owner_id = dict(record["p"]).get("user_id")
             if owner_id == current_user.get("user_id"):
-                return
+                return {"keywords": [], "hidden_node_types": []}
 
     if not email:
         raise HTTPException(status_code=403, detail="No email on your account")
-    if not await user_has_access(db, orb_id, email):
+    grant = await get_access_grant_for_user(db, orb_id, email)
+    if grant is None:
         raise HTTPException(status_code=403, detail="You don't have access to this orb")
+    return {
+        "keywords": list(grant.get("keywords") or []),
+        "hidden_node_types": list(grant.get("hidden_node_types") or []),
+    }

--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -289,7 +289,9 @@ async def public_text_search(  # noqa: C901
     # 2. Branch on visibility
     token_data: dict | None = None
     if visibility == "restricted":
-        token_data = await assert_user_can_access_restricted(db, data.orb_id, current_user)
+        token_data = await assert_user_can_access_restricted(
+            db, data.orb_id, current_user
+        )
         if token_data is None:
             token_data = {"keywords": [], "hidden_node_types": []}
     else:

--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -289,7 +289,9 @@ async def public_text_search(  # noqa: C901
     # 2. Branch on visibility
     token_data: dict | None = None
     if visibility == "restricted":
-        await assert_user_can_access_restricted(db, data.orb_id, current_user)
+        token_data = await assert_user_can_access_restricted(db, data.orb_id, current_user)
+        if token_data is None:
+            token_data = {"keywords": [], "hidden_node_types": []}
     else:
         if not data.token:
             raise HTTPException(

--- a/backend/tests/unit/test_access_grants.py
+++ b/backend/tests/unit/test_access_grants.py
@@ -5,8 +5,10 @@ import pytest
 from app.orbs.access_grants import (
     _normalize_email,
     create_access_grant,
+    get_access_grant_for_user,
     list_access_grants,
     revoke_access_grant,
+    update_access_grant_filters,
     user_has_access,
 )
 
@@ -41,6 +43,8 @@ async def test_create_access_grant_success():
             "grant_id": "abc",
             "orb_id": "test-orb",
             "email": "alice@x.com",
+            "keywords": ["python"],
+            "hidden_node_types": ["Skill"],
             "created_at": "2026-04-11T00:00:00+00:00",
             "revoked": False,
             "revoked_at": None,
@@ -65,13 +69,23 @@ async def test_create_access_grant_no_orb_id_returns_none():
 @pytest.mark.asyncio
 async def test_list_access_grants():
     records = [
-        {"g": {"grant_id": "g1", "email": "a@x.com", "revoked": False}},
+        {
+            "g": {
+                "grant_id": "g1",
+                "email": "a@x.com",
+                "keywords": ["python"],
+                "hidden_node_types": ["Skill"],
+                "revoked": False,
+            }
+        },
         {"g": {"grant_id": "g2", "email": "b@x.com", "revoked": False}},
     ]
     driver = _mock_driver(async_iter_records=records)
     grants = await list_access_grants(driver, "owner-1")
     assert len(grants) == 2
     assert grants[0]["grant_id"] == "g1"
+    assert grants[1]["keywords"] == []
+    assert grants[1]["hidden_node_types"] == []
 
 
 @pytest.mark.asyncio
@@ -114,3 +128,47 @@ async def test_user_has_access_empty_email_returns_false():
     driver = _mock_driver(single_return={"g": {"grant_id": "g1"}})
     # Even if the DB would have returned a match, an empty email short-circuits
     assert await user_has_access(driver, "test-orb", "") is False
+
+
+@pytest.mark.asyncio
+async def test_get_access_grant_for_user_returns_filters():
+    driver = _mock_driver(
+        single_return={
+            "g": {
+                "grant_id": "g1",
+                "email": "alice@x.com",
+                "keywords": ["python"],
+                "hidden_node_types": ["Skill"],
+                "revoked": False,
+            }
+        }
+    )
+    grant = await get_access_grant_for_user(driver, "test-orb", "ALICE@X.COM")
+    assert grant is not None
+    assert grant["keywords"] == ["python"]
+    assert grant["hidden_node_types"] == ["Skill"]
+
+
+@pytest.mark.asyncio
+async def test_update_access_grant_filters_success():
+    driver = _mock_driver(
+        single_return={
+            "g": {
+                "grant_id": "g1",
+                "email": "alice@x.com",
+                "keywords": ["python"],
+                "hidden_node_types": ["Skill"],
+                "revoked": False,
+            }
+        }
+    )
+    updated = await update_access_grant_filters(
+        driver,
+        "owner-1",
+        "g1",
+        keywords=["Python", "  AI "],
+        hidden_node_types=["Skill"],
+    )
+    assert updated is not None
+    assert updated["keywords"] == ["python", "ai"]
+    assert updated["hidden_node_types"] == ["Skill"]

--- a/backend/tests/unit/test_access_grants.py
+++ b/backend/tests/unit/test_access_grants.py
@@ -156,7 +156,7 @@ async def test_update_access_grant_filters_success():
             "g": {
                 "grant_id": "g1",
                 "email": "alice@x.com",
-                "keywords": ["python"],
+                "keywords": ["python", "ai"],
                 "hidden_node_types": ["Skill"],
                 "revoked": False,
             }

--- a/backend/tests/unit/test_connection_requests.py
+++ b/backend/tests/unit/test_connection_requests.py
@@ -1,0 +1,101 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+_SENTINEL = object()
+
+
+def _mock_db(records=None, single=_SENTINEL):
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+    if single is not _SENTINEL:
+        mock_result.single.return_value = single
+    if records is not None:
+        mock_result.__aiter__ = lambda self: iter(records)
+    mock_session.run.return_value = mock_result
+    mock_db = MagicMock()
+    mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_db, mock_session
+
+
+@pytest.mark.asyncio
+async def test_create_connection_request_success():
+    cr_node = {
+        "request_id": "req-1",
+        "requester_user_id": "user-2",
+        "requester_email": "bob@example.com",
+        "requester_name": "Bob",
+        "status": "pending",
+        "created_at": "2026-04-11T00:00:00Z",
+        "resolved_at": None,
+    }
+    db, session = _mock_db(single={"cr": cr_node, "owner_user_id": "user-1"})
+
+    from app.orbs.connection_requests import create_connection_request
+
+    result = await create_connection_request(
+        db=db, orb_id="test-orb",
+        user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
+    )
+    assert result is not None
+    assert result["request_id"] == "req-1"
+    assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_connection_request_duplicate_returns_none():
+    db, session = _mock_db(single=None)
+
+    from app.orbs.connection_requests import create_connection_request
+
+    result = await create_connection_request(
+        db=db, orb_id="test-orb",
+        user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_my_connection_request():
+    cr_node = {"request_id": "req-1", "status": "pending", "created_at": "2026-04-11T00:00:00Z", "resolved_at": None}
+    db, _ = _mock_db(single={"cr": cr_node})
+
+    from app.orbs.connection_requests import get_my_connection_request
+
+    result = await get_my_connection_request(db=db, orb_id="test-orb", user_id="user-2")
+    assert result is not None
+    assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_my_connection_request_not_found():
+    db, _ = _mock_db(single=None)
+
+    from app.orbs.connection_requests import get_my_connection_request
+
+    result = await get_my_connection_request(db=db, orb_id="test-orb", user_id="user-2")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reject_request():
+    cr_node = {"request_id": "req-1", "status": "rejected"}
+    db, _ = _mock_db(single={"cr": cr_node})
+
+    from app.orbs.connection_requests import reject_request
+
+    result = await reject_request(db=db, user_id="user-1", request_id="req-1")
+    assert result is not None
+    assert result["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_reject_request_not_found():
+    db, _ = _mock_db(single=None)
+
+    from app.orbs.connection_requests import reject_request
+
+    result = await reject_request(db=db, user_id="user-1", request_id="nonexistent")
+    assert result is None

--- a/backend/tests/unit/test_connection_requests.py
+++ b/backend/tests/unit/test_connection_requests.py
@@ -35,7 +35,8 @@ async def test_create_connection_request_success():
     from app.orbs.connection_requests import create_connection_request
 
     result = await create_connection_request(
-        db=db, orb_id="test-orb",
+        db=db,
+        orb_id="test-orb",
         user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
     )
     assert result is not None
@@ -50,7 +51,8 @@ async def test_create_connection_request_duplicate_returns_none():
     from app.orbs.connection_requests import create_connection_request
 
     result = await create_connection_request(
-        db=db, orb_id="test-orb",
+        db=db,
+        orb_id="test-orb",
         user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
     )
     assert result is None
@@ -58,7 +60,12 @@ async def test_create_connection_request_duplicate_returns_none():
 
 @pytest.mark.asyncio
 async def test_get_my_connection_request():
-    cr_node = {"request_id": "req-1", "status": "pending", "created_at": "2026-04-11T00:00:00Z", "resolved_at": None}
+    cr_node = {
+        "request_id": "req-1",
+        "status": "pending",
+        "created_at": "2026-04-11T00:00:00Z",
+        "resolved_at": None,
+    }
     db, _ = _mock_db(single={"cr": cr_node})
 
     from app.orbs.connection_requests import get_my_connection_request
@@ -163,7 +170,11 @@ async def test_accept_request_success():
         if call_count == 1:
             mock_result.single.return_value = {"cr": cr_node}
         else:
-            mock_result.single.return_value = {"g": grant_node, "orb_id": "test-orb", "owner_name": "Owner"}
+            mock_result.single.return_value = {
+                "g": grant_node,
+                "orb_id": "test-orb",
+                "owner_name": "Owner",
+            }
         return mock_result
 
     mock_session.run.side_effect = _run_side_effect
@@ -174,8 +185,11 @@ async def test_accept_request_success():
     from app.orbs.connection_requests import accept_request
 
     result = await accept_request(
-        db=mock_db, user_id="user-1", request_id="req-1",
-        keywords=["python"], hidden_node_types=["Skill"],
+        db=mock_db,
+        user_id="user-1",
+        request_id="req-1",
+        keywords=["python"],
+        hidden_node_types=["Skill"],
     )
     assert result is not None
 

--- a/backend/tests/unit/test_connection_requests.py
+++ b/backend/tests/unit/test_connection_requests.py
@@ -2,7 +2,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 _SENTINEL = object()
 
 
@@ -12,7 +11,7 @@ def _mock_db(records=None, single=_SENTINEL):
     if single is not _SENTINEL:
         mock_result.single.return_value = single
     if records is not None:
-        mock_result.__aiter__ = lambda self: iter(records)
+        mock_result.__aiter__ = lambda _self: iter(records)
     mock_session.run.return_value = mock_result
     mock_db = MagicMock()
     mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -98,4 +97,94 @@ async def test_reject_request_not_found():
     from app.orbs.connection_requests import reject_request
 
     result = await reject_request(db=db, user_id="user-1", request_id="nonexistent")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_pending_requests():
+    cr1 = {
+        "request_id": "req-1",
+        "requester_email": "a@b.com",
+        "requester_name": "Alice",
+        "status": "pending",
+        "created_at": "2026-04-11T00:00:00Z",
+        "resolved_at": None,
+    }
+
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+
+    async def _aiter(_self):
+        yield {"cr": cr1}
+
+    mock_result.__aiter__ = _aiter
+    mock_session.run.return_value = mock_result
+    mock_db = MagicMock()
+    mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    from app.orbs.connection_requests import list_pending_requests
+
+    result = await list_pending_requests(db=mock_db, user_id="user-1")
+    assert len(result) == 1
+    assert result[0]["requester_email"] == "a@b.com"
+
+
+@pytest.mark.asyncio
+async def test_accept_request_success():
+    cr_node = {
+        "request_id": "req-1",
+        "requester_user_id": "user-2",
+        "requester_email": "bob@example.com",
+        "requester_name": "Bob",
+        "status": "accepted",
+        "created_at": "2026-04-11T00:00:00Z",
+        "resolved_at": "2026-04-11T01:00:00Z",
+    }
+    grant_node = {
+        "grant_id": "grant-1",
+        "orb_id": "test-orb",
+        "email": "bob@example.com",
+        "keywords": [],
+        "hidden_node_types": [],
+        "created_at": "2026-04-11T01:00:00Z",
+        "revoked": False,
+        "revoked_at": None,
+    }
+
+    call_count = 0
+
+    mock_session = AsyncMock()
+
+    async def _run_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        mock_result = AsyncMock()
+        if call_count == 1:
+            mock_result.single.return_value = {"cr": cr_node}
+        else:
+            mock_result.single.return_value = {"g": grant_node, "orb_id": "test-orb", "owner_name": "Owner"}
+        return mock_result
+
+    mock_session.run.side_effect = _run_side_effect
+    mock_db = MagicMock()
+    mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    from app.orbs.connection_requests import accept_request
+
+    result = await accept_request(
+        db=mock_db, user_id="user-1", request_id="req-1",
+        keywords=["python"], hidden_node_types=["Skill"],
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_accept_request_not_found():
+    db, _ = _mock_db(single=None)
+
+    from app.orbs.connection_requests import accept_request
+
+    result = await accept_request(db=db, user_id="user-1", request_id="nonexistent")
     assert result is None

--- a/backend/tests/unit/test_visibility.py
+++ b/backend/tests/unit/test_visibility.py
@@ -93,24 +93,28 @@ async def test_assert_restricted_no_email_raises_403():
 
 
 @pytest.mark.asyncio
-@patch("app.orbs.visibility.user_has_access", new_callable=AsyncMock)
-async def test_assert_restricted_allowed_email_passes(mock_has_access):
+@patch("app.orbs.visibility.get_access_grant_for_user", new_callable=AsyncMock)
+async def test_assert_restricted_allowed_email_passes(mock_get_grant):
     person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
     driver = _mock_driver_with_record({"p": person})
-    mock_has_access.return_value = True
+    mock_get_grant.return_value = {
+        "grant_id": "g-1",
+        "keywords": ["python"],
+        "hidden_node_types": ["Skill"],
+    }
     # Should not raise
     await assert_user_can_access_restricted(
         driver, "test-orb", {"user_id": "viewer-1", "email": "alice@x.com"}
     )
-    mock_has_access.assert_awaited_once()
+    mock_get_grant.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-@patch("app.orbs.visibility.user_has_access", new_callable=AsyncMock)
-async def test_assert_restricted_unallowed_email_raises_403(mock_has_access):
+@patch("app.orbs.visibility.get_access_grant_for_user", new_callable=AsyncMock)
+async def test_assert_restricted_unallowed_email_raises_403(mock_get_grant):
     person = MockNode({"user_id": "owner-1", "orb_id": "test-orb"}, ["Person"])
     driver = _mock_driver_with_record({"p": person})
-    mock_has_access.return_value = False
+    mock_get_grant.return_value = None
     with pytest.raises(HTTPException) as exc:
         await assert_user_can_access_restricted(
             driver, "test-orb", {"user_id": "viewer-1", "email": "bob@x.com"}

--- a/docs/superpowers/plans/2026-04-11-connection-request-flow.md
+++ b/docs/superpowers/plans/2026-04-11-connection-request-flow.md
@@ -1,0 +1,817 @@
+# Connection Request Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow authenticated visitors to request access to restricted orbs, with owner approval/rejection and filter configuration.
+
+**Architecture:** New `ConnectionRequest` Neo4j node linked to the owner's Person. Service layer in `connection_requests.py` follows the `access_grants.py` pattern. On accept, reuses `create_access_grant` to produce an AccessGrant. Frontend adds a "Request Access" button to SharedOrbPage and a "Pending Requests" section to the OrbViewPage restricted modal.
+
+**Tech Stack:** Python/FastAPI, Neo4j (Cypher), React/TypeScript
+
+---
+
+### Task 1: Add Neo4j schema and Cypher queries
+
+**Files:**
+- Modify: `infra/neo4j/init.cypher`
+- Modify: `backend/app/graph/queries.py`
+
+- [ ] **Step 1: Add constraints and indexes to `infra/neo4j/init.cypher`**
+
+Append at the end:
+
+```cypher
+// Connection requests for restricted orbs
+CREATE CONSTRAINT connection_request_id IF NOT EXISTS FOR (cr:ConnectionRequest) REQUIRE cr.request_id IS UNIQUE;
+CREATE INDEX connection_request_status IF NOT EXISTS FOR (cr:ConnectionRequest) ON (cr.status);
+CREATE INDEX connection_request_requester IF NOT EXISTS FOR (cr:ConnectionRequest) ON (cr.requester_user_id);
+```
+
+- [ ] **Step 2: Add Cypher queries to `backend/app/graph/queries.py`**
+
+Append after the Access Grants section:
+
+```python
+# ── Connection Requests ──
+
+CREATE_CONNECTION_REQUEST = """
+MATCH (p:Person {orb_id: $orb_id})
+WHERE p.visibility = 'restricted'
+OPTIONAL MATCH (p)-[:HAS_CONNECTION_REQUEST]->(existing:ConnectionRequest {
+    requester_user_id: $requester_user_id, status: 'pending'
+})
+WITH p, existing
+WHERE existing IS NULL
+CREATE (p)-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {
+    request_id: $request_id,
+    requester_user_id: $requester_user_id,
+    requester_email: $requester_email,
+    requester_name: $requester_name,
+    status: 'pending',
+    created_at: datetime(),
+    resolved_at: null
+})
+RETURN cr, p.user_id AS owner_user_id
+"""
+
+GET_CONNECTION_REQUEST_BY_REQUESTER = """
+MATCH (p:Person {orb_id: $orb_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {
+    requester_user_id: $requester_user_id, status: 'pending'
+})
+RETURN cr
+"""
+
+LIST_PENDING_CONNECTION_REQUESTS = """
+MATCH (p:Person {user_id: $user_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {status: 'pending'})
+RETURN cr
+ORDER BY cr.created_at DESC
+"""
+
+UPDATE_CONNECTION_REQUEST_STATUS = """
+MATCH (p:Person {user_id: $user_id})-[:HAS_CONNECTION_REQUEST]->(cr:ConnectionRequest {request_id: $request_id})
+WHERE cr.status = 'pending'
+SET cr.status = $status, cr.resolved_at = datetime()
+RETURN cr
+"""
+```
+
+- [ ] **Step 3: Run init.cypher against Neo4j**
+
+```bash
+cat infra/neo4j/init.cypher | docker exec -i orb_project-neo4j-1 cypher-shell -u neo4j -p orbis_dev_password
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/neo4j/init.cypher backend/app/graph/queries.py
+git commit -m "feat: add ConnectionRequest schema and Cypher queries (#264)"
+```
+
+---
+
+### Task 2: Create connection request service
+
+**Files:**
+- Create: `backend/app/orbs/connection_requests.py`
+- Create: `backend/tests/unit/test_connection_requests.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/unit/test_connection_requests.py
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _mock_db(records=None, single=None):
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+    if single is not None:
+        mock_result.single.return_value = single
+    if records is not None:
+        mock_result.__aiter__ = lambda self: iter(records)
+    mock_session.run.return_value = mock_result
+    mock_db = MagicMock()
+    mock_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_db, mock_session
+
+
+@pytest.mark.asyncio
+async def test_create_connection_request_success():
+    cr_node = {
+        "request_id": "req-1",
+        "requester_user_id": "user-2",
+        "requester_email": "bob@example.com",
+        "requester_name": "Bob",
+        "status": "pending",
+        "created_at": "2026-04-11T00:00:00Z",
+        "resolved_at": None,
+    }
+    db, session = _mock_db(single={"cr": cr_node, "owner_user_id": "user-1"})
+
+    from app.orbs.connection_requests import create_connection_request
+
+    result = await create_connection_request(
+        db=db, orb_id="test-orb",
+        user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
+    )
+    assert result is not None
+    assert result["request_id"] == "req-1"
+    assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_connection_request_duplicate_returns_none():
+    db, session = _mock_db(single=None)
+
+    from app.orbs.connection_requests import create_connection_request
+
+    result = await create_connection_request(
+        db=db, orb_id="test-orb",
+        user={"user_id": "user-2", "email": "bob@example.com", "name": "Bob"},
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_my_connection_request():
+    cr_node = {"request_id": "req-1", "status": "pending", "created_at": "2026-04-11T00:00:00Z", "resolved_at": None}
+    db, _ = _mock_db(single={"cr": cr_node})
+
+    from app.orbs.connection_requests import get_my_connection_request
+
+    result = await get_my_connection_request(db=db, orb_id="test-orb", user_id="user-2")
+    assert result is not None
+    assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_list_pending_requests():
+    cr1 = MagicMock()
+    cr1.__getitem__ = lambda self, key: {"request_id": "req-1", "requester_email": "a@b.com", "status": "pending", "created_at": "2026-04-11T00:00:00Z", "resolved_at": None}[key]
+    db, _ = _mock_db(records=[{"cr": cr1}])
+
+    from app.orbs.connection_requests import list_pending_requests
+
+    result = await list_pending_requests(db=db, user_id="user-1")
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_request():
+    cr_node = {"request_id": "req-1", "requester_email": "bob@example.com", "status": "accepted"}
+    db, _ = _mock_db(single={"cr": cr_node})
+
+    from app.orbs.connection_requests import accept_request
+
+    result = await accept_request(
+        db=db, user_id="user-1", request_id="req-1",
+        keywords=["python"], hidden_node_types=["Skill"],
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_reject_request():
+    cr_node = {"request_id": "req-1", "status": "rejected"}
+    db, _ = _mock_db(single={"cr": cr_node})
+
+    from app.orbs.connection_requests import reject_request
+
+    result = await reject_request(db=db, user_id="user-1", request_id="req-1")
+    assert result is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_connection_requests.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create the service**
+
+```python
+# backend/app/orbs/connection_requests.py
+"""Connection request service for restricted orbs."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from neo4j import AsyncDriver
+from neo4j.time import DateTime as Neo4jDateTime
+
+from app.graph.queries import (
+    CREATE_CONNECTION_REQUEST,
+    GET_CONNECTION_REQUEST_BY_REQUESTER,
+    LIST_PENDING_CONNECTION_REQUESTS,
+    UPDATE_CONNECTION_REQUEST_STATUS,
+)
+from app.orbs.access_grants import create_access_grant
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize(d: dict) -> dict:
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, Neo4jDateTime):
+            result[k] = v.iso_format()
+        else:
+            result[k] = v
+    return result
+
+
+async def create_connection_request(
+    db: AsyncDriver,
+    orb_id: str,
+    user: dict,
+) -> dict | None:
+    """Create a pending connection request. Returns None if duplicate."""
+    request_id = str(uuid.uuid4())
+    async with db.session() as session:
+        result = await session.run(
+            CREATE_CONNECTION_REQUEST,
+            request_id=request_id,
+            orb_id=orb_id,
+            requester_user_id=user["user_id"],
+            requester_email=(user.get("email") or "").strip().lower(),
+            requester_name=user.get("name") or "",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))
+
+
+async def get_my_connection_request(
+    db: AsyncDriver,
+    orb_id: str,
+    user_id: str,
+) -> dict | None:
+    """Get the current user's pending request for an orb."""
+    async with db.session() as session:
+        result = await session.run(
+            GET_CONNECTION_REQUEST_BY_REQUESTER,
+            orb_id=orb_id,
+            requester_user_id=user_id,
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))
+
+
+async def list_pending_requests(
+    db: AsyncDriver,
+    user_id: str,
+) -> list[dict]:
+    """List all pending connection requests for the owner's orb."""
+    async with db.session() as session:
+        result = await session.run(
+            LIST_PENDING_CONNECTION_REQUESTS,
+            user_id=user_id,
+        )
+        return [_sanitize(dict(r["cr"])) async for r in result]
+
+
+async def accept_request(
+    db: AsyncDriver,
+    user_id: str,
+    request_id: str,
+    keywords: list[str] | None = None,
+    hidden_node_types: list[str] | None = None,
+) -> dict | None:
+    """Accept a request: update status and create an AccessGrant."""
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_CONNECTION_REQUEST_STATUS,
+            user_id=user_id,
+            request_id=request_id,
+            status="accepted",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        cr = _sanitize(dict(record["cr"]))
+
+    # Create AccessGrant for the requester
+    grant = await create_access_grant(
+        db=db,
+        user_id=user_id,
+        email=cr["requester_email"],
+        keywords=keywords,
+        hidden_node_types=hidden_node_types,
+    )
+    return grant
+
+
+async def reject_request(
+    db: AsyncDriver,
+    user_id: str,
+    request_id: str,
+) -> dict | None:
+    """Reject a connection request."""
+    async with db.session() as session:
+        result = await session.run(
+            UPDATE_CONNECTION_REQUEST_STATUS,
+            user_id=user_id,
+            request_id=request_id,
+            status="rejected",
+        )
+        record = await result.single()
+        if record is None:
+            return None
+        return _sanitize(dict(record["cr"]))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_connection_requests.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/orbs/connection_requests.py backend/tests/unit/test_connection_requests.py
+git commit -m "feat: add connection request service (#264)"
+```
+
+---
+
+### Task 3: Add backend endpoints
+
+**Files:**
+- Modify: `backend/app/orbs/models.py` — add request/response models
+- Modify: `backend/app/orbs/router.py` — add endpoints
+
+- [ ] **Step 1: Add Pydantic models to `backend/app/orbs/models.py`**
+
+Append after the AccessGrant models:
+
+```python
+# ── Connection Requests ──
+
+
+class ConnectionRequestResponse(BaseModel):
+    request_id: str
+    requester_user_id: str
+    requester_email: str
+    requester_name: str
+    status: str
+    created_at: str
+    resolved_at: str | None = None
+
+
+class ConnectionRequestListResponse(BaseModel):
+    requests: list[ConnectionRequestResponse]
+
+
+class AcceptConnectionRequestBody(BaseModel):
+    keywords: list[str] = []
+    hidden_node_types: list[str] = []
+```
+
+- [ ] **Step 2: Add endpoints to `backend/app/orbs/router.py`**
+
+Add imports at the top:
+
+```python
+from app.orbs.connection_requests import (
+    accept_request,
+    create_connection_request,
+    get_my_connection_request,
+    list_pending_requests,
+    reject_request,
+)
+from app.orbs.models import (
+    AcceptConnectionRequestBody,
+    ConnectionRequestListResponse,
+    ConnectionRequestResponse,
+)
+```
+
+Add endpoints after the access grants section:
+
+```python
+# ── Connection Requests ──
+
+
+@router.post("/{orb_id}/connection-requests", response_model=ConnectionRequestResponse, status_code=201)
+async def request_access(
+    orb_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Request access to a restricted orb."""
+    result = await create_connection_request(db=db, orb_id=orb_id, user=current_user)
+    if result is None:
+        raise HTTPException(status_code=409, detail="Request already pending or orb not restricted")
+    return result
+
+
+@router.get("/{orb_id}/connection-requests/me", response_model=ConnectionRequestResponse)
+async def get_my_request(
+    orb_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Check if the current user has a pending request for this orb."""
+    result = await get_my_connection_request(db=db, orb_id=orb_id, user_id=current_user["user_id"])
+    if result is None:
+        raise HTTPException(status_code=404, detail="No pending request")
+    return result
+
+
+@router.get("/me/connection-requests", response_model=ConnectionRequestListResponse)
+async def list_my_connection_requests(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """List pending connection requests for the current user's orb."""
+    requests = await list_pending_requests(db=db, user_id=current_user["user_id"])
+    return {"requests": requests}
+
+
+@router.post("/me/connection-requests/{request_id}/accept", response_model=AccessGrantResponse)
+async def accept_connection_request(
+    request_id: str,
+    data: AcceptConnectionRequestBody,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Accept a connection request and create an access grant with optional filters."""
+    grant = await accept_request(
+        db=db,
+        user_id=current_user["user_id"],
+        request_id=request_id,
+        keywords=data.keywords,
+        hidden_node_types=data.hidden_node_types,
+    )
+    if grant is None:
+        raise HTTPException(status_code=404, detail="Request not found or already resolved")
+    return grant
+
+
+@router.post("/me/connection-requests/{request_id}/reject")
+async def reject_connection_request(
+    request_id: str,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Reject a connection request."""
+    result = await reject_request(db=db, user_id=current_user["user_id"], request_id=request_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Request not found or already resolved")
+    return {"status": "rejected"}
+```
+
+IMPORTANT: The `/{orb_id}/connection-requests` routes must be placed BEFORE the `/{orb_id}` catch-all route (the `get_public_orb` endpoint) to avoid being matched by it. Check the router ordering.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/orbs/models.py backend/app/orbs/router.py
+git commit -m "feat: add connection request endpoints (#264)"
+```
+
+---
+
+### Task 4: Add frontend API functions and SharedOrbPage "Request Access" button
+
+**Files:**
+- Modify: `frontend/src/api/orbs.ts` — add connection request API functions
+- Modify: `frontend/src/pages/SharedOrbPage.tsx` — add Request Access button
+
+- [ ] **Step 1: Add types and API functions to `frontend/src/api/orbs.ts`**
+
+```typescript
+export interface ConnectionRequest {
+  request_id: string;
+  requester_user_id: string;
+  requester_email: string;
+  requester_name: string;
+  status: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export async function requestAccess(orbId: string): Promise<ConnectionRequest> {
+  const { data } = await client.post(`/orbs/${orbId}/connection-requests`);
+  return data;
+}
+
+export async function getMyConnectionRequest(orbId: string): Promise<ConnectionRequest | null> {
+  try {
+    const { data } = await client.get(`/orbs/${orbId}/connection-requests/me`);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export async function listConnectionRequests(): Promise<ConnectionRequest[]> {
+  const { data } = await client.get('/orbs/me/connection-requests');
+  return data.requests;
+}
+
+export async function acceptConnectionRequest(
+  requestId: string,
+  filters: { keywords: string[]; hidden_node_types: string[] },
+): Promise<void> {
+  await client.post(`/orbs/me/connection-requests/${requestId}/accept`, filters);
+}
+
+export async function rejectConnectionRequest(requestId: string): Promise<void> {
+  await client.post(`/orbs/me/connection-requests/${requestId}/reject`);
+}
+```
+
+- [ ] **Step 2: Update SharedOrbPage — add "Request Access" button**
+
+In `frontend/src/pages/SharedOrbPage.tsx`, find the `isNoAccess` error block. The current code shows a title and message. Add state and a button.
+
+Add imports at the top:
+
+```typescript
+import { requestAccess, getMyConnectionRequest } from '../api/orbs';
+```
+
+Add state variables inside the component (near the other useState calls):
+
+```typescript
+const [requestPending, setRequestPending] = useState(false);
+const [requestSubmitting, setRequestSubmitting] = useState(false);
+const [requestChecked, setRequestChecked] = useState(false);
+```
+
+Add a useEffect that checks for existing pending request when the error is "no access" and user is authenticated:
+
+```typescript
+useEffect(() => {
+  if (!isNoAccess || !user || !orbId || requestChecked) return;
+  getMyConnectionRequest(orbId).then((req) => {
+    if (req) setRequestPending(true);
+    setRequestChecked(true);
+  });
+}, [isNoAccess, user, orbId, requestChecked]);
+```
+
+Note: `isNoAccess` is computed inside the error block. You'll need to hoist the computation above the useEffect. Compute it from the `error` state:
+
+```typescript
+const isNoAccess = !!error && error.toLowerCase().includes("don't have access");
+```
+
+Place this line near the other derived state (before the useEffect).
+
+In the error block's JSX, for the `isNoAccess` branch, add the button after the message paragraph:
+
+```tsx
+{isNoAccess && user && (
+  <button
+    onClick={async () => {
+      if (!orbId || requestPending || requestSubmitting) return;
+      setRequestSubmitting(true);
+      try {
+        await requestAccess(orbId);
+        setRequestPending(true);
+      } catch {
+        // Already pending or failed
+      } finally {
+        setRequestSubmitting(false);
+      }
+    }}
+    disabled={requestPending || requestSubmitting}
+    className={`mt-4 px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
+      requestPending
+        ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
+        : 'bg-purple-600 hover:bg-purple-500 text-white'
+    }`}
+  >
+    {requestSubmitting ? 'Sending...' : requestPending ? 'Request Pending' : 'Request Access'}
+  </button>
+)}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/orbs.ts frontend/src/pages/SharedOrbPage.tsx
+git commit -m "feat: add Request Access button to SharedOrbPage (#264)"
+```
+
+---
+
+### Task 5: Add "Pending Requests" section to OrbViewPage restricted modal
+
+**Files:**
+- Modify: `frontend/src/pages/OrbViewPage.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+Add imports at the top of OrbViewPage.tsx:
+
+```typescript
+import { listConnectionRequests, acceptConnectionRequest, rejectConnectionRequest, type ConnectionRequest } from '../api/orbs';
+```
+
+Add state variables near the other restricted-section state:
+
+```typescript
+const [pendingRequests, setPendingRequests] = useState<ConnectionRequest[]>([]);
+const [pendingLoading, setPendingLoading] = useState(false);
+const [acceptingRequestId, setAcceptingRequestId] = useState<string | null>(null);
+const [acceptKeywords, setAcceptKeywords] = useState('');
+const [acceptHiddenTypes, setAcceptHiddenTypes] = useState('');
+const [rejectingRequestId, setRejectingRequestId] = useState<string | null>(null);
+```
+
+- [ ] **Step 2: Add fetch effect**
+
+Near the existing grants fetch effect, add:
+
+```typescript
+useEffect(() => {
+  if (!isRestricted) return;
+  setPendingLoading(true);
+  listConnectionRequests()
+    .then(setPendingRequests)
+    .catch(() => {})
+    .finally(() => setPendingLoading(false));
+}, [isRestricted]);
+```
+
+- [ ] **Step 3: Add handler functions**
+
+```typescript
+const handleAcceptRequest = async (requestId: string) => {
+  const keywords = acceptKeywords.split(',').map(k => k.trim()).filter(Boolean);
+  const hiddenTypes = acceptHiddenTypes.split(',').map(t => t.trim()).filter(Boolean);
+  try {
+    await acceptConnectionRequest(requestId, { keywords, hidden_node_types: hiddenTypes });
+    setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
+    setAcceptingRequestId(null);
+    setAcceptKeywords('');
+    setAcceptHiddenTypes('');
+    // Refresh grants list
+    listAccessGrants().then(g => setGrants(g));
+    addToast('Access granted', 'success');
+  } catch {
+    addToast('Failed to accept request', 'error');
+  }
+};
+
+const handleRejectRequest = async (requestId: string) => {
+  setRejectingRequestId(requestId);
+  try {
+    await rejectConnectionRequest(requestId);
+    setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
+    addToast('Request rejected', 'success');
+  } catch {
+    addToast('Failed to reject request', 'error');
+  } finally {
+    setRejectingRequestId(null);
+  }
+};
+```
+
+- [ ] **Step 4: Add "Pending Requests" JSX**
+
+In the restricted section of OrbViewPage, BEFORE the "Invite By Email" section, add:
+
+```tsx
+{pendingRequests.length > 0 && (
+  <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+    <div className="flex items-center justify-between gap-2 mb-3">
+      <label className="text-xs text-amber-200/80 uppercase tracking-wide font-medium">Pending Requests</label>
+      <span className="text-[11px] text-amber-200/60">{pendingRequests.length}</span>
+    </div>
+    <div className="space-y-2 max-h-64 overflow-y-auto">
+      {pendingRequests.map((req) => (
+        <div key={req.request_id} className="border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60 space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm text-white truncate">{req.requester_name || req.requester_email}</p>
+              <p className="text-[11px] text-gray-400 mt-0.5">{req.requester_email}</p>
+              <p className="text-[10px] text-gray-500 mt-0.5">{formatDate(req.created_at)}</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setAcceptingRequestId(acceptingRequestId === req.request_id ? null : req.request_id);
+                  setAcceptKeywords('');
+                  setAcceptHiddenTypes('');
+                }}
+                className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRejectRequest(req.request_id)}
+                disabled={rejectingRequestId === req.request_id}
+                className="h-8 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
+              >
+                {rejectingRequestId === req.request_id ? 'Rejecting...' : 'Reject'}
+              </button>
+            </div>
+          </div>
+
+          {acceptingRequestId === req.request_id && (
+            <div className="rounded-lg border border-gray-700/70 bg-gray-900/60 p-2.5 space-y-2">
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Filtered Keywords (comma separated)</label>
+                <input
+                  type="text"
+                  value={acceptKeywords}
+                  onChange={(e) => setAcceptKeywords(e.target.value)}
+                  placeholder="python, machine learning"
+                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                />
+              </div>
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Hidden Node Types (comma separated)</label>
+                <input
+                  type="text"
+                  value={acceptHiddenTypes}
+                  onChange={(e) => setAcceptHiddenTypes(e.target.value)}
+                  placeholder="Skill, Project"
+                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleAcceptRequest(req.request_id)}
+                  className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
+                >
+                  Confirm & Grant Access
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAcceptingRequestId(null)}
+                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Run backend tests**
+
+Run: `cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/OrbViewPage.tsx
+git commit -m "feat: add Pending Requests section to restricted share modal (#264)"
+```

--- a/docs/superpowers/specs/2026-04-11-connection-request-flow-design.md
+++ b/docs/superpowers/specs/2026-04-11-connection-request-flow-design.md
@@ -1,0 +1,150 @@
+# Connection Request Flow for Restricted Orbs — Design Spec
+
+**Issue:** #264 — Restricted orb: connection request flow with pending approval
+**Date:** 2026-04-11
+
+## Goal
+
+Allow authenticated visitors to request access to a restricted orb. The owner
+reviews pending requests in the share modal, and accepts (with filter
+configuration) or rejects each one.
+
+## Data Model
+
+### New node: ConnectionRequest
+
+```
+(Person)-[:HAS_CONNECTION_REQUEST]->(ConnectionRequest {
+    request_id: str,            # UUID
+    requester_user_id: str,     # user_id of the requester
+    requester_email: str,
+    requester_name: str,
+    status: str,                # "pending" | "accepted" | "rejected"
+    created_at: datetime,
+    resolved_at: datetime | null
+})
+```
+
+The owner's Person node owns the requests via `HAS_CONNECTION_REQUEST`.
+
+**Constraints:**
+- `ConnectionRequest.request_id IS UNIQUE`
+
+**Indexes:**
+- `ConnectionRequest.status` (for filtering pending requests)
+- `ConnectionRequest.requester_user_id` (for checking if user already requested)
+
+## Backend
+
+### New endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/orbs/{orb_id}/connection-requests` | Required | Create a pending request |
+| `GET` | `/orbs/{orb_id}/connection-requests/me` | Required | Check if current user has a pending request |
+| `GET` | `/orbs/me/connection-requests` | Required | Owner lists pending requests |
+| `POST` | `/orbs/me/connection-requests/{request_id}/accept` | Required | Accept + create AccessGrant |
+| `POST` | `/orbs/me/connection-requests/{request_id}/reject` | Required | Reject request |
+
+### POST `/orbs/{orb_id}/connection-requests`
+
+- Requires authentication.
+- Checks that the orb exists and is restricted.
+- Checks that the requester doesn't already have an active grant.
+- Checks that the requester doesn't already have a pending request.
+- Creates a `ConnectionRequest` node with status "pending".
+- Returns 201 with the request record.
+
+### GET `/orbs/{orb_id}/connection-requests/me`
+
+- Returns the current user's pending request for this orb, or 404 if none.
+- Used by SharedOrbPage to show "Request Pending" state.
+
+### GET `/orbs/me/connection-requests`
+
+- Returns all pending `ConnectionRequest` nodes for the current user's orb.
+- Ordered by `created_at DESC`.
+
+### POST `/orbs/me/connection-requests/{request_id}/accept`
+
+- Request body: `{ keywords: string[], hidden_node_types: string[] }` (both optional, default empty).
+- Sets `ConnectionRequest.status = "accepted"` and `resolved_at = datetime()`.
+- Creates an `AccessGrant` for the requester's email with the specified filters.
+- Reuses existing `create_access_grant` logic.
+- Returns the created grant.
+
+### POST `/orbs/me/connection-requests/{request_id}/reject`
+
+- Sets `ConnectionRequest.status = "rejected"` and `resolved_at = datetime()`.
+- Returns 200.
+
+### New service file
+
+`backend/app/orbs/connection_requests.py` — contains all business logic:
+- `create_connection_request(db, orb_id, user)`
+- `get_my_connection_request(db, orb_id, user_id)`
+- `list_pending_requests(db, user_id)`
+- `accept_request(db, user_id, request_id, keywords, hidden_node_types)`
+- `reject_request(db, user_id, request_id)`
+
+### New Cypher queries
+
+Added to `backend/app/graph/queries.py`:
+- `CREATE_CONNECTION_REQUEST`
+- `GET_CONNECTION_REQUEST_BY_REQUESTER`
+- `LIST_PENDING_CONNECTION_REQUESTS`
+- `ACCEPT_CONNECTION_REQUEST`
+- `REJECT_CONNECTION_REQUEST`
+
+## Frontend
+
+### SharedOrbPage — requester side
+
+In the error block where `title = "You don't have access"`:
+
+- If user is authenticated, show a "Request Access" button.
+- On mount, call `GET /orbs/{orb_id}/connection-requests/me` to check for existing request.
+- If pending request exists, show "Request Pending" (disabled button with muted styling).
+- On click: `POST /orbs/{orb_id}/connection-requests`, switch to pending state.
+
+### OrbViewPage — owner side (restricted modal)
+
+Add a "Pending Requests" section between the "Invite By Email" section and "People With Access":
+
+- Calls `GET /orbs/me/connection-requests` on modal open.
+- Lists each pending request: requester name, email, timestamp.
+- Each request has "Accept" and "Reject" buttons.
+- **Accept flow**: clicking "Accept" expands an inline filter editor below the request (same fields as existing grant filter editor: keywords textarea + hidden node types textarea). A "Confirm" button creates the grant with filters. A "Cancel" button collapses the editor.
+- **Reject flow**: clicking "Reject" calls the reject endpoint and removes the request from the list.
+
+### New API functions
+
+In `frontend/src/api/orbs.ts`:
+- `requestAccess(orbId: string): Promise<ConnectionRequest>`
+- `getMyConnectionRequest(orbId: string): Promise<ConnectionRequest | null>`
+
+In `frontend/src/api/admin.ts` or a new `frontend/src/api/connectionRequests.ts`:
+- `listConnectionRequests(): Promise<ConnectionRequest[]>`
+- `acceptConnectionRequest(requestId: string, filters: { keywords: string[], hidden_node_types: string[] }): Promise<void>`
+- `rejectConnectionRequest(requestId: string): Promise<void>`
+
+## Neo4j Schema Updates
+
+Add to `infra/neo4j/init.cypher`:
+
+```cypher
+CREATE CONSTRAINT connection_request_id IF NOT EXISTS
+  FOR (cr:ConnectionRequest) REQUIRE cr.request_id IS UNIQUE;
+CREATE INDEX connection_request_status IF NOT EXISTS
+  FOR (cr:ConnectionRequest) ON (cr.status);
+CREATE INDEX connection_request_requester IF NOT EXISTS
+  FOR (cr:ConnectionRequest) ON (cr.requester_user_id);
+```
+
+## Testing
+
+- Unit tests for each service function (mock Neo4j).
+- Test duplicate request prevention.
+- Test accept creates AccessGrant with correct filters.
+- Test reject updates status.
+- Test requester can check their own request status.

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -83,12 +83,25 @@ export interface AccessGrant {
   grant_id: string;
   orb_id: string;
   email: string;
+  keywords: string[];
+  hidden_node_types: string[];
   created_at: string;
   revoked: boolean;
 }
 
-export async function createAccessGrant(email: string): Promise<AccessGrant> {
-  const { data } = await client.post('/orbs/me/access-grants', { email });
+export interface AccessGrantCreatePayload {
+  email: string;
+  keywords?: string[];
+  hidden_node_types?: string[];
+}
+
+export interface AccessGrantFiltersUpdatePayload {
+  keywords: string[];
+  hidden_node_types: string[];
+}
+
+export async function createAccessGrant(payload: AccessGrantCreatePayload): Promise<AccessGrant> {
+  const { data } = await client.post('/orbs/me/access-grants', payload);
   return data;
 }
 
@@ -99,6 +112,14 @@ export async function listAccessGrants(): Promise<{ grants: AccessGrant[] }> {
 
 export async function revokeAccessGrant(grantId: string): Promise<void> {
   await client.delete(`/orbs/me/access-grants/${grantId}`);
+}
+
+export async function updateAccessGrantFilters(
+  grantId: string,
+  payload: AccessGrantFiltersUpdatePayload,
+): Promise<AccessGrant> {
+  const { data } = await client.put(`/orbs/me/access-grants/${grantId}/filters`, payload);
+  return data;
 }
 
 export async function addNode(nodeType: string, properties: Record<string, unknown>): Promise<OrbNode> {

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -236,3 +236,45 @@ export async function deleteVersion(snapshotId: string): Promise<void> {
 export async function submitIdea(text: string): Promise<void> {
   await client.post('/ideas', { text });
 }
+
+// ── Connection Requests ──
+
+export interface ConnectionRequest {
+  request_id: string;
+  requester_user_id: string;
+  requester_email: string;
+  requester_name: string;
+  status: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export async function requestAccess(orbId: string): Promise<ConnectionRequest> {
+  const { data } = await client.post(`/orbs/${orbId}/connection-requests`);
+  return data;
+}
+
+export async function getMyConnectionRequest(orbId: string): Promise<ConnectionRequest | null> {
+  try {
+    const { data } = await client.get(`/orbs/${orbId}/connection-requests/me`);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export async function listConnectionRequests(): Promise<ConnectionRequest[]> {
+  const { data } = await client.get('/orbs/me/connection-requests');
+  return data.requests;
+}
+
+export async function acceptConnectionRequest(
+  requestId: string,
+  filters: { keywords: string[]; hidden_node_types: string[] },
+): Promise<void> {
+  await client.post(`/orbs/me/connection-requests/${requestId}/accept`, filters);
+}
+
+export async function rejectConnectionRequest(requestId: string): Promise<void> {
+  await client.post(`/orbs/me/connection-requests/${requestId}/reject`);
+}

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from 'react';
 import { textSearch } from '../../api/orbs';
-import type { OrbNode } from '../../api/orbs';
+import type { OrbNode, OrbVisibility } from '../../api/orbs';
 import { NODE_TYPE_COLORS } from '../graph/NodeColors';
 
 interface ChatMessage {
@@ -25,6 +25,7 @@ interface ChatBoxProps {
   searchFn?: (query: string) => Promise<OrbNode[]>;
   interactionHint?: string;
   onRecenter?: () => void;
+  visibility?: OrbVisibility;
 }
 
 export type { ChatMessage };
@@ -92,6 +93,7 @@ export default function ChatBox({
   searchFn = textSearch,
   interactionHint = 'Zoom: mouse wheel · Pan: right-drag · Rotate: left-drag',
   onRecenter,
+  visibility = 'public',
 }: ChatBoxProps) {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -120,6 +122,11 @@ export default function ChatBox({
     () => [...messages].reverse().find((msg) => msg.role === 'user')?.text ?? '',
     [messages],
   );
+  const shareButtonClass = visibility === 'private'
+    ? 'bg-red-600/80 hover:bg-red-500 border-red-500/35 hover:border-red-400/55 shadow-red-600/25'
+    : visibility === 'restricted'
+      ? 'bg-orange-600/80 hover:bg-orange-500 border-orange-500/35 hover:border-orange-400/55 shadow-orange-600/25'
+      : 'bg-emerald-600/80 hover:bg-emerald-500 border-emerald-500/35 hover:border-emerald-400/55 shadow-emerald-600/25';
 
   const clearResults = useCallback(() => {
     onMessagesChange([]);
@@ -471,7 +478,7 @@ export default function ChatBox({
             {onShare && (
               <button
                 onClick={onShare}
-                className="w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-green-600/80 hover:bg-green-500 border border-green-500/30 hover:border-green-400/50 text-white/90 hover:text-white transition-all shadow-lg shadow-green-600/20"
+                className={`w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center border text-white/90 hover:text-white transition-all shadow-lg ${shareButtonClass}`}
                 title="Share"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -122,11 +122,7 @@ export default function ChatBox({
     () => [...messages].reverse().find((msg) => msg.role === 'user')?.text ?? '',
     [messages],
   );
-  const shareButtonClass = visibility === 'private'
-    ? 'bg-red-600/80 hover:bg-red-500 border-red-500/35 hover:border-red-400/55 shadow-red-600/25'
-    : visibility === 'restricted'
-      ? 'bg-orange-600/80 hover:bg-orange-500 border-orange-500/35 hover:border-orange-400/55 shadow-orange-600/25'
-      : 'bg-emerald-600/80 hover:bg-emerald-500 border-emerald-500/35 hover:border-emerald-400/55 shadow-emerald-600/25';
+  const shareButtonClass = 'bg-orange-600/80 hover:bg-orange-500 border-orange-500/35 hover:border-orange-400/55 shadow-orange-600/25';
 
   const clearResults = useCallback(() => {
     onMessagesChange([]);

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -122,7 +122,9 @@ export default function ChatBox({
     () => [...messages].reverse().find((msg) => msg.role === 'user')?.text ?? '',
     [messages],
   );
-  const shareButtonClass = 'bg-orange-600/80 hover:bg-orange-500 border-orange-500/35 hover:border-orange-400/55 shadow-orange-600/25';
+  const shareButtonClass = visibility === 'restricted'
+    ? 'bg-emerald-600/80 hover:bg-emerald-500 border-emerald-500/35 hover:border-emerald-400/55 shadow-emerald-600/25'
+    : 'bg-orange-600/80 hover:bg-orange-500 border-orange-500/35 hover:border-orange-400/55 shadow-orange-600/25';
 
   const clearResults = useCallback(() => {
     onMessagesChange([]);

--- a/frontend/src/components/cv/KeywordFilterDropdown.tsx
+++ b/frontend/src/components/cv/KeywordFilterDropdown.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useFilterStore } from '../../stores/filterStore';
 
 export default function KeywordFilterDropdown() {
-  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
+  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword, deactivateAll } = useFilterStore();
   const [open, setOpen] = useState(false);
   const [newKeyword, setNewKeyword] = useState('');
   const ref = useRef<HTMLDivElement>(null);
@@ -64,7 +64,7 @@ export default function KeywordFilterDropdown() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -8, scale: 0.97 }}
             transition={{ duration: 0.15 }}
-            className="absolute right-0 mt-2 w-72 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50"
+            className="absolute right-0 mt-2 w-80 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl overflow-hidden z-50"
           >
             <div className="px-4 py-3 border-b border-white/5">
               <h3 className="text-white text-sm font-semibold">Keyword Filters</h3>
@@ -74,19 +74,26 @@ export default function KeywordFilterDropdown() {
             </div>
 
             <div className="px-4 py-3">
-              <div className="flex items-center gap-2 mb-3">
+              <div className="flex items-center gap-2 mb-2">
                 <input
                   value={newKeyword}
                   onChange={(e) => setNewKeyword(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
                   placeholder="e.g. confidential, private..."
-                  className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-white text-xs focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
+                  className="flex-1 min-w-0 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-white text-xs focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-transparent"
                 />
                 <button
                   onClick={handleAdd}
-                  className="bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium py-1.5 px-3 rounded-lg transition-colors whitespace-nowrap cursor-pointer"
+                  className="bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium py-1.5 px-3 rounded-lg transition-colors whitespace-nowrap cursor-pointer shrink-0"
                 >
                   Add
+                </button>
+                <button
+                  onClick={deactivateAll}
+                  disabled={activeKeywords.length === 0}
+                  className="bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white/70 text-xs font-medium py-1.5 px-3 rounded-lg transition-colors whitespace-nowrap cursor-pointer shrink-0"
+                >
+                  Deactivate All
                 </button>
               </div>
 
@@ -135,13 +142,7 @@ export default function KeywordFilterDropdown() {
 
               {activeKeywords.length > 0 && (
                 <p className="text-amber-400/70 text-[11px] mt-2">
-                  {activeKeywords.length === 1 ? 'Filter' : 'Filters'}{' '}
-                  {activeKeywords.map((kw, i) => (
-                    <span key={kw}>
-                      {i > 0 && ', '}"<span className="font-semibold">{kw}</span>"
-                    </span>
-                  ))}{' '}
-                  active.
+                  {activeKeywords.length} filter{activeKeywords.length !== 1 ? 's' : ''} active.
                 </p>
               )}
             </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -43,6 +43,21 @@ const IMPORT_PROGRESS_STEP_LABELS: Record<string, string> = {
   done: 'Finalizing',
 };
 
+function computeShortFilterHash(keywords: string[], hiddenTypes: string[]): string {
+  const normalizedKeywords = keywords.map((k) => k.trim().toLowerCase()).filter(Boolean).sort();
+  const normalizedTypes = hiddenTypes.map((t) => t.trim().toLowerCase()).filter(Boolean).sort();
+  const payload = JSON.stringify({ keywords: normalizedKeywords, hiddenTypes: normalizedTypes });
+
+  // FNV-1a 32-bit for a deterministic short client-side hash.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < payload.length; i += 1) {
+    hash ^= payload.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+
+  return (hash >>> 0).toString(36).padStart(6, '0').slice(0, 6);
+}
+
 function resolveImportStepLabel(step: string | null | undefined, detail: string | null | undefined, message: string | null | undefined): string {
   if (step && IMPORT_PROGRESS_STEP_LABELS[step]) return IMPORT_PROGRESS_STEP_LABELS[step];
   if (detail?.trim()) return detail.trim();
@@ -94,7 +109,11 @@ function SharePanel({
   const qrValue = shareableUrl || bareUrl;
   const canDownloadQr = !isPrivate && (isRestricted || Boolean(shareTokenId));
   const canCopyShareLink = !isPrivate && Boolean(shareableUrl);
-  const mcpUri = `orb://${orbId}`;
+  const filterHash = useMemo(
+    () => computeShortFilterHash(activeKeywords, hiddenTypesArray),
+    [activeKeywords, hiddenTypesArray],
+  );
+  const mcpUri = `orb://${orbId}+${filterHash}`;
   const filteredGrants = useMemo(() => {
     const query = grantSearch.trim().toLowerCase();
     if (!query) return grants;

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -362,11 +362,13 @@ function SharePanel({
                 ? 'border-red-500/70 bg-red-500/15 text-red-100 shadow-[0_0_0_1px_rgba(239,68,68,0.2)]'
                 : opt.value === 'public'
                   ? 'border-emerald-500/70 bg-emerald-500/15 text-emerald-100 shadow-[0_0_0_1px_rgba(16,185,129,0.2)]'
-                  : 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]';
+                  : 'border-orange-500/70 bg-orange-500/15 text-orange-100 shadow-[0_0_0_1px_rgba(249,115,22,0.2)]';
               const descriptionClass = selected && opt.value === 'private'
                 ? 'text-red-200/80'
                 : selected && opt.value === 'public'
                   ? 'text-emerald-200/80'
+                  : selected && opt.value === 'restricted'
+                    ? 'text-orange-200/80'
                   : 'text-gray-400';
               return (
                 <button

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -379,15 +379,10 @@ function SharePanel({
         </div>
 
         {isPrivate && (
-          <div className="space-y-4">
+          <div>
             <div className="rounded-xl border border-gray-700 bg-gray-800/50 p-4">
               <p className="text-sm text-gray-200 font-medium mb-1">This orbis is currently private</p>
               <p className="text-xs text-gray-400">No link or QR is available until you switch to Public or Restricted.</p>
-            </div>
-            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
-              <p className="text-[11px] text-gray-500 mt-0.5 mb-2">MCP access is available only in Public mode.</p>
-              <input readOnly value={mcpUri} className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-gray-400 text-sm font-mono" />
             </div>
           </div>
         )}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -350,10 +350,7 @@ function SharePanel({
           </svg>
         </button>
         <h2 className="text-white text-lg font-semibold mb-1">Share Your Orbis</h2>
-        <p className="text-gray-400 text-sm mb-2">Choose visibility, then share with a direct link or QR code.</p>
-        {!isPrivate && (
-          <p className="text-[11px] text-gray-500 mb-5">Keyboard shortcuts: <span className="text-gray-300">Ctrl/Cmd + C</span> copy link, <span className="text-gray-300">Ctrl/Cmd + D</span> download QR.</p>
-        )}
+        <p className="text-gray-400 text-sm mb-5">Choose visibility, then share with a direct link or QR code.</p>
 
         {/* Visibility selector */}
         <div className="mb-4">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -76,6 +76,7 @@ function SharePanel({
   const [grantEmail, setGrantEmail] = useState('');
   const [grantError, setGrantError] = useState<string | null>(null);
   const [grantSubmitting, setGrantSubmitting] = useState(false);
+  const [qrActionHint, setQrActionHint] = useState<'copied' | 'downloaded' | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
   const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const addToast = useToastStore((s) => s.addToast);
@@ -199,23 +200,33 @@ function SharePanel({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const copyText = useCallback(async (text: string, label: string) => {
+  const flashQrHint = useCallback((kind: 'copied' | 'downloaded') => {
+    setQrActionHint(kind);
+    window.setTimeout(() => {
+      setQrActionHint((current) => (current === kind ? null : current));
+    }, 1600);
+  }, []);
+
+  const copyText = useCallback(async (text: string, label: string): Promise<boolean> => {
     if (!navigator.clipboard?.writeText) {
       addToast('Clipboard is not available in this browser', 'error');
-      return;
+      return false;
     }
     try {
       await navigator.clipboard.writeText(text);
       addToast(`${label} copied`, 'success');
+      return true;
     } catch {
       addToast(`Failed to copy ${label.toLowerCase()}`, 'error');
+      return false;
     }
   }, [addToast]);
 
-  const handleCopyShareLink = useCallback(() => {
+  const handleCopyShareLink = useCallback(async () => {
     if (!canCopyShareLink || !shareableUrl) return;
-    void copyText(shareableUrl, 'Share link');
-  }, [canCopyShareLink, copyText, shareableUrl]);
+    const copied = await copyText(shareableUrl, 'Share link');
+    if (copied) flashQrHint('copied');
+  }, [canCopyShareLink, copyText, flashQrHint, shareableUrl]);
 
   const handleCopyMcp = useCallback(() => {
     if (!isPublic) return;
@@ -232,32 +243,11 @@ function SharePanel({
       link.click();
       document.body.removeChild(link);
       addToast('QR code downloaded', 'success');
+      flashQrHint('downloaded');
     } catch {
       addToast('Failed to download QR code', 'error');
     }
-  }, [addToast, canDownloadQr, isRestricted, orbId]);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      const isTyping = tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(target?.isContentEditable);
-      if (isTyping) return;
-      const key = event.key.toLowerCase();
-      const hasModifier = event.metaKey || event.ctrlKey;
-      if (hasModifier && key === 'c' && canCopyShareLink) {
-        event.preventDefault();
-        handleCopyShareLink();
-        return;
-      }
-      if (hasModifier && key === 'd' && canDownloadQr) {
-        event.preventDefault();
-        handleDownloadQr();
-      }
-    };
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [canCopyShareLink, canDownloadQr, handleCopyShareLink, handleDownloadQr]);
+  }, [addToast, canDownloadQr, flashQrHint, isRestricted, orbId]);
 
   const handleGrantSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -472,31 +462,41 @@ function SharePanel({
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <div className="mt-3 flex justify-center">
-                <div className="w-full max-w-[760px] grid grid-cols-1 sm:grid-cols-[auto_minmax(240px,280px)] items-center gap-4 sm:gap-6">
-                  <div className="justify-self-center sm:justify-self-start">
-                    <div className="bg-white p-0.5 rounded-md">
-                      <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={0} />
-                    </div>
+              <div className="mt-3 max-w-[700px] mx-auto grid grid-cols-1 md:grid-cols-[auto_minmax(250px,280px)] items-center gap-4 md:gap-8">
+                <div className="justify-self-center md:justify-self-start rounded-xl border border-gray-700/70 bg-gray-900/35 p-2">
+                  <div className="bg-white p-[3px] rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
+                    <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={0} />
                   </div>
-                  <div className="w-full max-w-[280px] justify-self-center sm:justify-self-end flex flex-col gap-2">
-                    <button
-                      type="button"
-                      onClick={handleCopyShareLink}
-                      disabled={!canCopyShareLink || generatingToken}
-                      className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-                    >
-                      {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleDownloadQr}
-                      disabled={!canDownloadQr || generatingToken}
-                      className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-                    >
-                      Download QR (.png)
-                    </button>
-                  </div>
+                </div>
+                <div className="w-full max-w-[280px] justify-self-center md:justify-self-end md:border-l md:border-gray-700/60 md:pl-6 flex flex-col gap-2.5">
+                  <button
+                    type="button"
+                    onClick={handleCopyShareLink}
+                    disabled={!canCopyShareLink || generatingToken}
+                    className="h-10 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                  >
+                    {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDownloadQr}
+                    disabled={!canDownloadQr || generatingToken}
+                    className="h-10 rounded-lg border border-gray-600/80 bg-gray-800/70 hover:bg-gray-700/80 disabled:opacity-50 disabled:cursor-not-allowed text-gray-100 text-sm font-semibold transition-colors"
+                  >
+                    Download QR (.png)
+                  </button>
+                  <p
+                    aria-live="polite"
+                    className={`text-[11px] h-4 transition-colors ${
+                      qrActionHint === 'copied'
+                        ? 'text-emerald-300'
+                        : qrActionHint === 'downloaded'
+                          ? 'text-sky-300'
+                          : 'text-transparent'
+                    }`}
+                  >
+                    {qrActionHint === 'copied' ? 'Copied to clipboard' : qrActionHint === 'downloaded' ? 'QR downloaded' : 'Status'}
+                  </p>
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -360,7 +360,14 @@ function SharePanel({
               const selected = visibility === opt.value;
               const selectedClass = opt.value === 'private'
                 ? 'border-red-500/70 bg-red-500/15 text-red-100 shadow-[0_0_0_1px_rgba(239,68,68,0.2)]'
-                : 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]';
+                : opt.value === 'public'
+                  ? 'border-emerald-500/70 bg-emerald-500/15 text-emerald-100 shadow-[0_0_0_1px_rgba(16,185,129,0.2)]'
+                  : 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]';
+              const descriptionClass = selected && opt.value === 'private'
+                ? 'text-red-200/80'
+                : selected && opt.value === 'public'
+                  ? 'text-emerald-200/80'
+                  : 'text-gray-400';
               return (
                 <button
                   key={opt.value}
@@ -374,7 +381,7 @@ function SharePanel({
                   }`}
                 >
                   <div className="text-xs font-semibold">{opt.label}</div>
-                  <div className={`text-[10px] mt-0.5 leading-tight ${selected && opt.value === 'private' ? 'text-red-200/80' : 'text-gray-400'}`}>{opt.description}</div>
+                  <div className={`text-[10px] mt-0.5 leading-tight ${descriptionClass}`}>{opt.description}</div>
                 </button>
               );
             })}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -414,7 +414,7 @@ function SharePanel({
                 </div>
               </div>
 
-              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-base font-bold text-yellow-300'}`}>
+              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-yellow-300'}`}>
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view.'}
               </p>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1333,15 +1333,6 @@ export default function OrbViewPage() {
             </div>
           </div>
 
-          {!isPendingDeletion && (
-            <div className="flex flex-wrap items-center gap-1.5 px-2.5 sm:px-3 pb-2">
-              {activeKeywords.length > 0 && (
-                <span className="text-[10px] font-medium rounded-full px-2 py-0.5 bg-amber-500/12 border border-amber-500/30 text-amber-200">
-                  Filters: {activeKeywords.length}
-                </span>
-              )}
-            </div>
-          )}
         </div>
       </div>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -414,7 +414,7 @@ function SharePanel({
                 </div>
               </div>
 
-              <p className="text-xs text-gray-400 mt-2.5">
+              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-base font-bold text-yellow-300'}`}>
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view.'}
               </p>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -405,7 +405,7 @@ function SharePanel({
               </div>
 
               <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-yellow-300'}`}>
-                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view.'}
+                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients can see only the filtered orbis'}
               </p>
 
               <div className="mt-3">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -476,7 +476,7 @@ function SharePanel({
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
               <div className="mt-3 flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
-                <div className="order-2 sm:order-1 flex-1 flex flex-col gap-2 sm:max-w-[260px]">
+                <div className="order-2 sm:order-2 flex-1 flex flex-col gap-2 sm:max-w-[260px]">
                   <button
                     type="button"
                     onClick={handleCopyShareLink}
@@ -494,7 +494,7 @@ function SharePanel({
                     Download QR (.png)
                   </button>
                 </div>
-                <div className="order-1 sm:order-2 flex-1 flex justify-center sm:justify-end">
+                <div className="order-1 sm:order-1 flex-1 flex justify-center sm:justify-start">
                   <div className="bg-white p-1 rounded-lg">
                     <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
                   </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -414,13 +414,6 @@ function SharePanel({
                 <div className="min-w-0">
                   <label className="text-[11px] text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
                 </div>
-                <div className="flex items-center gap-2 flex-wrap justify-end">
-                  {isRestricted && (
-                    <span className="text-[10px] px-2.5 py-1 rounded-full border border-blue-500/40 text-blue-200 bg-blue-500/10">
-                      Invite-Only
-                    </span>
-                  )}
-                </div>
               </div>
 
               <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-emerald-300'}`}>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -13,6 +13,7 @@ import {
   linkSkill,
   listAccessGrants,
   revokeAccessGrant,
+  updateAccessGrantFilters,
 } from '../api/orbs';
 import type { AccessGrant, OrbVisibility } from '../api/orbs';
 import { QRCodeCanvas } from 'qrcode.react';
@@ -91,6 +92,11 @@ function SharePanel({
   const [grantEmail, setGrantEmail] = useState('');
   const [grantError, setGrantError] = useState<string | null>(null);
   const [grantSubmitting, setGrantSubmitting] = useState(false);
+  const [applyFiltersOnInvite, setApplyFiltersOnInvite] = useState(true);
+  const [editingGrantId, setEditingGrantId] = useState<string | null>(null);
+  const [editingGrantKeywords, setEditingGrantKeywords] = useState('');
+  const [editingGrantHiddenTypes, setEditingGrantHiddenTypes] = useState('');
+  const [updatingGrantFiltersId, setUpdatingGrantFiltersId] = useState<string | null>(null);
   const [qrActionHint, setQrActionHint] = useState<'copied' | 'downloaded' | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
   const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -119,6 +125,10 @@ function SharePanel({
     if (!query) return grants;
     return grants.filter((g) => g.email.toLowerCase().includes(query));
   }, [grantSearch, grants]);
+
+  useEffect(() => {
+    if (!hasActiveFilters) setApplyFiltersOnInvite(false);
+  }, [hasActiveFilters]);
 
   // Generate a share token only in public mode
   useEffect(() => {
@@ -268,6 +278,54 @@ function SharePanel({
     }
   }, [addToast, canDownloadQr, flashQrHint, isRestricted, orbId]);
 
+  const parseCommaSeparated = useCallback((value: string, lowerCase = false): string[] => {
+    const items = value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+    const normalized = lowerCase ? items.map((item) => item.toLowerCase()) : items;
+    return Array.from(new Set(normalized));
+  }, []);
+
+  const openGrantEditor = useCallback((grant: AccessGrant) => {
+    setEditingGrantId(grant.grant_id);
+    setEditingGrantKeywords((grant.keywords || []).join(', '));
+    setEditingGrantHiddenTypes((grant.hidden_node_types || []).join(', '));
+    setGrantError(null);
+  }, []);
+
+  const closeGrantEditor = useCallback(() => {
+    setEditingGrantId(null);
+    setEditingGrantKeywords('');
+    setEditingGrantHiddenTypes('');
+  }, []);
+
+  const saveGrantFilters = useCallback(async (
+    grantId: string,
+    keywordsRaw: string,
+    hiddenTypesRaw: string,
+  ) => {
+    const keywords = parseCommaSeparated(keywordsRaw, true);
+    const hiddenNodeTypes = parseCommaSeparated(hiddenTypesRaw, false);
+    setUpdatingGrantFiltersId(grantId);
+    setGrantError(null);
+    try {
+      const updated = await updateAccessGrantFilters(grantId, {
+        keywords,
+        hidden_node_types: hiddenNodeTypes,
+      });
+      setGrants((prev) => prev.map((g) => (g.grant_id === grantId ? updated : g)));
+      addToast('Filters updated for invited user', 'success');
+      closeGrantEditor();
+    } catch (err) {
+      const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setGrantError(msg || 'Failed to update filters');
+      addToast(msg || 'Failed to update filters', 'error');
+    } finally {
+      setUpdatingGrantFiltersId(null);
+    }
+  }, [addToast, closeGrantEditor, parseCommaSeparated]);
+
   const handleGrantSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const email = grantEmail.trim();
@@ -280,7 +338,11 @@ function SharePanel({
     setGrantSubmitting(true);
     setGrantError(null);
     try {
-      const grant = await createAccessGrant(email);
+      const grant = await createAccessGrant({
+        email,
+        keywords: applyFiltersOnInvite ? activeKeywords : [],
+        hidden_node_types: applyFiltersOnInvite ? hiddenTypesArray : [],
+      });
       setGrants((prev) => [grant, ...prev]);
       setGrantEmail('');
       addToast(`Access granted to ${email}`, 'success');
@@ -304,6 +366,18 @@ function SharePanel({
       setGrantError('Failed to revoke access');
       addToast('Failed to revoke access', 'error');
     }
+  };
+
+  const handleApplyCurrentFiltersToGrant = async (grant: AccessGrant) => {
+    await saveGrantFilters(
+      grant.grant_id,
+      activeKeywords.join(', '),
+      hiddenTypesArray.join(', '),
+    );
+  };
+
+  const handleClearGrantFilters = async (grant: AccessGrant) => {
+    await saveGrantFilters(grant.grant_id, '', '');
   };
 
   const handleVisibilityClick = async (next: OrbVisibility) => {
@@ -520,6 +594,24 @@ function SharePanel({
                 <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
                   <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
                   <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in.</p>
+                  <div className="mb-2.5 rounded-lg border border-gray-700/70 bg-gray-900/40 px-3 py-2">
+                    <label className="flex items-start gap-2 text-[11px] text-gray-200 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={applyFiltersOnInvite}
+                        onChange={(e) => setApplyFiltersOnInvite(e.target.checked)}
+                        className="mt-0.5 accent-purple-500"
+                      />
+                      <span>
+                        Apply current filters for this invite.
+                        <span className="block text-gray-500 mt-0.5">
+                          {hasActiveFilters
+                            ? `Current set: ${activeKeywords.length} keyword(s), ${hiddenTypesArray.length} hidden type(s).`
+                            : 'No active filters are set right now.'}
+                        </span>
+                      </span>
+                    </label>
+                  </div>
                   <form onSubmit={handleGrantSubmit} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
                     <input
                       type="email"
@@ -559,15 +651,99 @@ function SharePanel({
                     {!grantsLoading && filteredGrants.length > 0 && (
                       <ul className="space-y-2">
                         {filteredGrants.map((grant) => (
-                          <li key={grant.grant_id} className="flex items-center justify-between gap-3 border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60">
-                            <span className="text-sm text-white truncate">{grant.email}</span>
-                            <button
-                              type="button"
-                              onClick={() => handleRevokeGrant(grant)}
-                              className="h-9 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 text-xs font-medium transition-colors whitespace-nowrap"
-                            >
-                              Revoke Access
-                            </button>
+                          <li key={grant.grant_id} className="border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60 space-y-2">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <p className="text-sm text-white truncate">{grant.email}</p>
+                                <p className="text-[11px] text-gray-400 mt-0.5">
+                                  {(grant.keywords || []).length} keyword filter(s) • {(grant.hidden_node_types || []).length} hidden type filter(s)
+                                </p>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => handleRevokeGrant(grant)}
+                                className="h-9 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 text-xs font-medium transition-colors whitespace-nowrap"
+                              >
+                                Revoke Access
+                              </button>
+                            </div>
+
+                            {editingGrantId === grant.grant_id ? (
+                              <div className="rounded-lg border border-gray-700/70 bg-gray-900/60 p-2.5 space-y-2">
+                                <div>
+                                  <label className="text-[10px] text-gray-500 uppercase tracking-wide">Filtered Keywords (comma separated)</label>
+                                  <input
+                                    type="text"
+                                    value={editingGrantKeywords}
+                                    onChange={(e) => setEditingGrantKeywords(e.target.value)}
+                                    placeholder="python, machine learning"
+                                    className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="text-[10px] text-gray-500 uppercase tracking-wide">Hidden Node Types (comma separated)</label>
+                                  <input
+                                    type="text"
+                                    value={editingGrantHiddenTypes}
+                                    onChange={(e) => setEditingGrantHiddenTypes(e.target.value)}
+                                    placeholder="Skill, Project"
+                                    className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                                  />
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => void saveGrantFilters(grant.grant_id, editingGrantKeywords, editingGrantHiddenTypes)}
+                                    disabled={updatingGrantFiltersId === grant.grant_id}
+                                    className="h-8 px-3 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white text-xs font-medium transition-colors"
+                                  >
+                                    {updatingGrantFiltersId === grant.grant_id ? 'Saving...' : 'Save Filters'}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={closeGrantEditor}
+                                    disabled={updatingGrantFiltersId === grant.grant_id}
+                                    className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                                  >
+                                    Cancel
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => void saveGrantFilters(grant.grant_id, activeKeywords.join(', '), hiddenTypesArray.join(', '))}
+                                    disabled={updatingGrantFiltersId === grant.grant_id}
+                                    className="h-8 px-3 rounded-lg border border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 text-xs font-medium transition-colors"
+                                  >
+                                    Use Current Filters
+                                  </button>
+                                </div>
+                              </div>
+                            ) : (
+                              <div className="flex flex-wrap gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => openGrantEditor(grant)}
+                                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                                >
+                                  Manage Filters
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void handleApplyCurrentFiltersToGrant(grant)}
+                                  disabled={updatingGrantFiltersId === grant.grant_id}
+                                  className="h-8 px-3 rounded-lg border border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
+                                >
+                                  Apply Current
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void handleClearGrantFilters(grant)}
+                                  disabled={updatingGrantFiltersId === grant.grant_id}
+                                  className="h-8 px-3 rounded-lg border border-orange-500/40 text-orange-300 hover:bg-orange-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
+                                >
+                                  Clear Filters
+                                </button>
+                              </div>
+                            )}
                           </li>
                         ))}
                       </ul>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -94,7 +94,6 @@ function SharePanel({
   const canDownloadQr = !isPrivate && (isRestricted || Boolean(shareTokenId));
   const canCopyShareLink = !isPrivate && Boolean(shareableUrl);
   const mcpUri = `orb://${orbId}`;
-  const shareSummary = hasActiveFilters && isPublic ? 'Filtered View' : 'Full Orbis';
   const filteredGrants = useMemo(() => {
     const query = grantSearch.trim().toLowerCase();
     if (!query) return grants;
@@ -410,9 +409,6 @@ function SharePanel({
                   </p>
                 </div>
                 <div className="flex items-center gap-2 flex-wrap justify-end">
-                  <span className={`text-[10px] px-2.5 py-1 rounded-full border ${hasActiveFilters && isPublic ? 'border-amber-500/40 text-amber-200 bg-amber-500/10' : 'border-emerald-500/40 text-emerald-200 bg-emerald-500/10'}`}>
-                    {shareSummary}
-                  </span>
                   {isRestricted && (
                     <span className="text-[10px] px-2.5 py-1 rounded-full border border-blue-500/40 text-blue-200 bg-blue-500/10">
                       Invite-Only
@@ -422,7 +418,7 @@ function SharePanel({
               </div>
 
               <p className="text-xs text-gray-400 mt-2.5">
-                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the view shown by your current sharing settings.'}
+                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view (filtered in yellow).'}
               </p>
 
               <div className="mt-3">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -418,11 +418,7 @@ function SharePanel({
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the view shown by your current sharing settings.'}
               </p>
 
-              <div className="mt-3 grid grid-cols-2 gap-2">
-                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
-                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Visibility</p>
-                  <p className="text-xs text-gray-200 mt-1">{isRestricted ? 'Restricted' : 'Public'}</p>
-                </div>
+              <div className="mt-3">
                 <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
                   <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
                   <p className="text-xs text-gray-200 mt-1">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -404,7 +404,7 @@ function SharePanel({
                 </div>
               </div>
 
-              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-yellow-300'}`}>
+              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-emerald-300'}`}>
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients can see only the filtered orbis'}
               </p>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -460,17 +460,6 @@ function SharePanel({
               )}
             </div>
 
-            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <p className="text-[11px] text-gray-500 mb-3">Use this code on printed material for instant access.</p>
-              <div className="flex justify-center">
-                <div className="bg-white p-3 rounded-xl">
-                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={2} />
-                </div>
-              </div>
-              <p className="text-[11px] text-gray-500 mt-3">Scans to your current share link.</p>
-            </div>
-
             {isPublic && (
               <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
@@ -487,6 +476,17 @@ function SharePanel({
                 </div>
               </div>
             )}
+
+            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
+              <p className="text-[11px] text-gray-500 mb-3">Use this code on printed material for instant access.</p>
+              <div className="flex justify-center">
+                <div className="bg-white p-3 rounded-xl">
+                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={2} />
+                </div>
+              </div>
+              <p className="text-[11px] text-gray-500 mt-3">Scans to your current share link.</p>
+            </div>
 
             {isRestricted && (
               <>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1472,7 +1472,7 @@ export default function OrbViewPage() {
             key="share"
             orbId={orbId}
             hiddenNodeTypes={hiddenNodeTypes}
-            visibility={((data?.person?.visibility as OrbVisibility) || 'private')}
+            visibility={((data?.person?.visibility as OrbVisibility) || 'public')}
             onVisibilityChange={updateVisibility}
             onClose={() => setShowShare(false)}
           />

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1443,6 +1443,7 @@ export default function OrbViewPage() {
         onDiscover={() => setShowDiscoverUses(true)}
         highlightAdd={data.nodes.length === 0 && !showInput}
         onRecenter={() => handleFocusNode(personNodeId)}
+        visibility={((data?.person?.visibility as OrbVisibility) || 'public')}
       />}
 
       {/* ── Draft Notes ── */}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -394,24 +394,48 @@ function SharePanel({
 
         {!isPrivate && (
           <div className="space-y-4">
-            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
-              <div className="mt-2 flex items-center gap-2 flex-wrap">
-                <span className={`text-[10px] px-2 py-1 rounded-full border ${hasActiveFilters && isPublic ? 'border-amber-500/40 text-amber-200 bg-amber-500/10' : 'border-emerald-500/40 text-emerald-200 bg-emerald-500/10'}`}>
-                  {shareSummary}
-                </span>
-                {isRestricted && (
-                  <span className="text-[10px] px-2 py-1 rounded-full border border-blue-500/40 text-blue-200 bg-blue-500/10">
-                    Invite-Only
+            <div className="rounded-2xl border border-gray-700/80 bg-gradient-to-br from-gray-800/65 to-gray-900/70 p-4 sm:p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <label className="text-[11px] text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
+                  <p className="text-sm text-gray-200 mt-1">
+                    {isPublic ? 'Public link preview' : 'Restricted link preview'}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 flex-wrap justify-end">
+                  <span className={`text-[10px] px-2.5 py-1 rounded-full border ${hasActiveFilters && isPublic ? 'border-amber-500/40 text-amber-200 bg-amber-500/10' : 'border-emerald-500/40 text-emerald-200 bg-emerald-500/10'}`}>
+                    {shareSummary}
                   </span>
-                )}
+                  {isRestricted && (
+                    <span className="text-[10px] px-2.5 py-1 rounded-full border border-blue-500/40 text-blue-200 bg-blue-500/10">
+                      Invite-Only
+                    </span>
+                  )}
+                </div>
               </div>
-              <p className="text-[11px] text-gray-400 mt-2">{isPublic && generatingToken ? 'Generating secure link...' : 'Your current share settings will be applied to this link.'}</p>
+
+              <p className="text-xs text-gray-400 mt-2.5">
+                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the view shown by your current sharing settings.'}
+              </p>
+
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Visibility</p>
+                  <p className="text-xs text-gray-200 mt-1">{isRestricted ? 'Restricted' : 'Public'}</p>
+                </div>
+                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
+                  <p className="text-xs text-gray-200 mt-1">
+                    {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
+                  </p>
+                </div>
+              </div>
+
               {hasActiveFilters && isPublic && (
-                <div className="mt-3 space-y-2">
+                <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 space-y-2">
                   {hiddenTypesArray.length > 0 && (
                     <div>
-                      <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Hidden node types</p>
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Hidden node types</p>
                       <div className="flex flex-wrap gap-1.5">
                         {hiddenTypesArray.map((type) => (
                           <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
@@ -421,7 +445,7 @@ function SharePanel({
                   )}
                   {activeKeywords.length > 0 && (
                     <div>
-                      <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Filtered keywords</p>
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Filtered keywords</p>
                       <div className="flex flex-wrap gap-1.5">
                         {activeKeywords.map((keyword) => (
                           <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -50,13 +50,6 @@ function resolveImportStepLabel(step: string | null | undefined, detail: string 
   return 'Reading PDF';
 }
 
-function truncateMiddle(value: string, max = 64): string {
-  if (value.length <= max) return value;
-  const leftChars = Math.ceil((max - 3) / 2);
-  const rightChars = Math.floor((max - 3) / 2);
-  return `${value.slice(0, leftChars)}...${value.slice(-rightChars)}`;
-}
-
 const QR_SIZE_OPTIONS = [
   { label: 'Small', value: 128 },
   { label: 'Medium', value: 160 },
@@ -107,8 +100,6 @@ function SharePanel({
   const canCopyShareLink = !isPrivate && Boolean(shareableUrl);
   const mcpUri = `orb://${orbId}`;
   const shareSummary = hasActiveFilters && isPublic ? 'Filtered View' : 'Full Orbis';
-  const shortSharePreview = useMemo(() => truncateMiddle(shareableUrl || bareUrl), [bareUrl, shareableUrl]);
-  const shortQrTarget = useMemo(() => truncateMiddle(qrValue), [qrValue]);
   const filteredGrants = useMemo(() => {
     const query = grantSearch.trim().toLowerCase();
     if (!query) return grants;
@@ -423,7 +414,7 @@ function SharePanel({
                   </span>
                 )}
               </div>
-              <p className="text-[11px] text-gray-400 mt-2 font-mono break-all">{isPublic && generatingToken ? 'Generating secure link...' : shortSharePreview}</p>
+              <p className="text-[11px] text-gray-400 mt-2">{isPublic && generatingToken ? 'Generating secure link...' : 'Your current share settings will be applied to this link.'}</p>
               {hasActiveFilters && isPublic && (
                 <div className="mt-3 space-y-2">
                   {hiddenTypesArray.length > 0 && (
@@ -477,7 +468,7 @@ function SharePanel({
                   <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={qrSize} level="M" marginSize={2} />
                 </div>
               </div>
-              <p className="text-[11px] text-gray-500 mt-3">Scans to: <span className="text-gray-300 font-mono">{shortQrTarget}</span></p>
+              <p className="text-[11px] text-gray-500 mt-3">Scans to your current share link.</p>
             </div>
 
             {isPublic && (

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -413,40 +413,33 @@ function SharePanel({
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the view shown by your current sharing settings.'}
               </p>
 
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <span className="text-[10px] px-2.5 py-1 rounded-full border border-gray-600/70 bg-gray-900/55 text-gray-200">
-                  Active filters: {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
-                </span>
-                {isPublic && activeKeywords.length > 0 && (
-                  <span className="text-[10px] px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/8 text-amber-200">
-                    Keywords: {activeKeywords.length}
-                  </span>
-                )}
-                {isPublic && hiddenTypesArray.length > 0 && (
-                  <span className="text-[10px] px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/8 text-amber-200">
-                    Hidden types: {hiddenTypesArray.length}
-                  </span>
-                )}
+              <div className="mt-3">
+                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
+                  <p className="text-xs text-gray-200 mt-1">
+                    {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
+                  </p>
+                </div>
               </div>
 
               {hasActiveFilters && isPublic && (
-                <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-                  {activeKeywords.length > 0 && (
-                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1.5">Filtered keywords</p>
+                <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 space-y-2">
+                  {hiddenTypesArray.length > 0 && (
+                    <div>
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Hidden node types</p>
                       <div className="flex flex-wrap gap-1.5">
-                        {activeKeywords.map((keyword) => (
-                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
+                        {hiddenTypesArray.map((type) => (
+                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
                         ))}
                       </div>
                     </div>
                   )}
-                  {hiddenTypesArray.length > 0 && (
-                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1.5">Hidden node types</p>
+                  {activeKeywords.length > 0 && (
+                    <div>
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Filtered keywords</p>
                       <div className="flex flex-wrap gap-1.5">
-                        {hiddenTypesArray.map((type) => (
-                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
+                        {activeKeywords.map((keyword) => (
+                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
                         ))}
                       </div>
                     </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -418,33 +418,40 @@ function SharePanel({
                 {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the view shown by your current sharing settings.'}
               </p>
 
-              <div className="mt-3">
-                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
-                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
-                  <p className="text-xs text-gray-200 mt-1">
-                    {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
-                  </p>
-                </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="text-[10px] px-2.5 py-1 rounded-full border border-gray-600/70 bg-gray-900/55 text-gray-200">
+                  Active filters: {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
+                </span>
+                {isPublic && activeKeywords.length > 0 && (
+                  <span className="text-[10px] px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/8 text-amber-200">
+                    Keywords: {activeKeywords.length}
+                  </span>
+                )}
+                {isPublic && hiddenTypesArray.length > 0 && (
+                  <span className="text-[10px] px-2.5 py-1 rounded-full border border-amber-500/30 bg-amber-500/8 text-amber-200">
+                    Hidden types: {hiddenTypesArray.length}
+                  </span>
+                )}
               </div>
 
               {hasActiveFilters && isPublic && (
-                <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 space-y-2">
-                  {hiddenTypesArray.length > 0 && (
-                    <div>
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Hidden node types</p>
+                <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                  {activeKeywords.length > 0 && (
+                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1.5">Filtered keywords</p>
                       <div className="flex flex-wrap gap-1.5">
-                        {hiddenTypesArray.map((type) => (
-                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
+                        {activeKeywords.map((keyword) => (
+                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
                         ))}
                       </div>
                     </div>
                   )}
-                  {activeKeywords.length > 0 && (
-                    <div>
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Filtered keywords</p>
+                  {hiddenTypesArray.length > 0 && (
+                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5">
+                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1.5">Hidden node types</p>
                       <div className="flex flex-wrap gap-1.5">
-                        {activeKeywords.map((keyword) => (
-                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
+                        {hiddenTypesArray.map((type) => (
+                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
                         ))}
                       </div>
                     </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -358,6 +358,9 @@ function SharePanel({
           <div className="mt-2 grid grid-cols-3 gap-2">
             {visibilityOptions.map((opt) => {
               const selected = visibility === opt.value;
+              const selectedClass = opt.value === 'private'
+                ? 'border-red-500/70 bg-red-500/15 text-red-100 shadow-[0_0_0_1px_rgba(239,68,68,0.2)]'
+                : 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]';
               return (
                 <button
                   key={opt.value}
@@ -366,12 +369,12 @@ function SharePanel({
                   disabled={updatingVisibility}
                   className={`text-left rounded-xl border px-3 py-3 transition-colors disabled:opacity-60 ${
                     selected
-                      ? 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]'
+                      ? selectedClass
                       : 'border-gray-700 bg-gray-800/40 text-gray-300 hover:bg-gray-800'
                   }`}
                 >
                   <div className="text-xs font-semibold">{opt.label}</div>
-                  <div className="text-[10px] text-gray-400 mt-0.5 leading-tight">{opt.description}</div>
+                  <div className={`text-[10px] mt-0.5 leading-tight ${selected && opt.value === 'private' ? 'text-red-200/80' : 'text-gray-400'}`}>{opt.description}</div>
                 </button>
               );
             })}
@@ -380,9 +383,9 @@ function SharePanel({
 
         {isPrivate && (
           <div>
-            <div className="rounded-xl border border-gray-700 bg-gray-800/50 p-4">
-              <p className="text-sm text-gray-200 font-medium mb-1">This orbis is currently private</p>
-              <p className="text-xs text-gray-400">No link or QR is available until you switch to Public or Restricted.</p>
+            <div className="rounded-xl border border-red-500/25 bg-red-500/8 p-4">
+              <p className="text-sm text-red-100 font-medium mb-1">This orbis is currently private</p>
+              <p className="text-xs text-red-200/75">No link or QR is available until you switch to Public or Restricted.</p>
             </div>
           </div>
         )}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -418,7 +418,7 @@ function SharePanel({
               </div>
 
               <p className="text-xs text-gray-400 mt-2.5">
-                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view (filtered in yellow).'}
+                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients will open exactly the filtered view.'}
               </p>
 
               <div className="mt-3">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -404,9 +404,6 @@ function SharePanel({
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <label className="text-[11px] text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
-                  <p className="text-sm text-gray-200 mt-1">
-                    {isPublic ? 'Public link preview' : 'Restricted link preview'}
-                  </p>
                 </div>
                 <div className="flex items-center gap-2 flex-wrap justify-end">
                   {isRestricted && (

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -114,7 +114,8 @@ function SharePanel({
   const modalRef = useRef<HTMLDivElement | null>(null);
   const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const addToast = useToastStore((s) => s.addToast);
-  const { activeKeywords } = useFilterStore();
+  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
+  const [inlineFilterKeyword, setInlineFilterKeyword] = useState('');
   const hiddenTypesArray = useMemo(() => Array.from(hiddenNodeTypes), [hiddenNodeTypes]);
   const hasActiveFilters = activeKeywords.length > 0 || hiddenTypesArray.length > 0;
   const isPrivate = visibility === 'private';
@@ -280,9 +281,9 @@ function SharePanel({
   }, [canCopyShareLink, copyText, flashQrHint, shareableUrl]);
 
   const handleCopyMcp = useCallback(() => {
-    if (!isPublic) return;
+    if (isPrivate) return;
     void copyText(mcpUri, 'MCP Orbis ID');
-  }, [copyText, isPublic, mcpUri]);
+  }, [copyText, isPrivate, mcpUri]);
 
   const handleDownloadQr = useCallback(() => {
     if (!canDownloadQr || !qrCanvasRef.current) return;
@@ -447,7 +448,6 @@ function SharePanel({
     label: string;
     description: string;
   }[] = [
-    { value: 'private', label: 'Private', description: 'Only you can view your orbis' },
     { value: 'public', label: 'Public', description: 'Anyone with the link can view' },
     { value: 'restricted', label: 'Restricted', description: 'Share via invite links' },
   ];
@@ -489,20 +489,20 @@ function SharePanel({
         {/* Visibility selector */}
         <div className="mb-4">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility</label>
-          <div className="mt-2 grid grid-cols-3 gap-2">
+          <div className="mt-2 grid grid-cols-2 gap-2">
             {visibilityOptions.map((opt) => {
               const selected = visibility === opt.value;
               const selectedClass = opt.value === 'private'
                 ? 'border-red-500/70 bg-red-500/15 text-red-100 shadow-[0_0_0_1px_rgba(239,68,68,0.2)]'
                 : opt.value === 'public'
-                  ? 'border-emerald-500/70 bg-emerald-500/15 text-emerald-100 shadow-[0_0_0_1px_rgba(16,185,129,0.2)]'
-                  : 'border-orange-500/70 bg-orange-500/15 text-orange-100 shadow-[0_0_0_1px_rgba(249,115,22,0.2)]';
+                  ? 'border-orange-500/70 bg-orange-500/15 text-orange-100 shadow-[0_0_0_1px_rgba(249,115,22,0.2)]'
+                  : 'border-emerald-500/70 bg-emerald-500/15 text-emerald-100 shadow-[0_0_0_1px_rgba(16,185,129,0.2)]';
               const descriptionClass = selected && opt.value === 'private'
                 ? 'text-red-200/80'
                 : selected && opt.value === 'public'
-                  ? 'text-emerald-200/80'
+                  ? 'text-orange-200/80'
                   : selected && opt.value === 'restricted'
-                    ? 'text-orange-200/80'
+                    ? 'text-emerald-200/80'
                   : 'text-gray-400';
               return (
                 <button
@@ -524,63 +524,78 @@ function SharePanel({
           </div>
         </div>
 
-        {isPrivate && (
-          <div>
-            <div className="rounded-xl border border-red-500/25 bg-red-500/8 p-4">
-              <p className="text-sm text-red-100 font-medium mb-1">This orbis is currently private</p>
-              <p className="text-xs text-red-200/75">No link or QR is available until you switch to Public or Restricted.</p>
-            </div>
-          </div>
-        )}
-
-        {!isPrivate && (
           <div className="space-y-4">
+
             {isPublic && (
-            <div className="rounded-2xl border border-gray-700/80 bg-gradient-to-br from-gray-800/65 to-gray-900/70 p-4 sm:p-5">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <label className="text-[11px] text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
+              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
+                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to share links and excluded from exports.</p>
+                <div className="flex items-center gap-2 mb-3">
+                  <input
+                    value={inlineFilterKeyword}
+                    onChange={(e) => setInlineFilterKeyword(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
+                    placeholder="e.g. confidential, private..."
+                    className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
+                    className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                  >
+                    Add
+                  </button>
                 </div>
-              </div>
-
-              <p className={`mt-2.5 ${generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-emerald-300'}`}>
-                {generatingToken ? 'Generating secure link...' : 'Recipients can see only the filtered orbis'}
-              </p>
-
-              <div className="mt-3">
-                <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
-                  <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
-                  <p className="text-xs text-gray-200 mt-1">
-                    {hasActiveFilters ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
+                {keywords.length === 0 ? (
+                  <p className="text-white/20 text-xs italic">No filter keywords configured.</p>
+                ) : (
+                  <div className="space-y-1.5 max-h-36 overflow-y-auto">
+                    {keywords.map((kw) => {
+                      const isActive = activeKeywords.includes(kw);
+                      return (
+                        <div
+                          key={kw}
+                          className={`flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border transition-all ${
+                            isActive
+                              ? 'bg-amber-600/15 border-amber-500/40'
+                              : 'bg-white/5 border-white/5 hover:border-white/10'
+                          }`}
+                        >
+                          <span className="text-white text-xs font-mono truncate">{kw}</span>
+                          <div className="flex items-center gap-1.5 flex-shrink-0">
+                            <button
+                              type="button"
+                              onClick={() => toggleKeyword(kw)}
+                              className={`text-[10px] font-medium px-2 py-0.5 rounded transition-colors cursor-pointer ${
+                                isActive
+                                  ? 'bg-amber-500 text-white'
+                                  : 'bg-white/10 text-white/40 hover:text-white hover:bg-white/20'
+                              }`}
+                            >
+                              {isActive ? 'Active' : 'Activate'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => removeKeyword(kw)}
+                              className="text-white/20 hover:text-red-400 transition-colors cursor-pointer"
+                              title="Remove"
+                            >
+                              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+                {activeKeywords.length > 0 && (
+                  <p className="text-amber-400/70 text-[11px] mt-2">
+                    {activeKeywords.length} filter{activeKeywords.length !== 1 ? 's' : ''} active.
                   </p>
-                </div>
+                )}
               </div>
-
-              {hasActiveFilters && (
-                <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 space-y-2">
-                  {hiddenTypesArray.length > 0 && (
-                    <div>
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Hidden node types</p>
-                      <div className="flex flex-wrap gap-1.5">
-                        {hiddenTypesArray.map((type) => (
-                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  {activeKeywords.length > 0 && (
-                    <div>
-                      <p className="text-[10px] text-amber-200/80 uppercase tracking-wide mb-1">Filtered keywords</p>
-                      <div className="flex flex-wrap gap-1.5">
-                        {activeKeywords.map((keyword) => (
-                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
             )}
 
             {isPublic && (
@@ -732,45 +747,114 @@ function SharePanel({
                   </div>
                 )}
 
-                <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
-                  <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in.</p>
-                  <div className="mb-2.5 rounded-lg border border-gray-700/70 bg-gray-900/40 px-3 py-2">
-                    <label className="flex items-start gap-2 text-[11px] text-gray-200 cursor-pointer">
+                <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4 space-y-4">
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
+                    <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to new invites and excluded from shares.</p>
+                    <div className="flex items-center gap-2 mb-3">
                       <input
-                        type="checkbox"
-                        checked={applyFiltersOnInvite}
-                        onChange={(e) => setApplyFiltersOnInvite(e.target.checked)}
-                        className="mt-0.5 accent-purple-500"
+                        value={inlineFilterKeyword}
+                        onChange={(e) => setInlineFilterKeyword(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
+                        placeholder="e.g. confidential, private..."
+                        className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
                       />
-                      <span>
-                        Apply current filters for this invite.
-                        <span className="block text-gray-500 mt-0.5">
-                          {hasActiveFilters
-                            ? `Current set: ${activeKeywords.length} keyword(s), ${hiddenTypesArray.length} hidden type(s).`
-                            : 'No active filters are set right now.'}
-                        </span>
-                      </span>
-                    </label>
+                      <button
+                        type="button"
+                        onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
+                        className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                      >
+                        Add
+                      </button>
+                    </div>
+                    {keywords.length === 0 ? (
+                      <p className="text-white/20 text-xs italic">No filter keywords configured.</p>
+                    ) : (
+                      <div className="space-y-1.5 max-h-36 overflow-y-auto">
+                        {keywords.map((kw) => {
+                          const isActive = activeKeywords.includes(kw);
+                          return (
+                            <div
+                              key={kw}
+                              className={`flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border transition-all ${
+                                isActive
+                                  ? 'bg-amber-600/15 border-amber-500/40'
+                                  : 'bg-white/5 border-white/5 hover:border-white/10'
+                              }`}
+                            >
+                              <span className="text-white text-xs font-mono truncate">{kw}</span>
+                              <div className="flex items-center gap-1.5 flex-shrink-0">
+                                <button
+                                  type="button"
+                                  onClick={() => toggleKeyword(kw)}
+                                  className={`text-[10px] font-medium px-2 py-0.5 rounded transition-colors cursor-pointer ${
+                                    isActive
+                                      ? 'bg-amber-500 text-white'
+                                      : 'bg-white/10 text-white/40 hover:text-white hover:bg-white/20'
+                                  }`}
+                                >
+                                  {isActive ? 'Active' : 'Activate'}
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => removeKeyword(kw)}
+                                  className="text-white/20 hover:text-red-400 transition-colors cursor-pointer"
+                                  title="Remove"
+                                >
+                                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {activeKeywords.length > 0 && (
+                      <p className="text-amber-400/70 text-[11px] mt-2">
+                        {activeKeywords.length} filter{activeKeywords.length !== 1 ? 's' : ''} active.
+                      </p>
+                    )}
                   </div>
-                  <form onSubmit={handleGrantSubmit} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
-                    <input
-                      type="email"
-                      value={grantEmail}
-                      onChange={(e) => { setGrantEmail(e.target.value); setGrantError(null); }}
-                      placeholder="name@example.com"
-                      disabled={grantSubmitting}
-                      className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-gray-500"
-                    />
-                    <button
-                      type="submit"
-                      disabled={grantSubmitting || !grantEmail.trim()}
-                      className="h-11 px-4 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
-                    >
-                      {grantSubmitting ? 'Granting...' : 'Grant Access'}
-                    </button>
-                  </form>
-                  {grantError && <p className="text-[11px] text-red-400 mt-2">{grantError}</p>}
+
+                  <div className="border-t border-gray-700/50 pt-3">
+                    <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
+                    <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access according to your active privacy filters.</p>
+                    <div className="flex items-center gap-2">
+                      <input readOnly value={mcpUri} className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                      <button
+                        type="button"
+                        onClick={handleCopyMcp}
+                        className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="border-t border-gray-700/50 pt-3">
+                    <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
+                    <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in according to the filters selected.</p>
+                    <form onSubmit={handleGrantSubmit} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+                      <input
+                        type="email"
+                        value={grantEmail}
+                        onChange={(e) => { setGrantEmail(e.target.value); setGrantError(null); }}
+                        placeholder="name@example.com"
+                        disabled={grantSubmitting}
+                        className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-gray-500"
+                      />
+                      <button
+                        type="submit"
+                        disabled={grantSubmitting || !grantEmail.trim()}
+                        className="h-11 px-4 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+                      >
+                        {grantSubmitting ? 'Granting...' : 'Grant Access'}
+                      </button>
+                    </form>
+                    {grantError && <p className="text-[11px] text-red-400 mt-2">{grantError}</p>}
+                  </div>
                 </div>
 
                 <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
@@ -848,32 +932,17 @@ function SharePanel({
                                   >
                                     Cancel
                                   </button>
-                                  <button
-                                    type="button"
-                                    onClick={() => void saveGrantFilters(grant.grant_id, activeKeywords.join(', '), hiddenTypesArray.join(', '))}
-                                    disabled={updatingGrantFiltersId === grant.grant_id}
-                                    className="h-8 px-3 rounded-lg border border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 text-xs font-medium transition-colors"
-                                  >
-                                    Use Current Filters
-                                  </button>
                                 </div>
                               </div>
                             ) : (
                               <div className="flex flex-wrap gap-2">
                                 <button
                                   type="button"
-                                  onClick={() => openGrantEditor(grant)}
-                                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
-                                >
-                                  Manage Filters
-                                </button>
-                                <button
-                                  type="button"
                                   onClick={() => void handleApplyCurrentFiltersToGrant(grant)}
                                   disabled={updatingGrantFiltersId === grant.grant_id}
                                   className="h-8 px-3 rounded-lg border border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
                                 >
-                                  Apply Current
+                                  Apply Current Filters
                                 </button>
                                 <button
                                   type="button"
@@ -882,6 +951,13 @@ function SharePanel({
                                   className="h-8 px-3 rounded-lg border border-orange-500/40 text-orange-300 hover:bg-orange-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
                                 >
                                   Clear Filters
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => openGrantEditor(grant)}
+                                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                                >
+                                  Manage Filters
                                 </button>
                               </div>
                             )}
@@ -937,7 +1013,6 @@ function SharePanel({
               </>
             )}
           </div>
-        )}
 
       </motion.div>
     </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -50,11 +50,7 @@ function resolveImportStepLabel(step: string | null | undefined, detail: string 
   return 'Reading PDF';
 }
 
-const QR_SIZE_OPTIONS = [
-  { label: 'Small', value: 128 },
-  { label: 'Medium', value: 160 },
-  { label: 'Large', value: 220 },
-] as const;
+const SHARE_QR_SIZE = 160;
 
 // ── Modals ──
 
@@ -74,7 +70,6 @@ function SharePanel({
   const [shareTokenId, setShareTokenId] = useState<string | null>(null);
   const [generatingToken, setGeneratingToken] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
-  const [qrSize, setQrSize] = useState<(typeof QR_SIZE_OPTIONS)[number]['value']>(160);
   const [grants, setGrants] = useState<AccessGrant[]>([]);
   const [grantsLoading, setGrantsLoading] = useState(false);
   const [grantSearch, setGrantSearch] = useState('');
@@ -233,7 +228,7 @@ function SharePanel({
     try {
       const link = document.createElement('a');
       link.href = qrCanvasRef.current.toDataURL('image/png');
-      link.download = `orbis-${orbId}-${isRestricted ? 'restricted' : 'public'}-${qrSize}px-qr.png`;
+      link.download = `orbis-${orbId}-${isRestricted ? 'restricted' : 'public'}-qr.png`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -241,7 +236,7 @@ function SharePanel({
     } catch {
       addToast('Failed to download QR code', 'error');
     }
-  }, [addToast, canDownloadQr, isRestricted, orbId, qrSize]);
+  }, [addToast, canDownloadQr, isRestricted, orbId]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -442,30 +437,11 @@ function SharePanel({
             </div>
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-                <div className="flex items-center gap-1.5">
-                  {QR_SIZE_OPTIONS.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      onClick={() => setQrSize(option.value)}
-                      className={`h-8 px-3 rounded-lg text-[11px] border transition-colors ${
-                        qrSize === option.value
-                          ? 'border-purple-400/70 bg-purple-500/15 text-white'
-                          : 'border-gray-700 bg-gray-900 text-gray-300 hover:bg-gray-800'
-                      }`}
-                      aria-pressed={qrSize === option.value}
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
               <p className="text-[11px] text-gray-500 mb-3">Use this code on printed material for instant access.</p>
               <div className="flex justify-center">
                 <div className="bg-white p-3 rounded-xl">
-                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={qrSize} level="M" marginSize={2} />
+                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={2} />
                 </div>
               </div>
               <p className="text-[11px] text-gray-500 mt-3">Scans to your current share link.</p>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -479,13 +479,11 @@ function SharePanel({
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <p className="text-[11px] text-gray-500 mb-3">Use this code on printed material for instant access.</p>
-              <div className="flex justify-center">
+              <div className="flex justify-center mt-3">
                 <div className="bg-white p-3 rounded-xl">
                   <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={2} />
                 </div>
               </div>
-              <p className="text-[11px] text-gray-500 mt-3">Scans to your current share link.</p>
             </div>
 
             {isRestricted && (

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -15,7 +15,7 @@ import {
   revokeAccessGrant,
 } from '../api/orbs';
 import type { AccessGrant, OrbVisibility } from '../api/orbs';
-import { QRCodeSVG } from 'qrcode.react';
+import { QRCodeCanvas } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import FloatingInput from '../components/editor/FloatingInput';
@@ -65,7 +65,8 @@ function SharePanel({
   visibility: OrbVisibility;
   onVisibilityChange: (v: OrbVisibility) => Promise<void>;
 }) {
-  const [copied, setCopied] = useState(false);
+  const [copiedField, setCopiedField] = useState<'link' | 'mcp' | null>(null);
+  const [qrDownloaded, setQrDownloaded] = useState(false);
   const [shareTokenId, setShareTokenId] = useState<string | null>(null);
   const [generatingToken, setGeneratingToken] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
@@ -80,10 +81,14 @@ function SharePanel({
   const isPrivate = visibility === 'private';
   const isRestricted = visibility === 'restricted';
   const isPublic = visibility === 'public';
+  const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const bareUrl = `${window.location.origin}/${orbId}`;
   const shareUrl = isRestricted
     ? bareUrl
     : (shareTokenId ? `${bareUrl}?token=${shareTokenId}` : '');
+  const shareableUrl = isRestricted ? bareUrl : shareUrl;
+  const qrValue = shareableUrl || bareUrl;
+  const canDownloadQr = !isPrivate && (isRestricted || Boolean(shareTokenId));
   const mcpUri = `orb://${orbId}`;
 
   // Generate a share token only in public mode
@@ -165,10 +170,24 @@ function SharePanel({
     { value: 'restricted', label: 'Restricted', description: 'Share via invite links' },
   ];
 
-  const copy = (text: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const copy = (text: string, field: 'link' | 'mcp') => {
+    void navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => {
+      setCopiedField((current) => (current === field ? null : current));
+    }, 2000);
+  };
+
+  const handleDownloadQr = () => {
+    if (!canDownloadQr || !qrCanvasRef.current) return;
+    const link = document.createElement('a');
+    link.href = qrCanvasRef.current.toDataURL('image/png');
+    link.download = `orbis-${orbId}-${isRestricted ? 'restricted' : 'public'}-qr.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setQrDownloaded(true);
+    setTimeout(() => setQrDownloaded(false), 2000);
   };
 
   return (
@@ -218,9 +237,25 @@ function SharePanel({
         </div>
 
         {/* QR Code */}
-        <div className={`flex justify-center mb-5 ${isPrivate ? 'opacity-40' : ''}`}>
-          <div className="bg-white p-3 rounded-xl">
-            <QRCodeSVG value={shareUrl || bareUrl} size={140} level="M" />
+        <div className="mb-5">
+          <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
+          <p className="text-[11px] text-gray-500 mt-0.5 mb-2">
+            {isPrivate
+              ? 'Switch to Public or Restricted to download a scannable QR code.'
+              : 'Use this QR code on printed material to open your shared orbis.'}
+          </p>
+          <div className={`flex flex-col items-center gap-3 ${isPrivate ? 'opacity-40' : ''}`}>
+            <div className="bg-white p-3 rounded-xl">
+              <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={156} level="M" marginSize={2} />
+            </div>
+            <button
+              type="button"
+              onClick={handleDownloadQr}
+              disabled={!canDownloadQr || generatingToken}
+              className="bg-gray-800 border border-gray-600 hover:bg-gray-700 hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
+            >
+              {qrDownloaded ? 'Downloaded' : 'Download QR (.png)'}
+            </button>
           </div>
         </div>
 
@@ -260,11 +295,11 @@ function SharePanel({
                 <input readOnly value={shareUrl} className={`flex-1 bg-gray-800 border rounded-lg px-3 py-2 text-white text-sm font-mono ${hasActiveFilters ? 'border-amber-600/30' : 'border-gray-600'}`} />
               )}
               <button
-                onClick={() => copy(shareUrl)}
+                onClick={() => copy(shareUrl, 'link')}
                 disabled={!shareTokenId}
                 className={`${hasActiveFilters ? 'bg-amber-600 hover:bg-amber-700' : 'bg-purple-600 hover:bg-purple-700'} disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap`}
               >
-                {copied ? 'Copied!' : 'Copy'}
+                {copiedField === 'link' ? 'Copied!' : 'Copy'}
               </button>
             </div>
           </div>
@@ -281,10 +316,10 @@ function SharePanel({
               <div className="mt-1 flex items-center gap-2">
                 <input readOnly value={bareUrl} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
                 <button
-                  onClick={() => copy(bareUrl)}
+                  onClick={() => copy(bareUrl, 'link')}
                   className="bg-purple-600 hover:bg-purple-700 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
                 >
-                  {copied ? 'Copied!' : 'Copy'}
+                  {copiedField === 'link' ? 'Copied!' : 'Copy'}
                 </button>
               </div>
             </div>
@@ -349,7 +384,7 @@ function SharePanel({
           </p>
           <div className={`flex items-center gap-2 ${!isPublic ? 'opacity-40 pointer-events-none' : ''}`}>
             <input readOnly value={mcpUri} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-            <button onClick={() => copy(mcpUri)} className="bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap">Copy</button>
+            <button onClick={() => copy(mcpUri, 'mcp')} className="bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap">{copiedField === 'mcp' ? 'Copied!' : 'Copy'}</button>
           </div>
         </div>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -462,10 +462,12 @@ function SharePanel({
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <div className="mt-3 max-w-[700px] mx-auto grid grid-cols-1 md:grid-cols-[auto_minmax(250px,280px)] items-center gap-4 md:gap-8">
-                <div className="justify-self-center md:justify-self-start rounded-xl border border-gray-700/70 bg-gray-900/35 p-2">
-                  <div className="bg-white p-[3px] rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
-                    <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={0} />
+              <div className="mt-3 max-w-[760px] mx-auto grid grid-cols-1 md:grid-cols-2 items-center gap-4 md:gap-0">
+                <div className="flex items-center justify-center md:pr-8">
+                  <div className="rounded-xl border border-gray-700/70 bg-gray-900/35 p-3">
+                    <div className="bg-white p-2 rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
+                      <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+                    </div>
                   </div>
                 </div>
                 <div className="w-full max-w-[280px] justify-self-center md:justify-self-end md:border-l md:border-gray-700/60 md:pl-6 flex flex-col gap-2.5">

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -114,7 +114,7 @@ function SharePanel({
   const modalRef = useRef<HTMLDivElement | null>(null);
   const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const addToast = useToastStore((s) => s.addToast);
-  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword } = useFilterStore();
+  const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword, deactivateAll } = useFilterStore();
   const [inlineFilterKeyword, setInlineFilterKeyword] = useState('');
   const hiddenTypesArray = useMemo(() => Array.from(hiddenNodeTypes), [hiddenNodeTypes]);
   const hasActiveFilters = activeKeywords.length > 0 || hiddenTypesArray.length > 0;
@@ -378,16 +378,26 @@ function SharePanel({
     }
   };
 
-  const handleRevokeGrant = async (grant: AccessGrant) => {
-    const confirmed = window.confirm(`Revoke access for ${grant.email}?`);
-    if (!confirmed) return;
+  const [revokeTarget, setRevokeTarget] = useState<AccessGrant | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  const handleRevokeGrant = (grant: AccessGrant) => {
+    setRevokeTarget(grant);
+  };
+
+  const confirmRevoke = async () => {
+    if (!revokeTarget) return;
+    setRevoking(true);
     try {
-      await revokeAccessGrant(grant.grant_id);
-      setGrants((prev) => prev.filter((g) => g.grant_id !== grant.grant_id));
-      addToast(`Access revoked for ${grant.email}`, 'info');
+      await revokeAccessGrant(revokeTarget.grant_id);
+      setGrants((prev) => prev.filter((g) => g.grant_id !== revokeTarget.grant_id));
+      addToast(`Access revoked for ${revokeTarget.email}`, 'info');
     } catch {
       setGrantError('Failed to revoke access');
       addToast('Failed to revoke access', 'error');
+    } finally {
+      setRevoking(false);
+      setRevokeTarget(null);
     }
   };
 
@@ -433,13 +443,21 @@ function SharePanel({
     }
   };
 
-  const handleVisibilityClick = async (next: OrbVisibility) => {
+  const [pendingVisibility, setPendingVisibility] = useState<OrbVisibility | null>(null);
+
+  const handleVisibilityClick = (next: OrbVisibility) => {
     if (next === visibility || updatingVisibility) return;
+    setPendingVisibility(next);
+  };
+
+  const confirmVisibilityChange = async () => {
+    if (!pendingVisibility) return;
     setUpdatingVisibility(true);
     try {
-      await onVisibilityChange(next);
+      await onVisibilityChange(pendingVisibility);
     } finally {
       setUpdatingVisibility(false);
+      setPendingVisibility(null);
     }
   };
 
@@ -448,8 +466,8 @@ function SharePanel({
     label: string;
     description: string;
   }[] = [
-    { value: 'public', label: 'Public', description: 'Anyone with the link can view' },
     { value: 'restricted', label: 'Restricted', description: 'Share via invite links' },
+    { value: 'public', label: 'Public', description: 'Anyone with the link can view' },
   ];
 
   return (
@@ -530,20 +548,23 @@ function SharePanel({
               <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
                 <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to share links and excluded from exports.</p>
-                <div className="flex items-center gap-2 mb-3">
+                <div className="flex items-center gap-2 mb-2">
                   <input
                     value={inlineFilterKeyword}
                     onChange={(e) => setInlineFilterKeyword(e.target.value)}
                     onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
                     placeholder="e.g. confidential, private..."
-                    className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
+                    className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
                   />
                   <button
                     type="button"
                     onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
-                    className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                    className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors shrink-0"
                   >
                     Add
+                  </button>
+                  <button type="button" onClick={deactivateAll} disabled={activeKeywords.length === 0} className="h-9 px-3 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white/70 text-xs font-medium transition-colors shrink-0 whitespace-nowrap">
+                    Deactivate All
                   </button>
                 </div>
                 {keywords.length === 0 ? (
@@ -751,20 +772,23 @@ function SharePanel({
                   <div>
                     <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
                     <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to new invites and excluded from shares.</p>
-                    <div className="flex items-center gap-2 mb-3">
+                    <div className="flex items-center gap-2 mb-2">
                       <input
                         value={inlineFilterKeyword}
                         onChange={(e) => setInlineFilterKeyword(e.target.value)}
                         onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
                         placeholder="e.g. confidential, private..."
-                        className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
+                        className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
                       />
                       <button
                         type="button"
                         onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
-                        className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors"
+                        className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors shrink-0"
                       >
                         Add
+                      </button>
+                      <button type="button" onClick={deactivateAll} disabled={activeKeywords.length === 0} className="h-9 px-3 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white/70 text-xs font-medium transition-colors shrink-0 whitespace-nowrap">
+                        Deactivate All
                       </button>
                     </div>
                     {keywords.length === 0 ? (
@@ -1015,6 +1039,141 @@ function SharePanel({
           </div>
 
       </motion.div>
+
+      {/* Visibility change confirmation modal */}
+      <AnimatePresence>
+        {pendingVisibility && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/60 z-[60] rounded-2xl"
+              onClick={() => setPendingVisibility(null)}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.92 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.92 }}
+              transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+              className="absolute inset-0 z-[61] flex items-center justify-center p-6"
+            >
+              <div className={`bg-gray-900 border rounded-xl p-5 max-w-sm w-full shadow-2xl ${
+                pendingVisibility === 'restricted'
+                  ? 'border-emerald-500/30'
+                  : 'border-orange-500/30'
+              }`}>
+                <div className="flex items-center gap-3 mb-3">
+                  <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${
+                    pendingVisibility === 'restricted'
+                      ? 'bg-emerald-500/15 border border-emerald-500/30'
+                      : 'bg-orange-500/15 border border-orange-500/30'
+                  }`}>
+                    {pendingVisibility === 'restricted' ? (
+                      <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                      </svg>
+                    ) : (
+                      <svg className="w-5 h-5 text-orange-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="text-white text-sm font-semibold">Switch to {pendingVisibility === 'restricted' ? 'Restricted' : 'Public'}</h3>
+                    <p className={`text-[11px] mt-0.5 ${
+                      pendingVisibility === 'restricted' ? 'text-emerald-400/70' : 'text-orange-400/70'
+                    }`}>
+                      {visibility === 'public' ? 'Public' : 'Restricted'} → {pendingVisibility === 'restricted' ? 'Restricted' : 'Public'}
+                    </p>
+                  </div>
+                </div>
+
+                <div className={`rounded-lg px-3 py-2.5 mb-4 text-xs leading-relaxed ${
+                  pendingVisibility === 'restricted'
+                    ? 'bg-emerald-500/8 border border-emerald-500/15 text-emerald-100/80'
+                    : 'bg-orange-500/8 border border-orange-500/15 text-orange-100/80'
+                }`}>
+                  {pendingVisibility === 'restricted' ? (
+                    <>Only people you explicitly invite will be able to view your orbis. Existing public share links will stop working.</>
+                  ) : (
+                    <>Anyone with a valid share link will be able to view your orbis. You can still control what they see using privacy filters.</>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setPendingVisibility(null)}
+                    className="h-9 px-4 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmVisibilityChange}
+                    disabled={updatingVisibility}
+                    className={`h-9 px-4 rounded-lg text-white text-xs font-medium transition-colors disabled:opacity-50 ${
+                      pendingVisibility === 'restricted'
+                        ? 'bg-emerald-600 hover:bg-emerald-500'
+                        : 'bg-orange-600 hover:bg-orange-500'
+                    }`}
+                  >
+                    {updatingVisibility ? 'Switching...' : 'Confirm'}
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+
+      {/* Revoke access confirmation modal */}
+      <AnimatePresence>
+        {revokeTarget && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/60 z-[60] rounded-2xl"
+              onClick={() => setRevokeTarget(null)}
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.92 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.92 }}
+              transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+              className="absolute inset-0 z-[61] flex items-center justify-center p-6"
+            >
+              <div className="bg-gray-900 border border-gray-700 rounded-xl p-5 max-w-sm w-full shadow-2xl">
+                <h3 className="text-white text-sm font-semibold mb-2">Revoke Access</h3>
+                <p className="text-gray-400 text-xs mb-1">
+                  Remove access for <span className="font-semibold text-white">{revokeTarget.email}</span>?
+                </p>
+                <p className="text-gray-500 text-[11px] mb-4">They will no longer be able to view your orbis.</p>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setRevokeTarget(null)}
+                    className="h-9 px-4 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmRevoke}
+                    disabled={revoking}
+                    className="h-9 px-4 rounded-lg bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-xs font-medium transition-colors"
+                  >
+                    {revoking ? 'Revoking...' : 'Revoke'}
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -525,27 +525,8 @@ function SharePanel({
           </div>
         )}
 
-        <div className="sticky bottom-0 -mx-4 sm:-mx-6 mt-6 px-4 sm:px-6 py-3 border-t border-gray-800 bg-gray-900/95 backdrop-blur">
-          {isPrivate ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={() => handleVisibilityClick('public')}
-                disabled={updatingVisibility}
-                className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-              >
-                Switch To Public
-              </button>
-              <button
-                type="button"
-                onClick={() => handleVisibilityClick('restricted')}
-                disabled={updatingVisibility}
-                className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-              >
-                Switch To Restricted
-              </button>
-            </div>
-          ) : (
+        {!isPrivate && (
+          <div className="sticky bottom-0 -mx-4 sm:-mx-6 mt-6 px-4 sm:px-6 py-3 border-t border-gray-800 bg-gray-900/95 backdrop-blur">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               <button
                 type="button"
@@ -564,8 +545,8 @@ function SharePanel({
                 Download QR (.png)
               </button>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </motion.div>
     </div>
   );

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -12,10 +12,13 @@ import {
   enhanceNote,
   linkSkill,
   listAccessGrants,
+  listConnectionRequests,
+  acceptConnectionRequest,
+  rejectConnectionRequest,
   revokeAccessGrant,
   updateAccessGrantFilters,
 } from '../api/orbs';
-import type { AccessGrant, OrbVisibility } from '../api/orbs';
+import type { AccessGrant, ConnectionRequest, OrbVisibility } from '../api/orbs';
 import { QRCodeCanvas } from 'qrcode.react';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
@@ -66,6 +69,10 @@ function resolveImportStepLabel(step: string | null | undefined, detail: string 
   return 'Reading PDF';
 }
 
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
 const SHARE_QR_SIZE = 160;
 
 // ── Modals ──
@@ -97,6 +104,12 @@ function SharePanel({
   const [editingGrantKeywords, setEditingGrantKeywords] = useState('');
   const [editingGrantHiddenTypes, setEditingGrantHiddenTypes] = useState('');
   const [updatingGrantFiltersId, setUpdatingGrantFiltersId] = useState<string | null>(null);
+  const [pendingRequests, setPendingRequests] = useState<ConnectionRequest[]>([]);
+  const [pendingLoading, setPendingLoading] = useState(false);
+  const [acceptingRequestId, setAcceptingRequestId] = useState<string | null>(null);
+  const [acceptKeywords, setAcceptKeywords] = useState('');
+  const [acceptHiddenTypes, setAcceptHiddenTypes] = useState('');
+  const [rejectingRequestId, setRejectingRequestId] = useState<string | null>(null);
   const [qrActionHint, setQrActionHint] = useState<'copied' | 'downloaded' | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
   const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -184,6 +197,15 @@ function SharePanel({
     return () => {
       active = false;
     };
+  }, [isRestricted]);
+
+  useEffect(() => {
+    if (!isRestricted) return;
+    setPendingLoading(true);
+    listConnectionRequests()
+      .then(setPendingRequests)
+      .catch(() => {})
+      .finally(() => setPendingLoading(false));
   }, [isRestricted]);
 
   useEffect(() => {
@@ -380,6 +402,36 @@ function SharePanel({
     await saveGrantFilters(grant.grant_id, '', '');
   };
 
+  const handleAcceptRequest = async (requestId: string) => {
+    const keywords = acceptKeywords.split(',').map(k => k.trim()).filter(Boolean);
+    const hiddenTypes = acceptHiddenTypes.split(',').map(t => t.trim()).filter(Boolean);
+    try {
+      await acceptConnectionRequest(requestId, { keywords, hidden_node_types: hiddenTypes });
+      setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
+      setAcceptingRequestId(null);
+      setAcceptKeywords('');
+      setAcceptHiddenTypes('');
+      // Refresh grants list
+      listAccessGrants().then(g => setGrants(g.grants));
+      addToast('Access granted', 'success');
+    } catch {
+      addToast('Failed to accept request', 'error');
+    }
+  };
+
+  const handleRejectRequest = async (requestId: string) => {
+    setRejectingRequestId(requestId);
+    try {
+      await rejectConnectionRequest(requestId);
+      setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
+      addToast('Request rejected', 'success');
+    } catch {
+      addToast('Failed to reject request', 'error');
+    } finally {
+      setRejectingRequestId(null);
+    }
+  };
+
   const handleVisibilityClick = async (next: OrbVisibility) => {
     if (next === visibility || updatingVisibility) return;
     setUpdatingVisibility(true);
@@ -483,6 +535,7 @@ function SharePanel({
 
         {!isPrivate && (
           <div className="space-y-4">
+            {isPublic && (
             <div className="rounded-2xl border border-gray-700/80 bg-gradient-to-br from-gray-800/65 to-gray-900/70 p-4 sm:p-5">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
@@ -490,20 +543,20 @@ function SharePanel({
                 </div>
               </div>
 
-              <p className={`mt-2.5 ${isPublic && generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-emerald-300'}`}>
-                {isPublic && generatingToken ? 'Generating secure link...' : 'Recipients can see only the filtered orbis'}
+              <p className={`mt-2.5 ${generatingToken ? 'text-xs text-gray-400' : 'text-sm font-semibold text-emerald-300'}`}>
+                {generatingToken ? 'Generating secure link...' : 'Recipients can see only the filtered orbis'}
               </p>
 
               <div className="mt-3">
                 <div className="rounded-lg border border-gray-700/70 bg-gray-900/45 px-3 py-2">
                   <p className="text-[10px] text-gray-500 uppercase tracking-wide">Active Filters</p>
                   <p className="text-xs text-gray-200 mt-1">
-                    {hasActiveFilters && isPublic ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
+                    {hasActiveFilters ? `${activeKeywords.length + hiddenTypesArray.length}` : '0'}
                   </p>
                 </div>
               </div>
 
-              {hasActiveFilters && isPublic && (
+              {hasActiveFilters && (
                 <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 space-y-2">
                   {hiddenTypesArray.length > 0 && (
                     <div>
@@ -528,6 +581,7 @@ function SharePanel({
                 </div>
               )}
             </div>
+            )}
 
             {isPublic && (
               <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
@@ -546,51 +600,138 @@ function SharePanel({
               </div>
             )}
 
-            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <div className="mt-3 max-w-[760px] mx-auto grid grid-cols-1 md:grid-cols-2 items-center gap-4 md:gap-0">
-                <div className="flex items-center justify-center md:pr-8">
-                  <div className="rounded-xl border border-gray-700/70 bg-gray-900/35 p-3">
-                    <div className="bg-white p-2 rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
-                      <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+            {isPublic && (
+              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
+                <div className="mt-3 max-w-[760px] mx-auto grid grid-cols-1 md:grid-cols-2 items-center gap-4 md:gap-0">
+                  <div className="flex items-center justify-center md:pr-8">
+                    <div className="rounded-xl border border-gray-700/70 bg-gray-900/35 p-3">
+                      <div className="bg-white p-2 rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
+                        <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="w-full max-w-[280px] justify-self-center md:justify-self-end md:border-l md:border-gray-700/60 md:pl-6 flex flex-col gap-2.5">
-                  <button
-                    type="button"
-                    onClick={handleCopyShareLink}
-                    disabled={!canCopyShareLink || generatingToken}
-                    className="h-10 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-                  >
-                    {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDownloadQr}
-                    disabled={!canDownloadQr || generatingToken}
-                    className="h-10 rounded-lg border border-gray-600/80 bg-gray-800/70 hover:bg-gray-700/80 disabled:opacity-50 disabled:cursor-not-allowed text-gray-100 text-sm font-semibold transition-colors"
-                  >
-                    Download QR (.png)
-                  </button>
-                  <p
-                    aria-live="polite"
-                    className={`text-[11px] h-4 transition-colors ${
-                      qrActionHint === 'copied'
-                        ? 'text-emerald-300'
-                        : qrActionHint === 'downloaded'
-                          ? 'text-sky-300'
-                          : 'text-transparent'
-                    }`}
-                  >
-                    {qrActionHint === 'copied' ? 'Copied to clipboard' : qrActionHint === 'downloaded' ? 'QR downloaded' : 'Status'}
-                  </p>
+                  <div className="w-full max-w-[280px] justify-self-center md:justify-self-end md:border-l md:border-gray-700/60 md:pl-6 flex flex-col gap-2.5">
+                    <button
+                      type="button"
+                      onClick={handleCopyShareLink}
+                      disabled={!canCopyShareLink || generatingToken}
+                      className="h-10 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                    >
+                      {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDownloadQr}
+                      disabled={!canDownloadQr || generatingToken}
+                      className="h-10 rounded-lg border border-gray-600/80 bg-gray-800/70 hover:bg-gray-700/80 disabled:opacity-50 disabled:cursor-not-allowed text-gray-100 text-sm font-semibold transition-colors"
+                    >
+                      Download QR (.png)
+                    </button>
+                    <p
+                      aria-live="polite"
+                      className={`text-[11px] h-4 transition-colors ${
+                        qrActionHint === 'copied'
+                          ? 'text-emerald-300'
+                          : qrActionHint === 'downloaded'
+                            ? 'text-sky-300'
+                            : 'text-transparent'
+                      }`}
+                    >
+                      {qrActionHint === 'copied' ? 'Copied to clipboard' : qrActionHint === 'downloaded' ? 'QR downloaded' : 'Status'}
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
 
             {isRestricted && (
               <>
+                {(pendingLoading || pendingRequests.length > 0) && (
+                  <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                    <div className="flex items-center justify-between gap-2 mb-3">
+                      <label className="text-xs text-amber-200/80 uppercase tracking-wide font-medium">Pending Requests</label>
+                      <span className="text-[11px] text-amber-200/60">{pendingRequests.length}</span>
+                    </div>
+                    {pendingLoading && <p className="text-[11px] text-gray-500">Loading requests...</p>}
+                    <div className="space-y-2 max-h-64 overflow-y-auto">
+                      {pendingRequests.map((req) => (
+                        <div key={req.request_id} className="border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60 space-y-2">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <p className="text-sm text-white truncate">{req.requester_name || req.requester_email}</p>
+                              <p className="text-[11px] text-gray-400 mt-0.5">{req.requester_email}</p>
+                              <p className="text-[10px] text-gray-500 mt-0.5">{formatDate(req.created_at)}</p>
+                            </div>
+                            <div className="flex gap-2">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setAcceptingRequestId(acceptingRequestId === req.request_id ? null : req.request_id);
+                                  setAcceptKeywords('');
+                                  setAcceptHiddenTypes('');
+                                }}
+                                className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
+                              >
+                                Accept
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => handleRejectRequest(req.request_id)}
+                                disabled={rejectingRequestId === req.request_id}
+                                className="h-8 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
+                              >
+                                {rejectingRequestId === req.request_id ? 'Rejecting...' : 'Reject'}
+                              </button>
+                            </div>
+                          </div>
+
+                          {acceptingRequestId === req.request_id && (
+                            <div className="rounded-lg border border-gray-700/70 bg-gray-900/60 p-2.5 space-y-2">
+                              <div>
+                                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Filtered Keywords (comma separated)</label>
+                                <input
+                                  type="text"
+                                  value={acceptKeywords}
+                                  onChange={(e) => setAcceptKeywords(e.target.value)}
+                                  placeholder="python, machine learning"
+                                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                                />
+                              </div>
+                              <div>
+                                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Hidden Node Types (comma separated)</label>
+                                <input
+                                  type="text"
+                                  value={acceptHiddenTypes}
+                                  onChange={(e) => setAcceptHiddenTypes(e.target.value)}
+                                  placeholder="Skill, Project"
+                                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
+                                />
+                              </div>
+                              <div className="flex gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => handleAcceptRequest(req.request_id)}
+                                  className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
+                                >
+                                  Confirm &amp; Grant Access
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => setAcceptingRequestId(null)}
+                                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
                   <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
                   <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in.</p>
@@ -748,6 +889,49 @@ function SharePanel({
                         ))}
                       </ul>
                     )}
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
+                  <div className="mt-3 max-w-[760px] mx-auto grid grid-cols-1 md:grid-cols-2 items-center gap-4 md:gap-0">
+                    <div className="flex items-center justify-center md:pr-8">
+                      <div className="rounded-xl border border-gray-700/70 bg-gray-900/35 p-3">
+                        <div className="bg-white p-2 rounded-md shadow-[0_4px_14px_rgba(255,255,255,0.08)]">
+                          <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+                        </div>
+                      </div>
+                    </div>
+                    <div className="w-full max-w-[280px] justify-self-center md:justify-self-end md:border-l md:border-gray-700/60 md:pl-6 flex flex-col gap-2.5">
+                      <button
+                        type="button"
+                        onClick={handleCopyShareLink}
+                        disabled={!canCopyShareLink || generatingToken}
+                        className="h-10 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                      >
+                        {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleDownloadQr}
+                        disabled={!canDownloadQr || generatingToken}
+                        className="h-10 rounded-lg border border-gray-600/80 bg-gray-800/70 hover:bg-gray-700/80 disabled:opacity-50 disabled:cursor-not-allowed text-gray-100 text-sm font-semibold transition-colors"
+                      >
+                        Download QR (.png)
+                      </button>
+                      <p
+                        aria-live="polite"
+                        className={`text-[11px] h-4 transition-colors ${
+                          qrActionHint === 'copied'
+                            ? 'text-emerald-300'
+                            : qrActionHint === 'downloaded'
+                              ? 'text-sky-300'
+                              : 'text-transparent'
+                        }`}
+                      >
+                        {qrActionHint === 'copied' ? 'Copied to clipboard' : qrActionHint === 'downloaded' ? 'QR downloaded' : 'Status'}
+                      </p>
+                    </div>
                   </div>
                 </div>
               </>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -479,9 +479,29 @@ function SharePanel({
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <div className="flex justify-center mt-3">
-                <div className="bg-white p-3 rounded-xl">
-                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={2} />
+              <div className="mt-3 flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+                <div className="order-2 sm:order-1 flex-1 flex flex-col gap-2 sm:max-w-[260px]">
+                  <button
+                    type="button"
+                    onClick={handleCopyShareLink}
+                    disabled={!canCopyShareLink || generatingToken}
+                    className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                  >
+                    {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDownloadQr}
+                    disabled={!canDownloadQr || generatingToken}
+                    className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                  >
+                    Download QR (.png)
+                  </button>
+                </div>
+                <div className="order-1 sm:order-2 flex-1 flex justify-center sm:justify-end">
+                  <div className="bg-white p-1 rounded-lg">
+                    <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+                  </div>
                 </div>
               </div>
             </div>
@@ -550,28 +570,6 @@ function SharePanel({
           </div>
         )}
 
-        {!isPrivate && (
-          <div className="sticky bottom-0 -mx-4 sm:-mx-6 mt-6 px-4 sm:px-6 py-3 border-t border-gray-800 bg-gray-900/95 backdrop-blur">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={handleCopyShareLink}
-                disabled={!canCopyShareLink || generatingToken}
-                className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-              >
-                {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
-              </button>
-              <button
-                type="button"
-                onClick={handleDownloadQr}
-                disabled={!canDownloadQr || generatingToken}
-                className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-              >
-                Download QR (.png)
-              </button>
-            </div>
-          </div>
-        )}
       </motion.div>
     </div>
   );

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -50,6 +50,19 @@ function resolveImportStepLabel(step: string | null | undefined, detail: string 
   return 'Reading PDF';
 }
 
+function truncateMiddle(value: string, max = 64): string {
+  if (value.length <= max) return value;
+  const leftChars = Math.ceil((max - 3) / 2);
+  const rightChars = Math.floor((max - 3) / 2);
+  return `${value.slice(0, leftChars)}...${value.slice(-rightChars)}`;
+}
+
+const QR_SIZE_OPTIONS = [
+  { label: 'Small', value: 128 },
+  { label: 'Medium', value: 160 },
+  { label: 'Large', value: 220 },
+] as const;
+
 // ── Modals ──
 
 function SharePanel({
@@ -65,58 +78,201 @@ function SharePanel({
   visibility: OrbVisibility;
   onVisibilityChange: (v: OrbVisibility) => Promise<void>;
 }) {
-  const [copiedField, setCopiedField] = useState<'link' | 'mcp' | null>(null);
-  const [qrDownloaded, setQrDownloaded] = useState(false);
   const [shareTokenId, setShareTokenId] = useState<string | null>(null);
   const [generatingToken, setGeneratingToken] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
+  const [qrSize, setQrSize] = useState<(typeof QR_SIZE_OPTIONS)[number]['value']>(160);
   const [grants, setGrants] = useState<AccessGrant[]>([]);
   const [grantsLoading, setGrantsLoading] = useState(false);
+  const [grantSearch, setGrantSearch] = useState('');
   const [grantEmail, setGrantEmail] = useState('');
   const [grantError, setGrantError] = useState<string | null>(null);
   const [grantSubmitting, setGrantSubmitting] = useState(false);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const addToast = useToastStore((s) => s.addToast);
   const { activeKeywords } = useFilterStore();
-  const hiddenTypesArray = Array.from(hiddenNodeTypes);
+  const hiddenTypesArray = useMemo(() => Array.from(hiddenNodeTypes), [hiddenNodeTypes]);
   const hasActiveFilters = activeKeywords.length > 0 || hiddenTypesArray.length > 0;
   const isPrivate = visibility === 'private';
   const isRestricted = visibility === 'restricted';
   const isPublic = visibility === 'public';
-  const qrCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const bareUrl = `${window.location.origin}/${orbId}`;
   const shareUrl = isRestricted
     ? bareUrl
     : (shareTokenId ? `${bareUrl}?token=${shareTokenId}` : '');
-  const shareableUrl = isRestricted ? bareUrl : shareUrl;
+  const shareableUrl = isPrivate ? '' : shareUrl;
   const qrValue = shareableUrl || bareUrl;
   const canDownloadQr = !isPrivate && (isRestricted || Boolean(shareTokenId));
+  const canCopyShareLink = !isPrivate && Boolean(shareableUrl);
   const mcpUri = `orb://${orbId}`;
+  const shareSummary = hasActiveFilters && isPublic ? 'Filtered View' : 'Full Orbis';
+  const shortSharePreview = useMemo(() => truncateMiddle(shareableUrl || bareUrl), [bareUrl, shareableUrl]);
+  const shortQrTarget = useMemo(() => truncateMiddle(qrValue), [qrValue]);
+  const filteredGrants = useMemo(() => {
+    const query = grantSearch.trim().toLowerCase();
+    if (!query) return grants;
+    return grants.filter((g) => g.email.toLowerCase().includes(query));
+  }, [grantSearch, grants]);
 
   // Generate a share token only in public mode
   useEffect(() => {
+    let active = true;
     if (orbId && isPublic) {
+      setShareTokenId(null);
       setGeneratingToken(true);
       createShareToken(activeKeywords, hiddenTypesArray)
-        .then((token) => setShareTokenId(token.token_id))
-        .catch(() => setShareTokenId(null))
-        .finally(() => setGeneratingToken(false));
+        .then((token) => {
+          if (!active) return;
+          setShareTokenId(token.token_id);
+        })
+        .catch(() => {
+          if (!active) return;
+          setShareTokenId(null);
+          addToast('Failed to generate share link', 'error');
+        })
+        .finally(() => {
+          if (!active) return;
+          setGeneratingToken(false);
+        });
     } else {
       setShareTokenId(null);
+      setGeneratingToken(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeKeywords, orbId, hiddenNodeTypes.size, isPublic]);
+    return () => {
+      active = false;
+    };
+  }, [activeKeywords, addToast, hiddenTypesArray, orbId, isPublic]);
 
   // Load access grants when restricted mode is active
   useEffect(() => {
+    let active = true;
     if (!isRestricted) {
       setGrants([]);
+      setGrantSearch('');
       return;
     }
     setGrantsLoading(true);
     listAccessGrants()
-      .then((res) => setGrants(res.grants))
-      .catch(() => setGrants([]))
-      .finally(() => setGrantsLoading(false));
+      .then((res) => {
+        if (!active) return;
+        setGrants(res.grants);
+      })
+      .catch(() => {
+        if (!active) return;
+        setGrants([]);
+      })
+      .finally(() => {
+        if (!active) return;
+        setGrantsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, [isRestricted]);
+
+  useEffect(() => {
+    const panel = modalRef.current;
+    if (!panel) return;
+    const selector = [
+      'button:not([disabled])',
+      'a[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(', ');
+
+    const getFocusable = () => Array.from(panel.querySelectorAll<HTMLElement>(selector));
+    const initial = getFocusable();
+    initial[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (!activeEl || !panel.contains(activeEl)) {
+        event.preventDefault();
+        first.focus();
+        return;
+      }
+      if (event.shiftKey && activeEl === first) {
+        event.preventDefault();
+        last.focus();
+        return;
+      }
+      if (!event.shiftKey && activeEl === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const copyText = useCallback(async (text: string, label: string) => {
+    if (!navigator.clipboard?.writeText) {
+      addToast('Clipboard is not available in this browser', 'error');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast(`${label} copied`, 'success');
+    } catch {
+      addToast(`Failed to copy ${label.toLowerCase()}`, 'error');
+    }
+  }, [addToast]);
+
+  const handleCopyShareLink = useCallback(() => {
+    if (!canCopyShareLink || !shareableUrl) return;
+    void copyText(shareableUrl, 'Share link');
+  }, [canCopyShareLink, copyText, shareableUrl]);
+
+  const handleCopyMcp = useCallback(() => {
+    if (!isPublic) return;
+    void copyText(mcpUri, 'MCP Orbis ID');
+  }, [copyText, isPublic, mcpUri]);
+
+  const handleDownloadQr = useCallback(() => {
+    if (!canDownloadQr || !qrCanvasRef.current) return;
+    try {
+      const link = document.createElement('a');
+      link.href = qrCanvasRef.current.toDataURL('image/png');
+      link.download = `orbis-${orbId}-${isRestricted ? 'restricted' : 'public'}-${qrSize}px-qr.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      addToast('QR code downloaded', 'success');
+    } catch {
+      addToast('Failed to download QR code', 'error');
+    }
+  }, [addToast, canDownloadQr, isRestricted, orbId, qrSize]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      const isTyping = tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(target?.isContentEditable);
+      if (isTyping) return;
+      const key = event.key.toLowerCase();
+      const hasModifier = event.metaKey || event.ctrlKey;
+      if (hasModifier && key === 'c' && canCopyShareLink) {
+        event.preventDefault();
+        handleCopyShareLink();
+        return;
+      }
+      if (hasModifier && key === 'd' && canDownloadQr) {
+        event.preventDefault();
+        handleDownloadQr();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [canCopyShareLink, canDownloadQr, handleCopyShareLink, handleDownloadQr]);
 
   const handleGrantSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -133,20 +289,26 @@ function SharePanel({
       const grant = await createAccessGrant(email);
       setGrants((prev) => [grant, ...prev]);
       setGrantEmail('');
+      addToast(`Access granted to ${email}`, 'success');
     } catch (err) {
       const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
       setGrantError(msg || 'Failed to grant access');
+      addToast(msg || 'Failed to grant access', 'error');
     } finally {
       setGrantSubmitting(false);
     }
   };
 
-  const handleRevokeGrant = async (grantId: string) => {
+  const handleRevokeGrant = async (grant: AccessGrant) => {
+    const confirmed = window.confirm(`Revoke access for ${grant.email}?`);
+    if (!confirmed) return;
     try {
-      await revokeAccessGrant(grantId);
-      setGrants((prev) => prev.filter((g) => g.grant_id !== grantId));
+      await revokeAccessGrant(grant.grant_id);
+      setGrants((prev) => prev.filter((g) => g.grant_id !== grant.grant_id));
+      addToast(`Access revoked for ${grant.email}`, 'info');
     } catch {
       setGrantError('Failed to revoke access');
+      addToast('Failed to revoke access', 'error');
     }
   };
 
@@ -170,26 +332,6 @@ function SharePanel({
     { value: 'restricted', label: 'Restricted', description: 'Share via invite links' },
   ];
 
-  const copy = (text: string, field: 'link' | 'mcp') => {
-    void navigator.clipboard.writeText(text);
-    setCopiedField(field);
-    setTimeout(() => {
-      setCopiedField((current) => (current === field ? null : current));
-    }, 2000);
-  };
-
-  const handleDownloadQr = () => {
-    if (!canDownloadQr || !qrCanvasRef.current) return;
-    const link = document.createElement('a');
-    link.href = qrCanvasRef.current.toDataURL('image/png');
-    link.download = `orbis-${orbId}-${isRestricted ? 'restricted' : 'public'}-qr.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    setQrDownloaded(true);
-    setTimeout(() => setQrDownloaded(false), 2000);
-  };
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <motion.div
@@ -205,13 +347,30 @@ function SharePanel({
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.92, y: 24 }}
         transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-md w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share your orbis"
+        ref={modalRef}
+        className="relative bg-gray-900 border border-gray-700 rounded-2xl p-4 sm:p-6 max-w-[95vw] sm:max-w-2xl w-full mx-2 sm:mx-4 shadow-2xl max-h-[90vh] overflow-y-auto"
       >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-3 top-3 h-9 w-9 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors"
+          aria-label="Close share modal"
+        >
+          <svg className="w-4 h-4 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
         <h2 className="text-white text-lg font-semibold mb-1">Share Your Orbis</h2>
-        <p className="text-gray-400 text-sm mb-5">Choose who can view your orbis, then share the link or MCP identifier with people or AI agents.</p>
+        <p className="text-gray-400 text-sm mb-2">Choose visibility, then share with a direct link or QR code.</p>
+        {!isPrivate && (
+          <p className="text-[11px] text-gray-500 mb-5">Keyboard shortcuts: <span className="text-gray-300">Ctrl/Cmd + C</span> copy link, <span className="text-gray-300">Ctrl/Cmd + D</span> download QR.</p>
+        )}
 
         {/* Visibility selector */}
-        <div className="mb-5">
+        <div className="mb-4">
           <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Visibility</label>
           <div className="mt-2 grid grid-cols-3 gap-2">
             {visibilityOptions.map((opt) => {
@@ -222,9 +381,9 @@ function SharePanel({
                   type="button"
                   onClick={() => handleVisibilityClick(opt.value)}
                   disabled={updatingVisibility}
-                  className={`text-left rounded-lg border px-3 py-2 transition-colors disabled:opacity-60 ${
+                  className={`text-left rounded-xl border px-3 py-3 transition-colors disabled:opacity-60 ${
                     selected
-                      ? 'border-purple-500/70 bg-purple-500/15 text-white'
+                      ? 'border-purple-500/70 bg-purple-500/15 text-white shadow-[0_0_0_1px_rgba(168,85,247,0.2)]'
                       : 'border-gray-700 bg-gray-800/40 text-gray-300 hover:bg-gray-800'
                   }`}
                 >
@@ -236,159 +395,213 @@ function SharePanel({
           </div>
         </div>
 
-        {/* QR Code */}
-        <div className="mb-5">
-          <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-          <p className="text-[11px] text-gray-500 mt-0.5 mb-2">
-            {isPrivate
-              ? 'Switch to Public or Restricted to download a scannable QR code.'
-              : 'Use this QR code on printed material to open your shared orbis.'}
-          </p>
-          <div className={`flex flex-col items-center gap-3 ${isPrivate ? 'opacity-40' : ''}`}>
-            <div className="bg-white p-3 rounded-xl">
-              <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={156} level="M" marginSize={2} />
-            </div>
-            <button
-              type="button"
-              onClick={handleDownloadQr}
-              disabled={!canDownloadQr || generatingToken}
-              className="bg-gray-800 border border-gray-600 hover:bg-gray-700 hover:border-gray-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
-            >
-              {qrDownloaded ? 'Downloaded' : 'Download QR (.png)'}
-            </button>
-          </div>
-        </div>
-
         {isPrivate && (
-          <div className="mb-4 rounded-lg border border-gray-700 bg-gray-800/40 px-3 py-2 text-xs text-gray-400">
-            Your orbis is private. Switch to <span className="text-white">Public</span> or <span className="text-white">Restricted</span> to generate a share link.
+          <div className="space-y-4">
+            <div className="rounded-xl border border-gray-700 bg-gray-800/50 p-4">
+              <p className="text-sm text-gray-200 font-medium mb-1">This orbis is currently private</p>
+              <p className="text-xs text-gray-400">No link or QR is available until you switch to Public or Restricted.</p>
+            </div>
+            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
+              <p className="text-[11px] text-gray-500 mt-0.5 mb-2">MCP access is available only in Public mode.</p>
+              <input readOnly value={mcpUri} className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-gray-400 text-sm font-mono" />
+            </div>
           </div>
         )}
 
-        {/* Public mode: filtered share link with token */}
-        {isPublic && (
-          <div className="mb-4">
-            <label className={`text-xs uppercase tracking-wide font-medium ${hasActiveFilters ? 'text-amber-400/80' : 'text-gray-500'}`}>
-              {hasActiveFilters ? 'Filtered Share Link' : 'Share Link'}
-            </label>
-            {hasActiveFilters && (
-              <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
-                This link hides
-                {hiddenTypesArray.length > 0 && (
-                  <span> node types: {hiddenTypesArray.map((t, i) => (
-                    <span key={t}>{i > 0 && ', '}<span className="text-amber-400">{t}</span></span>
-                  ))}</span>
+        {!isPrivate && (
+          <div className="space-y-4">
+            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Shared Content</label>
+              <div className="mt-2 flex items-center gap-2 flex-wrap">
+                <span className={`text-[10px] px-2 py-1 rounded-full border ${hasActiveFilters && isPublic ? 'border-amber-500/40 text-amber-200 bg-amber-500/10' : 'border-emerald-500/40 text-emerald-200 bg-emerald-500/10'}`}>
+                  {shareSummary}
+                </span>
+                {isRestricted && (
+                  <span className="text-[10px] px-2 py-1 rounded-full border border-blue-500/40 text-blue-200 bg-blue-500/10">
+                    Invite-Only
+                  </span>
                 )}
-                {hiddenTypesArray.length > 0 && activeKeywords.length > 0 && ' and'}
-                {activeKeywords.length > 0 && (
-                  <span> keywords: {activeKeywords.map((kw, i) => (
-                    <span key={kw}>{i > 0 && ', '}"<span className="text-amber-400">{kw}</span>"</span>
-                  ))}</span>
-                )}
-                {' '}from the viewer.
-              </p>
-            )}
-            <div className="mt-1 flex items-center gap-2">
-              {generatingToken ? (
-                <div className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-gray-500 text-sm">Generating link...</div>
-              ) : (
-                <input readOnly value={shareUrl} className={`flex-1 bg-gray-800 border rounded-lg px-3 py-2 text-white text-sm font-mono ${hasActiveFilters ? 'border-amber-600/30' : 'border-gray-600'}`} />
+              </div>
+              <p className="text-[11px] text-gray-400 mt-2 font-mono break-all">{isPublic && generatingToken ? 'Generating secure link...' : shortSharePreview}</p>
+              {hasActiveFilters && isPublic && (
+                <div className="mt-3 space-y-2">
+                  {hiddenTypesArray.length > 0 && (
+                    <div>
+                      <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Hidden node types</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {hiddenTypesArray.map((type) => (
+                          <span key={type} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">{type}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {activeKeywords.length > 0 && (
+                    <div>
+                      <p className="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Filtered keywords</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {activeKeywords.map((keyword) => (
+                          <span key={keyword} className="text-[10px] px-2 py-1 rounded-full bg-amber-500/10 border border-amber-500/30 text-amber-200">"{keyword}"</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
               )}
+            </div>
+
+            <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
+                <div className="flex items-center gap-1.5">
+                  {QR_SIZE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setQrSize(option.value)}
+                      className={`h-8 px-3 rounded-lg text-[11px] border transition-colors ${
+                        qrSize === option.value
+                          ? 'border-purple-400/70 bg-purple-500/15 text-white'
+                          : 'border-gray-700 bg-gray-900 text-gray-300 hover:bg-gray-800'
+                      }`}
+                      aria-pressed={qrSize === option.value}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <p className="text-[11px] text-gray-500 mb-3">Use this code on printed material for instant access.</p>
+              <div className="flex justify-center">
+                <div className="bg-white p-3 rounded-xl">
+                  <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={qrSize} level="M" marginSize={2} />
+                </div>
+              </div>
+              <p className="text-[11px] text-gray-500 mt-3">Scans to: <span className="text-gray-300 font-mono">{shortQrTarget}</span></p>
+            </div>
+
+            {isPublic && (
+              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
+                <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access.</p>
+                <div className="flex items-center gap-2">
+                  <input readOnly value={mcpUri} className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                  <button
+                    type="button"
+                    onClick={handleCopyMcp}
+                    className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors"
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {isRestricted && (
+              <>
+                <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
+                  <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in.</p>
+                  <form onSubmit={handleGrantSubmit} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+                    <input
+                      type="email"
+                      value={grantEmail}
+                      onChange={(e) => { setGrantEmail(e.target.value); setGrantError(null); }}
+                      placeholder="name@example.com"
+                      disabled={grantSubmitting}
+                      className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-gray-500"
+                    />
+                    <button
+                      type="submit"
+                      disabled={grantSubmitting || !grantEmail.trim()}
+                      className="h-11 px-4 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+                    >
+                      {grantSubmitting ? 'Granting...' : 'Grant Access'}
+                    </button>
+                  </form>
+                  {grantError && <p className="text-[11px] text-red-400 mt-2">{grantError}</p>}
+                </div>
+
+                <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+                  <div className="flex items-center justify-between gap-2 mb-2">
+                    <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">People With Access</label>
+                    <span className="text-[11px] text-gray-500">{filteredGrants.length}/{grants.length}</span>
+                  </div>
+                  <input
+                    type="search"
+                    value={grantSearch}
+                    onChange={(e) => setGrantSearch(e.target.value)}
+                    placeholder="Search by email"
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2.5 text-white text-sm placeholder-gray-500 mb-3"
+                  />
+                  <div className="max-h-48 overflow-y-auto">
+                    {grantsLoading && <p className="text-[11px] text-gray-500">Loading access list...</p>}
+                    {!grantsLoading && grants.length === 0 && <p className="text-[11px] text-gray-500">No invited users yet.</p>}
+                    {!grantsLoading && grants.length > 0 && filteredGrants.length === 0 && <p className="text-[11px] text-gray-500">No results for this search.</p>}
+                    {!grantsLoading && filteredGrants.length > 0 && (
+                      <ul className="space-y-2">
+                        {filteredGrants.map((grant) => (
+                          <li key={grant.grant_id} className="flex items-center justify-between gap-3 border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60">
+                            <span className="text-sm text-white truncate">{grant.email}</span>
+                            <button
+                              type="button"
+                              onClick={() => handleRevokeGrant(grant)}
+                              className="h-9 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 text-xs font-medium transition-colors whitespace-nowrap"
+                            >
+                              Revoke Access
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="sticky bottom-0 -mx-4 sm:-mx-6 mt-6 px-4 sm:px-6 py-3 border-t border-gray-800 bg-gray-900/95 backdrop-blur">
+          {isPrivate ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               <button
-                onClick={() => copy(shareUrl, 'link')}
-                disabled={!shareTokenId}
-                className={`${hasActiveFilters ? 'bg-amber-600 hover:bg-amber-700' : 'bg-purple-600 hover:bg-purple-700'} disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap`}
+                type="button"
+                onClick={() => handleVisibilityClick('public')}
+                disabled={updatingVisibility}
+                className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
               >
-                {copiedField === 'link' ? 'Copied!' : 'Copy'}
+                Switch To Public
+              </button>
+              <button
+                type="button"
+                onClick={() => handleVisibilityClick('restricted')}
+                disabled={updatingVisibility}
+                className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+              >
+                Switch To Restricted
               </button>
             </div>
-          </div>
-        )}
-
-        {/* Restricted mode: bare URL + manage allowed users */}
-        {isRestricted && (
-          <>
-            <div className="mb-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Orbis Link</label>
-              <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
-                Anyone you grant access below can open this link after signing in.
-              </p>
-              <div className="mt-1 flex items-center gap-2">
-                <input readOnly value={bareUrl} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-                <button
-                  onClick={() => copy(bareUrl, 'link')}
-                  className="bg-purple-600 hover:bg-purple-700 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
-                >
-                  {copiedField === 'link' ? 'Copied!' : 'Copy'}
-                </button>
-              </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={handleCopyShareLink}
+                disabled={!canCopyShareLink || generatingToken}
+                className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+              >
+                {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadQr}
+                disabled={!canDownloadQr || generatingToken}
+                className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+              >
+                Download QR (.png)
+              </button>
             </div>
-
-            <div className="mb-4">
-              <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Allowed Users</label>
-              <p className="text-[11px] text-gray-500 mt-0.5 mb-2">
-                Grant access by email. Recipients receive a notification and can view your orbis after signing in.
-              </p>
-              <form onSubmit={handleGrantSubmit} className="flex items-center gap-2">
-                <input
-                  type="email"
-                  value={grantEmail}
-                  onChange={(e) => { setGrantEmail(e.target.value); setGrantError(null); }}
-                  placeholder="name@example.com"
-                  disabled={grantSubmitting}
-                  className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm placeholder-gray-500"
-                />
-                <button
-                  type="submit"
-                  disabled={grantSubmitting || !grantEmail.trim()}
-                  className="bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap"
-                >
-                  {grantSubmitting ? 'Granting...' : 'Grant'}
-                </button>
-              </form>
-              {grantError && <p className="text-[11px] text-red-400 mt-1">{grantError}</p>}
-
-              <div className="mt-3 max-h-40 overflow-y-auto">
-                {grantsLoading && (
-                  <p className="text-[11px] text-gray-500">Loading...</p>
-                )}
-                {!grantsLoading && grants.length === 0 && (
-                  <p className="text-[11px] text-gray-500">No one has access yet.</p>
-                )}
-                {!grantsLoading && grants.length > 0 && (
-                  <ul className="divide-y divide-gray-800 border border-gray-800 rounded-lg">
-                    {grants.map((g) => (
-                      <li key={g.grant_id} className="flex items-center justify-between px-3 py-2">
-                        <span className="text-xs text-white truncate">{g.email}</span>
-                        <button
-                          onClick={() => handleRevokeGrant(g.grant_id)}
-                          className="text-[10px] text-red-400 hover:text-red-300 ml-2 whitespace-nowrap"
-                        >
-                          Revoke
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            </div>
-          </>
-        )}
-
-        <div className="mb-5">
-          <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
-          <p className="text-[11px] text-gray-500 mt-0.5 mb-1">
-            {isPublic
-              ? 'Use this ID with the OpenOrbis MCP server to let AI agents query your graph.'
-              : 'MCP access is only available for public orbs.'}
-          </p>
-          <div className={`flex items-center gap-2 ${!isPublic ? 'opacity-40 pointer-events-none' : ''}`}>
-            <input readOnly value={mcpUri} className="flex-1 bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-            <button onClick={() => copy(mcpUri, 'mcp')} className="bg-gray-700 hover:bg-gray-600 text-white text-xs font-medium py-2 px-3 rounded-lg transition-colors whitespace-nowrap">{copiedField === 'mcp' ? 'Copied!' : 'Copy'}</button>
-          </div>
+          )}
         </div>
-
-        <button onClick={onClose} className="w-full border border-gray-600 text-gray-300 hover:bg-gray-800 font-medium py-2 rounded-lg transition-colors text-sm">Close</button>
       </motion.div>
     </div>
   );

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -472,28 +472,30 @@ function SharePanel({
 
             <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
               <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">QR Code</label>
-              <div className="mt-3 flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
-                <div className="order-2 sm:order-2 flex-1 flex flex-col gap-2 sm:max-w-[260px]">
-                  <button
-                    type="button"
-                    onClick={handleCopyShareLink}
-                    disabled={!canCopyShareLink || generatingToken}
-                    className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-                  >
-                    {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDownloadQr}
-                    disabled={!canDownloadQr || generatingToken}
-                    className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
-                  >
-                    Download QR (.png)
-                  </button>
-                </div>
-                <div className="order-1 sm:order-1 flex-1 flex justify-center sm:justify-start">
-                  <div className="bg-white p-1 rounded-lg">
-                    <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={1} />
+              <div className="mt-3 flex justify-center">
+                <div className="w-full max-w-[760px] grid grid-cols-1 sm:grid-cols-[auto_minmax(240px,280px)] items-center gap-4 sm:gap-6">
+                  <div className="justify-self-center sm:justify-self-start">
+                    <div className="bg-white p-0.5 rounded-md">
+                      <QRCodeCanvas ref={qrCanvasRef} value={qrValue} size={SHARE_QR_SIZE} level="M" marginSize={0} />
+                    </div>
+                  </div>
+                  <div className="w-full max-w-[280px] justify-self-center sm:justify-self-end flex flex-col gap-2">
+                    <button
+                      type="button"
+                      onClick={handleCopyShareLink}
+                      disabled={!canCopyShareLink || generatingToken}
+                      className="h-11 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                    >
+                      {generatingToken ? 'Generating Link...' : 'Copy Share Link'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDownloadQr}
+                      disabled={!canDownloadQr || generatingToken}
+                      className="h-11 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+                    >
+                      Download QR (.png)
+                    </button>
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useOrbStore } from '../stores/orbStore';
-import { publicTextSearch } from '../api/orbs';
+import { publicTextSearch, requestAccess, getMyConnectionRequest } from '../api/orbs';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import ChatBox from '../components/chat/ChatBox';
@@ -54,6 +54,11 @@ export default function SharedOrbPage() {
 
   const [initialFetchDone, setInitialFetchDone] = useState(false);
 
+  const isNoAccess = !!error && error.toLowerCase().includes("don't have access");
+  const [requestPending, setRequestPending] = useState(false);
+  const [requestSubmitting, setRequestSubmitting] = useState(false);
+  const [requestChecked, setRequestChecked] = useState(false);
+
   const handleNodeClick = useCallback((node: Record<string, unknown>) => {
     const url = (node.url || node.company_url || node.credential_url || node.doi) as string | undefined;
     if (url) {
@@ -86,6 +91,14 @@ export default function SharedOrbPage() {
       navigate('/', { replace: true });
     }
   }, [isUnauthorizedError, orbId, user, navigate]);
+
+  useEffect(() => {
+    if (!isNoAccess || !user || !orbId || requestChecked) return;
+    getMyConnectionRequest(orbId).then((req) => {
+      if (req) setRequestPending(true);
+      setRequestChecked(true);
+    });
+  }, [isNoAccess, user, orbId, requestChecked]);
 
   useEffect(() => {
     const handleResize = () => setDimensions({ width: window.innerWidth, height: window.innerHeight });
@@ -158,7 +171,6 @@ export default function SharedOrbPage() {
 
   if (error || !data) {
     const isPrivate = error?.toLowerCase().includes('private');
-    const isNoAccess = error?.toLowerCase().includes("don't have access");
     const isForbidden = !isPrivate && !isNoAccess && (error?.includes('403') || error?.includes('share token'));
     let title: string;
     let message: string;
@@ -189,6 +201,30 @@ export default function SharedOrbPage() {
           >
             {user ? 'Back to My Orbis' : 'Go to Home'}
           </button>
+          {isNoAccess && user && (
+            <button
+              onClick={async () => {
+                if (!orbId || requestPending || requestSubmitting) return;
+                setRequestSubmitting(true);
+                try {
+                  await requestAccess(orbId);
+                  setRequestPending(true);
+                } catch {
+                  // Already pending or failed
+                } finally {
+                  setRequestSubmitting(false);
+                }
+              }}
+              disabled={requestPending || requestSubmitting}
+              className={`mt-3 px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
+                requestPending
+                  ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                  : 'bg-purple-600 hover:bg-purple-500 text-white'
+              }`}
+            >
+              {requestSubmitting ? 'Sending...' : requestPending ? 'Request Pending' : 'Request Access'}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -195,36 +195,38 @@ export default function SharedOrbPage() {
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-2">{title}</h1>
           <p className="text-gray-400 mb-6">{message}</p>
-          <button
-            onClick={() => navigate(user ? '/myorbis' : '/')}
-            className="px-5 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium transition-colors"
-          >
-            {user ? 'Back to My Orbis' : 'Go to Home'}
-          </button>
-          {isNoAccess && user && (
+          <div className="flex flex-wrap items-center justify-center gap-4">
             <button
-              onClick={async () => {
-                if (!orbId || requestPending || requestSubmitting) return;
-                setRequestSubmitting(true);
-                try {
-                  await requestAccess(orbId);
-                  setRequestPending(true);
-                } catch {
-                  // Already pending or failed
-                } finally {
-                  setRequestSubmitting(false);
-                }
-              }}
-              disabled={requestPending || requestSubmitting}
-              className={`mt-3 px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
-                requestPending
-                  ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
-                  : 'bg-purple-600 hover:bg-purple-500 text-white'
-              }`}
+              onClick={() => navigate(user ? '/myorbis' : '/')}
+              className="px-5 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium transition-colors"
             >
-              {requestSubmitting ? 'Sending...' : requestPending ? 'Request Pending' : 'Request Access'}
+              {user ? 'Back to My Orbis' : 'Go to Home'}
             </button>
-          )}
+            {isNoAccess && user && (
+              <button
+                onClick={async () => {
+                  if (!orbId || requestPending || requestSubmitting) return;
+                  setRequestSubmitting(true);
+                  try {
+                    await requestAccess(orbId);
+                    setRequestPending(true);
+                  } catch {
+                    // Already pending or failed
+                  } finally {
+                    setRequestSubmitting(false);
+                  }
+                }}
+                disabled={requestPending || requestSubmitting}
+                className={`px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  requestPending
+                    ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                    : 'bg-purple-600 hover:bg-purple-500 text-white'
+                }`}
+              >
+                {requestSubmitting ? 'Sending...' : requestPending ? 'Request Pending' : 'Request Access'}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/stores/filterStore.ts
+++ b/frontend/src/stores/filterStore.ts
@@ -10,6 +10,7 @@ interface FilterState {
   addKeyword: (keyword: string) => void;
   removeKeyword: (keyword: string) => void;
   toggleKeyword: (keyword: string) => void;
+  deactivateAll: () => void;
 }
 
 export const useFilterStore = create<FilterState>()(
@@ -41,6 +42,10 @@ export const useFilterStore = create<FilterState>()(
         } else {
           set({ activeKeywords: [...activeKeywords, keyword] });
         }
+      },
+
+      deactivateAll: () => {
+        set({ activeKeywords: [] });
       },
 
     }),

--- a/frontend/src/stores/orbStore.ts
+++ b/frontend/src/stores/orbStore.ts
@@ -101,7 +101,6 @@ export const useOrbStore = create<OrbState>((set, get) => ({
     try {
       await orbsApi.updateVisibility(visibility);
       await get().fetchOrb();
-      useToastStore.getState().addToast('Visibility updated', 'success');
     } catch (e) {
       useToastStore.getState().addToast('Failed to update visibility', 'error');
       throw e;

--- a/infra/neo4j/init.cypher
+++ b/infra/neo4j/init.cypher
@@ -52,3 +52,8 @@ CREATE INDEX access_grant_email IF NOT EXISTS FOR (g:AccessGrant) ON (g.email);
 // LLM usage tracking
 CREATE CONSTRAINT llm_usage_id IF NOT EXISTS FOR (u:LLMUsage) REQUIRE u.usage_id IS UNIQUE;
 CREATE INDEX llm_usage_endpoint IF NOT EXISTS FOR (u:LLMUsage) ON (u.endpoint);
+
+// Connection requests for restricted orbs
+CREATE CONSTRAINT connection_request_id IF NOT EXISTS FOR (cr:ConnectionRequest) REQUIRE cr.request_id IS UNIQUE;
+CREATE INDEX connection_request_status IF NOT EXISTS FOR (cr:ConnectionRequest) ON (cr.status);
+CREATE INDEX connection_request_requester IF NOT EXISTS FOR (cr:ConnectionRequest) ON (cr.requester_user_id);


### PR DESCRIPTION
## Summary

### Share Modal UX
- Remove private visibility option, only Public and Restricted remain
- Swap colors: public=orange, restricted=green
- Share button color matches active visibility mode
- Restricted tab on the left, public on the right
- Visibility switch confirmation modal with icon + contextual impact description
- Revoke access confirmation modal
- Add inline privacy filters to both public and restricted modals
- Add "Deactivate All" button to keyword filters
- Integrate MCP Orbis ID between filters and invite in restricted view
- Widen keyword filter dropdown to fit all buttons
- Remove "Shared Content" block, "Apply current filters" checkbox
- Rename "Apply Current" to "Apply Current Filters"
- Move "Manage Filters" to last button position

### Connection Request Flow
- Authenticated visitors can request access to a restricted orb ("Request Access" button)
- Owner sees "Pending Requests" section with accept/reject
- Accept opens inline filter editor before granting access
- New `ConnectionRequest` Neo4j node with backend endpoints
- New service layer: create, get, list, accept, reject

### Backend
- Fix `_serialize_orb` KeyError for nodes without uid
- New Cypher queries and schema for ConnectionRequest
- 5 new REST endpoints for connection requests

Closes #264

## Schema Changes
- New `ConnectionRequest` node with constraint on `request_id`, indexes on `status` and `requester_user_id`
- `(Person)-[:HAS_CONNECTION_REQUEST]->(ConnectionRequest)` relationship

## Documentation
- Design spec: `docs/superpowers/specs/2026-04-11-connection-request-flow-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-11-connection-request-flow.md`

## Test plan
- [x] 516 unit tests pass, 75% coverage
- [x] Frontend type-check clean
- [ ] Visit a restricted orb as authenticated non-granted user → "Request Access" button visible
- [ ] Click "Request Access" → button changes to "Request Pending"
- [ ] Owner opens share modal → "Pending Requests" section shows the request
- [ ] Owner clicks "Accept" → filter editor opens, confirm grants access
- [ ] Owner clicks "Reject" → request removed
- [ ] Visibility switch shows confirmation modal with icon and impact
- [ ] Revoke access shows confirmation modal
- [ ] Privacy filters inline in both public and restricted modals
- [ ] Share button color matches visibility mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #265