### PR TITLE
feat: connection requests, share modal redesign, and discard orbis

### DIFF
--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -18,6 +18,7 @@ from app.graph.encryption import decrypt_properties, encrypt_properties
 from app.graph.queries import (
     ADD_NODE,
     DELETE_NODE,
+    DELETE_PERSON_FULL,
     GET_FULL_ORB,
     GET_FULL_ORB_PUBLIC,
     GET_PERSON_BY_ORB_ID,
@@ -347,6 +348,39 @@ async def delete_node(
     async with db.session() as session:
         await session.run(DELETE_NODE, uid=uid)
         return {"status": "deleted"}
+
+
+@router.delete("/me/content")
+async def discard_orb_content(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Delete all orb content (nodes, relationships) but keep the account."""
+    user_id = current_user["user_id"]
+    async with db.session() as session:
+        await session.run(DELETE_PERSON_FULL, user_id=user_id)
+
+    # Clear stored CVs, drafts, and snapshots
+    try:
+        from app.cv_storage.storage import delete_all_for_user as delete_cvs
+
+        delete_cvs(user_id)
+    except Exception:
+        logger.warning("Failed to clear stored CVs for %s", user_id)
+    try:
+        from app.drafts.db import delete_all_for_user as delete_drafts
+
+        delete_drafts(user_id)
+    except Exception:
+        logger.warning("Failed to clear drafts for %s", user_id)
+    try:
+        from app.snapshots.db import delete_all_for_user as delete_snapshots
+
+        delete_snapshots(user_id)
+    except Exception:
+        logger.warning("Failed to clear snapshots for %s", user_id)
+
+    return {"status": "discarded"}
 
 
 @router.post("/me/link-skill")

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -355,30 +355,10 @@ async def discard_orb_content(
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
 ):
-    """Delete all orb content (nodes, relationships) but keep the account."""
+    """Delete all orb nodes and relationships but keep account, CVs, drafts, and snapshots."""
     user_id = current_user["user_id"]
     async with db.session() as session:
         await session.run(DELETE_PERSON_FULL, user_id=user_id)
-
-    # Clear stored CVs, drafts, and snapshots
-    try:
-        from app.cv_storage.storage import delete_all_for_user as delete_cvs
-
-        delete_cvs(user_id)
-    except Exception:
-        logger.warning("Failed to clear stored CVs for %s", user_id)
-    try:
-        from app.drafts.db import delete_all_for_user as delete_drafts
-
-        delete_drafts(user_id)
-    except Exception:
-        logger.warning("Failed to clear drafts for %s", user_id)
-    try:
-        from app.snapshots.db import delete_all_for_user as delete_snapshots
-
-        delete_snapshots(user_id)
-    except Exception:
-        logger.warning("Failed to clear snapshots for %s", user_id)
 
     return {"status": "discarded"}
 

--- a/frontend/src/api/orbs.ts
+++ b/frontend/src/api/orbs.ts
@@ -33,6 +33,10 @@ export async function hasOrbContent(): Promise<boolean> {
   }
 }
 
+export async function discardOrbContent(): Promise<void> {
+  await client.delete('/orbs/me/content');
+}
+
 export async function getPublicOrb(orbId: string, token?: string | null): Promise<OrbData> {
   // Token is required only for public orbs. Restricted orbs use the
   // axios interceptor's Bearer auth instead.

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { deleteAccount } from '../api/auth';
-import { claimOrbId, getVersions, createVersion, restoreVersion, deleteVersion } from '../api/orbs';
+import { claimOrbId, getVersions, createVersion, restoreVersion, deleteVersion, discardOrbContent } from '../api/orbs';
 import type { SnapshotMetadata } from '../api/orbs';
 import { getDocuments, downloadCV } from '../api/cv';
 import type { DocumentMetadata } from '../api/cv';
@@ -375,17 +375,15 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
   const handleDiscardOrbis = async () => {
     setDiscarding(true);
     try {
-      const { discardOrbContent } = await import('../api/orbs');
       await discardOrbContent();
-      addToast('Orbis content discarded. You can start fresh.', 'info');
-      setShowDiscardConfirm(false);
-      setOpen(false);
-      navigate('/create', { replace: true });
-    } catch {
+    } catch (e) {
+      console.error('Discard failed:', e);
       addToast('Failed to discard orbis. Please try again.', 'error');
-    } finally {
       setDiscarding(false);
+      return;
     }
+    // Success — full page reload to refetch clean state
+    window.location.replace('/myorbis?discarded=1');
   };
 
   const handleDeleteAccount = async () => {
@@ -679,7 +677,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
                     <div className="bg-orange-500/8 border border-orange-500/25 rounded-xl p-4">
                       <h3 className="text-orange-300 text-sm font-semibold mb-2">Discard Orbis</h3>
                       <p className="text-white/65 text-xs leading-relaxed mb-4">
-                        Remove all nodes, relationships, uploaded CVs, drafts, and snapshots from your orbis. Your account and profile will be preserved.
+                        Remove all nodes and relationships from your orbis. Your account, profile, uploaded CVs, drafts, and snapshots will be preserved.
                       </p>
 
                       {!showDiscardConfirm ? (

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -303,6 +303,8 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
   // Delete account state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const [discarding, setDiscarding] = useState(false);
 
   const fetchVersions = useCallback(async () => {
     setVersionsLoading(true);
@@ -369,6 +371,22 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
   };
 
   const [recovering, setRecovering] = useState(false);
+
+  const handleDiscardOrbis = async () => {
+    setDiscarding(true);
+    try {
+      const { discardOrbContent } = await import('../api/orbs');
+      await discardOrbContent();
+      addToast('Orbis content discarded. You can start fresh.', 'info');
+      setShowDiscardConfirm(false);
+      setOpen(false);
+      navigate('/create', { replace: true });
+    } catch {
+      addToast('Failed to discard orbis. Please try again.', 'error');
+    } finally {
+      setDiscarding(false);
+    }
+  };
 
   const handleDeleteAccount = async () => {
     setDeleting(true);
@@ -656,7 +674,46 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
                       {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
                     </div>
                   ) : (
-                    /* ── Normal state — show delete option ── */
+                    <>
+                    {/* ── Discard Orbis ── */}
+                    <div className="bg-orange-500/8 border border-orange-500/25 rounded-xl p-4">
+                      <h3 className="text-orange-300 text-sm font-semibold mb-2">Discard Orbis</h3>
+                      <p className="text-white/65 text-xs leading-relaxed mb-4">
+                        Remove all nodes, relationships, uploaded CVs, drafts, and snapshots from your orbis. Your account and profile will be preserved.
+                      </p>
+
+                      {!showDiscardConfirm ? (
+                        <button
+                          onClick={() => setShowDiscardConfirm(true)}
+                          className="bg-orange-600/20 hover:bg-orange-600/30 text-orange-300 border border-orange-500/40 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70"
+                        >
+                          Discard my orbis
+                        </button>
+                      ) : (
+                        <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-3 mt-2">
+                          <p className="text-orange-300 text-xs font-medium mb-3">
+                            Are you sure? This will permanently delete all your orbis content. This action cannot be undone.
+                          </p>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => setShowDiscardConfirm(false)}
+                              className="border border-white/20 text-white/75 hover:bg-white/10 text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              onClick={handleDiscardOrbis}
+                              disabled={discarding}
+                              className="bg-orange-600 hover:bg-orange-500 disabled:opacity-50 text-white text-xs font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70"
+                            >
+                              {discarding ? 'Discarding...' : 'Yes, discard everything'}
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* ── Delete Account ── */}
                     <div className="bg-red-500/8 border border-red-500/25 rounded-xl p-4">
                       <h3 className="text-red-300 text-sm font-semibold mb-2">Delete Account</h3>
                       <p className="text-white/65 text-xs leading-relaxed mb-4">
@@ -694,6 +751,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
                         </div>
                       )}
                     </div>
+                    </>
                   )}
                 </motion.div>
               )}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1372,7 +1372,8 @@ export default function OrbViewPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const locationState = (location.state as { allowEmpty?: boolean; startTour?: boolean } | null) ?? null;
-  const allowEmpty = locationState?.allowEmpty === true;
+  const searchParams = new URLSearchParams(location.search);
+  const allowEmpty = locationState?.allowEmpty === true || searchParams.has('discarded');
   const hasRedirectedRef = useRef(false);
   const consumedStartTourRef = useRef(false);
   useEffect(() => {
@@ -1942,14 +1943,14 @@ export default function OrbViewPage() {
 
       {/* ── Empty graph hint — point to the + Add button ── */}
       {data.nodes.length === 0 && !showInput && (
-        <div className="absolute inset-0 z-20 flex items-end justify-center pointer-events-none pb-28 sm:pb-32">
+        <div className="fixed bottom-28 sm:bottom-36 left-1/2 z-20 pointer-events-none" style={{ transform: 'translateX(calc(-50% + min(45vw, 16rem)))' }}>
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.5, duration: 0.6 }}
             className="text-center"
           >
-            <p className="text-white/50 text-sm mb-3">
+            <p className="text-white/50 text-sm mb-3 whitespace-nowrap">
               Tap the <span className="text-purple-400 font-semibold">＋</span> button to start populating your Orbis
             </p>
             <motion.div


### PR DESCRIPTION
## Summary

### Connection Request Flow (#264)
- Authenticated visitors can request access to restricted orbs ("Request Access" button)
- Owner sees "Pending Requests" section with Accept/Reject
- Accept opens inline filter editor before granting access
- New `ConnectionRequest` Neo4j node + 5 REST endpoints + service layer

### Share Modal Redesign
- Remove private visibility option — only Public (orange) and Restricted (green)
- Visibility switch confirmation modal with icon + contextual impact description
- Revoke access confirmation modal
- Inline privacy filters in both public and restricted modals
- "Deactivate All" button for keyword filters
- MCP Orbis ID integrated between filters and invite
- Share button color matches active visibility mode

### Discard Orbis (#265)
- New DELETE /orbs/me/content endpoint — wipes nodes/relationships, preserves account + CVs + drafts + snapshots
- "Discard Orbis" section in UserMenu with confirmation dialog
- Page reloads showing only central Person node

### Other Fixes
- Fix `_serialize_orb` KeyError for nodes without uid
- Fix empty-graph arrow alignment with + button
- Fix `test_update_access_grant_filters_success` mock

Closes #264
Closes #265

## Schema Changes
- New `ConnectionRequest` node with constraint + indexes
- `(Person)-[:HAS_CONNECTION_REQUEST]->(ConnectionRequest)` relationship

## Documentation
- Design spec: `docs/superpowers/specs/2026-04-11-connection-request-flow-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-11-connection-request-flow.md`

## Test plan
- [x] 516 unit tests pass, 75% coverage
- [x] Frontend type-check clean
- [ ] Visit restricted orb as non-granted user → "Request Access" button
- [ ] Owner accepts request with filters → access granted
- [ ] Owner rejects request → removed from list
- [ ] Switch visibility → confirmation modal with icon + impact
- [ ] Revoke access → confirmation modal
- [ ] Privacy filters inline in both modals
- [ ] Discard orbis → page reloads with only central node
- [ ] Share button color matches visibility mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)