### PR TITLE
fix: require share token for MCP access and apply filters

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -32,40 +32,42 @@ async def _get_driver():
 
 
 @mcp.tool()
-async def orbis_get_summary(orb_id: str) -> dict:
-    """Get a summary of a person's professional profile including name, headline, location, and counts of each node type (education, work, skills, etc.)."""
+async def orbis_get_summary(orb_id: str, token: str) -> dict:
+    """Get a summary of a person's professional profile including name, headline, location, and counts of each node type. Requires a valid share token."""
     driver = await _get_driver()
-    return await get_orb_summary(driver, orb_id)
+    return await get_orb_summary(driver, orb_id, token)
 
 
 @mcp.tool()
-async def orbis_get_full_orb(orb_id: str) -> dict:
-    """Get the complete graph data for a person's orb, including all nodes (education, work experience, skills, publications, projects, certifications, languages, collaborators) and their properties."""
+async def orbis_get_full_orb(orb_id: str, token: str) -> dict:
+    """Get the complete graph data for a person's orb, filtered according to the share token's privacy settings. Requires a valid share token."""
     driver = await _get_driver()
-    return await get_orb_full(driver, orb_id)
+    return await get_orb_full(driver, orb_id, token)
 
 
 @mcp.tool()
-async def orbis_get_nodes_by_type(orb_id: str, node_type: str) -> list[dict]:
-    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, collaborator."""
+async def orbis_get_nodes_by_type(
+    orb_id: str, node_type: str, token: str
+) -> list[dict]:
+    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, collaborator. Requires a valid share token."""
     driver = await _get_driver()
-    return await get_nodes_by_type(driver, orb_id, node_type)
+    return await get_nodes_by_type(driver, orb_id, node_type, token)
 
 
 @mcp.tool()
-async def orbis_get_connections(orb_id: str, node_uid: str) -> dict:
-    """Get all relationships and connected nodes for a specific node identified by its uid."""
+async def orbis_get_connections(orb_id: str, node_uid: str, token: str) -> dict:
+    """Get all relationships and connected nodes for a specific node identified by its uid. Requires a valid share token."""
     driver = await _get_driver()
-    return await get_connections(driver, orb_id, node_uid)
+    return await get_connections(driver, orb_id, node_uid, token)
 
 
 @mcp.tool()
 async def orbis_get_skills_for_experience(
-    orb_id: str, experience_uid: str
+    orb_id: str, experience_uid: str, token: str
 ) -> list[dict]:
-    """Get all skills that were used in a specific work experience or project, identified by the experience's uid."""
+    """Get all skills that were used in a specific work experience or project, identified by the experience's uid. Requires a valid share token."""
     driver = await _get_driver()
-    return await get_skills_for_experience(driver, orb_id, experience_uid)
+    return await get_skills_for_experience(driver, orb_id, experience_uid, token)
 
 
 if __name__ == "__main__":

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -7,34 +7,59 @@ from neo4j import AsyncDriver
 from app.graph.encryption import decrypt_properties
 from app.graph.queries import (
     GET_FULL_ORB_PUBLIC,
-    GET_PERSON_VISIBILITY,
     NODE_TYPE_LABELS,
     NODE_TYPE_RELATIONSHIPS,
 )
+from app.orbs.share_token import node_matches_filters, validate_share_token
 
 
-async def _check_visibility(driver: AsyncDriver, orb_id: str) -> dict | None:
-    """Return an error dict if the orb is not publicly accessible, else ``None``.
+async def _validate_access(driver: AsyncDriver, orb_id: str, token: str) -> dict | None:
+    """Validate a share token and return filter config, or an error dict.
 
-    The MCP server is anonymous (no user context), so it can only serve
-    ``public`` orbs. ``private`` and ``restricted`` orbs are rejected
-    with a generic message that doesn't leak which mode is in use.
+    Returns ``{"keywords": [...], "hidden_node_types": [...]}`` on success,
+    or ``{"error": "..."}`` on failure.
     """
-    async with driver.session() as session:
-        result = await session.run(GET_PERSON_VISIBILITY, orb_id=orb_id)
-        record = await result.single()
-    if record is None:
-        return {"error": f"Orb '{orb_id}' not found"}
-    if record["visibility"] != "public":
-        return {"error": f"Orb '{orb_id}' is not publicly accessible"}
-    return None
+    if not token:
+        return {"error": "A share token is required to access this orb via MCP."}
+
+    token_data = await validate_share_token(driver, token)
+    if token_data is None:
+        return {"error": "Invalid or expired share token."}
+    if token_data["orb_id"] != orb_id:
+        return {"error": "Token does not grant access to this orb."}
+
+    return {
+        "keywords": token_data.get("keywords", []),
+        "hidden_node_types": token_data.get("hidden_node_types", []),
+    }
 
 
-async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
+def _apply_filters(
+    nodes: list[dict],
+    keywords: list[str],
+    hidden_node_types: list[str],
+) -> list[dict]:
+    """Filter out nodes matching keywords or hidden types."""
+    if not keywords and not hidden_node_types:
+        return nodes
+    hidden_set = set(hidden_node_types)
+    filtered = []
+    for node in nodes:
+        labels = set(node.get("_labels", []) or [node.get("_type", "")])
+        if hidden_set and labels & hidden_set:
+            continue
+        if keywords and node_matches_filters(node, keywords):
+            continue
+        filtered.append(node)
+    return filtered
+
+
+async def get_orb_summary(driver: AsyncDriver, orb_id: str, token: str) -> dict:
     """Get a structured summary of a person's professional profile."""
-    blocked = await _check_visibility(driver, orb_id)
-    if blocked is not None:
-        return blocked
+    access = await _validate_access(driver, orb_id, token)
+    if "error" in access:
+        return access
+
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
         record = await result.single()
@@ -46,13 +71,24 @@ async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
         person.pop("encryption_key_id", None)
         person.pop("embedding", None)
 
-        # Count nodes by type
+        keywords = access["keywords"]
+        hidden_types = access["hidden_node_types"]
+
+        # Count nodes by type, respecting filters
         type_counts: dict[str, int] = {}
         for conn in record["connections"]:
             if conn["node"] is None:
                 continue
+            node = decrypt_properties(dict(conn["node"]))
             labels = list(conn["node"].labels)
             label = labels[0] if labels else "Unknown"
+
+            # Apply filters
+            if label in hidden_types:
+                continue
+            if keywords and node_matches_filters(node, keywords):
+                continue
+
             type_counts[label] = type_counts.get(label, 0) + 1
 
         return {
@@ -66,11 +102,12 @@ async def get_orb_summary(driver: AsyncDriver, orb_id: str) -> dict:
         }
 
 
-async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
+async def get_orb_full(driver: AsyncDriver, orb_id: str, token: str) -> dict:
     """Get the complete graph data for an orb."""
-    blocked = await _check_visibility(driver, orb_id)
-    if blocked is not None:
-        return blocked
+    access = await _validate_access(driver, orb_id, token)
+    if "error" in access:
+        return access
+
     async with driver.session() as session:
         result = await session.run(GET_FULL_ORB_PUBLIC, orb_id=orb_id)
         record = await result.single()
@@ -91,11 +128,13 @@ async def get_orb_full(driver: AsyncDriver, orb_id: str) -> dict:
             node["_relationship"] = conn["rel"]
             nodes.append(node)
 
+        nodes = _apply_filters(nodes, access["keywords"], access["hidden_node_types"])
+
         return {"person": person, "nodes": nodes}
 
 
 async def get_nodes_by_type(
-    driver: AsyncDriver, orb_id: str, node_type: str
+    driver: AsyncDriver, orb_id: str, node_type: str, token: str
 ) -> list[dict]:
     """Get all nodes of a specific type from an orb."""
     if node_type not in NODE_TYPE_LABELS:
@@ -105,11 +144,15 @@ async def get_nodes_by_type(
             }
         ]
 
-    blocked = await _check_visibility(driver, orb_id)
-    if blocked is not None:
-        return [blocked]
+    access = await _validate_access(driver, orb_id, token)
+    if "error" in access:
+        return [access]
 
+    # Block if this node type is hidden
     label = NODE_TYPE_LABELS[node_type]
+    if label in access.get("hidden_node_types", []):
+        return []
+
     rel_type = NODE_TYPE_RELATIONSHIPS[node_type]
 
     query = f"""
@@ -117,33 +160,47 @@ async def get_nodes_by_type(
     RETURN n
     """
 
+    keywords = access["keywords"]
     async with driver.session() as session:
         result = await session.run(query, orb_id=orb_id)
         nodes = []
         async for record in result:
             node = decrypt_properties(dict(record["n"]))
             node.pop("embedding", None)
+            if keywords and node_matches_filters(node, keywords):
+                continue
             nodes.append(node)
         return nodes
 
 
-async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> dict:
+async def get_connections(
+    driver: AsyncDriver, orb_id: str, node_uid: str, token: str
+) -> dict:
     """Get all relationships for a specific node."""
-    blocked = await _check_visibility(driver, orb_id)
-    if blocked is not None:
-        return blocked
+    access = await _validate_access(driver, orb_id, token)
+    if "error" in access:
+        return access
+
     query = """
     MATCH (n {uid: $node_uid})-[r]-(connected)
     MATCH (p:Person {orb_id: $orb_id})-[*1..2]-(n)
     RETURN n, type(r) AS rel_type, connected, labels(connected) AS connected_labels
     """
 
+    keywords = access["keywords"]
+    hidden_types = set(access["hidden_node_types"])
+
     async with driver.session() as session:
         result = await session.run(query, orb_id=orb_id, node_uid=node_uid)
         connections = []
         async for record in result:
+            conn_labels = set(record["connected_labels"])
+            if hidden_types and conn_labels & hidden_types:
+                continue
             conn_node = decrypt_properties(dict(record["connected"]))
             conn_node.pop("embedding", None)
+            if keywords and node_matches_filters(conn_node, keywords):
+                continue
             conn_node["_labels"] = record["connected_labels"]
             connections.append(
                 {
@@ -155,23 +212,31 @@ async def get_connections(driver: AsyncDriver, orb_id: str, node_uid: str) -> di
 
 
 async def get_skills_for_experience(
-    driver: AsyncDriver, orb_id: str, experience_uid: str
+    driver: AsyncDriver, orb_id: str, experience_uid: str, token: str
 ) -> list[dict]:
     """Get skills associated with a specific work experience or project."""
-    blocked = await _check_visibility(driver, orb_id)
-    if blocked is not None:
-        return [blocked]
+    access = await _validate_access(driver, orb_id, token)
+    if "error" in access:
+        return [access]
+
+    # If Skill type is hidden, return empty
+    if "Skill" in access.get("hidden_node_types", []):
+        return []
+
     query = """
     MATCH (p:Person {orb_id: $orb_id})-[]->(exp {uid: $experience_uid})
     MATCH (exp)-[:USED_SKILL]->(s:Skill)
     RETURN s
     """
 
+    keywords = access["keywords"]
     async with driver.session() as session:
         result = await session.run(query, orb_id=orb_id, experience_uid=experience_uid)
         skills = []
         async for record in result:
             skill = dict(record["s"])
             skill.pop("embedding", None)
+            if keywords and node_matches_filters(skill, keywords):
+                continue
             skills.append(skill)
         return skills

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -16,6 +16,7 @@ import {
   acceptConnectionRequest,
   rejectConnectionRequest,
   revokeAccessGrant,
+  revokeShareToken,
   updateAccessGrantFilters,
 } from '../api/orbs';
 import type { AccessGrant, ConnectionRequest, OrbVisibility } from '../api/orbs';
@@ -144,6 +145,8 @@ function SharePanel({
     if (!hasActiveFilters) setApplyFiltersOnInvite(false);
   }, [hasActiveFilters]);
 
+  const [tokenGeneration, setTokenGeneration] = useState(0);
+
   // Generate a share token for public and restricted modes (used for share links and MCP Orbis ID)
   useEffect(() => {
     let active = true;
@@ -171,7 +174,7 @@ function SharePanel({
     return () => {
       active = false;
     };
-  }, [activeKeywords, addToast, hiddenTypesArray, orbId, isPublic, isRestricted]);
+  }, [activeKeywords, addToast, hiddenTypesArray, orbId, isPublic, isRestricted, tokenGeneration]);
 
   // Load access grants when restricted mode is active
   useEffect(() => {
@@ -284,6 +287,22 @@ function SharePanel({
     if (isPrivate) return;
     void copyText(mcpUri, 'MCP Orbis ID');
   }, [copyText, isPrivate, mcpUri]);
+
+  const [revokingToken, setRevokingToken] = useState(false);
+  const handleRevokeAndRegenerate = useCallback(async () => {
+    if (!shareTokenId) return;
+    setRevokingToken(true);
+    try {
+      await revokeShareToken(shareTokenId);
+      addToast('Token revoked. Generating a new one...', 'info');
+      // Bump counter to trigger useEffect regeneration
+      setTokenGeneration((n) => n + 1);
+    } catch {
+      addToast('Failed to revoke token', 'error');
+    } finally {
+      setRevokingToken(false);
+    }
+  }, [shareTokenId, addToast]);
 
   const handleDownloadQr = useCallback(() => {
     if (!canDownloadQr || !qrCanvasRef.current) return;
@@ -624,13 +643,21 @@ function SharePanel({
                 <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
                 <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access.</p>
                 <div className="flex items-center gap-2">
-                  <input readOnly value={mcpUri} className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                  <input readOnly value={mcpUri} className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
                   <button
                     type="button"
                     onClick={handleCopyMcp}
-                    className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors"
+                    className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors shrink-0"
                   >
                     Copy
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleRevokeAndRegenerate}
+                    disabled={!shareTokenId || revokingToken}
+                    className="h-10 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-40 disabled:cursor-not-allowed text-xs font-medium transition-colors shrink-0 whitespace-nowrap"
+                  >
+                    {revokingToken ? 'Revoking...' : 'Revoke'}
                   </button>
                 </div>
               </div>
@@ -846,13 +873,21 @@ function SharePanel({
                     <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
                     <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access according to your active privacy filters.</p>
                     <div className="flex items-center gap-2">
-                      <input readOnly value={mcpUri} className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                      <input readOnly value={mcpUri} className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
                       <button
                         type="button"
                         onClick={handleCopyMcp}
-                        className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors"
+                        className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors shrink-0"
                       >
                         Copy
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleRevokeAndRegenerate}
+                        disabled={!shareTokenId || revokingToken}
+                        className="h-10 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-40 disabled:cursor-not-allowed text-xs font-medium transition-colors shrink-0 whitespace-nowrap"
+                      >
+                        {revokingToken ? 'Revoking...' : 'Revoke'}
                       </button>
                     </div>
                   </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -144,10 +144,10 @@ function SharePanel({
     if (!hasActiveFilters) setApplyFiltersOnInvite(false);
   }, [hasActiveFilters]);
 
-  // Generate a share token only in public mode
+  // Generate a share token for public and restricted modes (used for share links and MCP Orbis ID)
   useEffect(() => {
     let active = true;
-    if (orbId && isPublic) {
+    if (orbId && (isPublic || isRestricted)) {
       setShareTokenId(null);
       setGeneratingToken(true);
       createShareToken(activeKeywords, hiddenTypesArray)
@@ -171,7 +171,7 @@ function SharePanel({
     return () => {
       active = false;
     };
-  }, [activeKeywords, addToast, hiddenTypesArray, orbId, isPublic]);
+  }, [activeKeywords, addToast, hiddenTypesArray, orbId, isPublic, isRestricted]);
 
   // Load access grants when restricted mode is active
   useEffect(() => {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -133,7 +133,7 @@ function SharePanel({
     () => computeShortFilterHash(activeKeywords, hiddenTypesArray),
     [activeKeywords, hiddenTypesArray],
   );
-  const mcpUri = `orb://${orbId}+${filterHash}`;
+  const mcpUri = shareTokenId ? `orb://${orbId}+${shareTokenId}` : `orb://${orbId}`;
   const filteredGrants = useMemo(() => {
     const query = grantSearch.trim().toLowerCase();
     if (!query) return grants;

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -564,101 +564,101 @@ function SharePanel({
           <div className="space-y-4">
 
             {isPublic && (
-              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to share links and excluded from exports.</p>
-                <div className="flex items-center gap-2 mb-2">
-                  <input
-                    value={inlineFilterKeyword}
-                    onChange={(e) => setInlineFilterKeyword(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
-                    placeholder="e.g. confidential, private..."
-                    className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
-                    className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors shrink-0"
-                  >
-                    Add
-                  </button>
-                  <button type="button" onClick={deactivateAll} disabled={activeKeywords.length === 0} className="h-9 px-3 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white/70 text-xs font-medium transition-colors shrink-0 whitespace-nowrap">
-                    Deactivate All
-                  </button>
-                </div>
-                {keywords.length === 0 ? (
-                  <p className="text-white/20 text-xs italic">No filter keywords configured.</p>
-                ) : (
-                  <div className="space-y-1.5 max-h-36 overflow-y-auto">
-                    {keywords.map((kw) => {
-                      const isActive = activeKeywords.includes(kw);
-                      return (
-                        <div
-                          key={kw}
-                          className={`flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border transition-all ${
-                            isActive
-                              ? 'bg-amber-600/15 border-amber-500/40'
-                              : 'bg-white/5 border-white/5 hover:border-white/10'
-                          }`}
-                        >
-                          <span className="text-white text-xs font-mono truncate">{kw}</span>
-                          <div className="flex items-center gap-1.5 flex-shrink-0">
-                            <button
-                              type="button"
-                              onClick={() => toggleKeyword(kw)}
-                              className={`text-[10px] font-medium px-2 py-0.5 rounded transition-colors cursor-pointer ${
-                                isActive
-                                  ? 'bg-amber-500 text-white'
-                                  : 'bg-white/10 text-white/40 hover:text-white hover:bg-white/20'
-                              }`}
-                            >
-                              {isActive ? 'Active' : 'Activate'}
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => removeKeyword(kw)}
-                              className="text-white/20 hover:text-red-400 transition-colors cursor-pointer"
-                              title="Remove"
-                            >
-                              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                      );
-                    })}
+              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4 space-y-4">
+                <div>
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Privacy Filters</label>
+                  <p className="text-[11px] text-gray-500 mt-0.5 mb-3">Active filters are applied to share links and excluded from exports.</p>
+                  <div className="flex items-center gap-2 mb-2">
+                    <input
+                      value={inlineFilterKeyword}
+                      onChange={(e) => setInlineFilterKeyword(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } } }}
+                      placeholder="e.g. confidential, private..."
+                      className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs placeholder-gray-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => { const t = inlineFilterKeyword.trim(); if (t) { addKeyword(t); setInlineFilterKeyword(''); } }}
+                      className="h-9 px-3 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-medium transition-colors shrink-0"
+                    >
+                      Add
+                    </button>
+                    <button type="button" onClick={deactivateAll} disabled={activeKeywords.length === 0} className="h-9 px-3 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed text-white/70 text-xs font-medium transition-colors shrink-0 whitespace-nowrap">
+                      Deactivate All
+                    </button>
                   </div>
-                )}
-                {activeKeywords.length > 0 && (
-                  <p className="text-amber-400/70 text-[11px] mt-2">
-                    {activeKeywords.length} filter{activeKeywords.length !== 1 ? 's' : ''} active.
-                  </p>
-                )}
-              </div>
-            )}
+                  {keywords.length === 0 ? (
+                    <p className="text-white/20 text-xs italic">No filter keywords configured.</p>
+                  ) : (
+                    <div className="space-y-1.5 max-h-36 overflow-y-auto">
+                      {keywords.map((kw) => {
+                        const isActive = activeKeywords.includes(kw);
+                        return (
+                          <div
+                            key={kw}
+                            className={`flex items-center justify-between gap-2 px-3 py-1.5 rounded-lg border transition-all ${
+                              isActive
+                                ? 'bg-amber-600/15 border-amber-500/40'
+                                : 'bg-white/5 border-white/5 hover:border-white/10'
+                            }`}
+                          >
+                            <span className="text-white text-xs font-mono truncate">{kw}</span>
+                            <div className="flex items-center gap-1.5 flex-shrink-0">
+                              <button
+                                type="button"
+                                onClick={() => toggleKeyword(kw)}
+                                className={`text-[10px] font-medium px-2 py-0.5 rounded transition-colors cursor-pointer ${
+                                  isActive
+                                    ? 'bg-amber-500 text-white'
+                                    : 'bg-white/10 text-white/40 hover:text-white hover:bg-white/20'
+                                }`}
+                              >
+                                {isActive ? 'Active' : 'Activate'}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => removeKeyword(kw)}
+                                className="text-white/20 hover:text-red-400 transition-colors cursor-pointer"
+                                title="Remove"
+                              >
+                                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {activeKeywords.length > 0 && (
+                    <p className="text-amber-400/70 text-[11px] mt-2">
+                      {activeKeywords.length} filter{activeKeywords.length !== 1 ? 's' : ''} active.
+                    </p>
+                  )}
+                </div>
 
-            {isPublic && (
-              <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
-                <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
-                <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access.</p>
-                <div className="flex items-center gap-2">
-                  <input readOnly value={mcpUri} className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-                  <button
-                    type="button"
-                    onClick={handleCopyMcp}
-                    className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors shrink-0"
-                  >
-                    Copy
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleRevokeAndRegenerate}
-                    disabled={!shareTokenId || revokingToken}
-                    className="h-10 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-40 disabled:cursor-not-allowed text-xs font-medium transition-colors shrink-0 whitespace-nowrap"
-                  >
-                    {revokingToken ? 'Revoking...' : 'Revoke'}
-                  </button>
+                <div className="border-t border-gray-700/50 pt-3">
+                  <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">MCP Orbis ID</label>
+                  <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Use this with the OpenOrbis MCP server for AI agent access.</p>
+                  <div className="flex items-center gap-2">
+                    <input readOnly value={mcpUri} className="flex-1 min-w-0 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                    <button
+                      type="button"
+                      onClick={handleCopyMcp}
+                      className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors shrink-0"
+                    >
+                      Copy
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleRevokeAndRegenerate}
+                      disabled={!shareTokenId || revokingToken}
+                      className="h-10 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-40 disabled:cursor-not-allowed text-xs font-medium transition-colors shrink-0 whitespace-nowrap"
+                    >
+                      {revokingToken ? 'Revoking...' : 'Revoke'}
+                    </button>
+                  </div>
                 </div>
               </div>
             )}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -48,20 +48,6 @@ const IMPORT_PROGRESS_STEP_LABELS: Record<string, string> = {
   done: 'Finalizing',
 };
 
-function computeShortFilterHash(keywords: string[], hiddenTypes: string[]): string {
-  const normalizedKeywords = keywords.map((k) => k.trim().toLowerCase()).filter(Boolean).sort();
-  const normalizedTypes = hiddenTypes.map((t) => t.trim().toLowerCase()).filter(Boolean).sort();
-  const payload = JSON.stringify({ keywords: normalizedKeywords, hiddenTypes: normalizedTypes });
-
-  // FNV-1a 32-bit for a deterministic short client-side hash.
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < payload.length; i += 1) {
-    hash ^= payload.charCodeAt(i);
-    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
-  }
-
-  return (hash >>> 0).toString(36).padStart(6, '0').slice(0, 6);
-}
 
 function resolveImportStepLabel(step: string | null | undefined, detail: string | null | undefined, message: string | null | undefined): string {
   if (step && IMPORT_PROGRESS_STEP_LABELS[step]) return IMPORT_PROGRESS_STEP_LABELS[step];
@@ -130,10 +116,6 @@ function SharePanel({
   const qrValue = shareableUrl || bareUrl;
   const canDownloadQr = !isPrivate && (isRestricted || Boolean(shareTokenId));
   const canCopyShareLink = !isPrivate && Boolean(shareableUrl);
-  const filterHash = useMemo(
-    () => computeShortFilterHash(activeKeywords, hiddenTypesArray),
-    [activeKeywords, hiddenTypesArray],
-  );
   const mcpUri = shareTokenId ? `orb://${orbId}+${shareTokenId}` : `orb://${orbId}`;
   const filteredGrants = useMemo(() => {
     const query = grantSearch.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- All 5 MCP tools now require a `token` parameter (share token ID)
- Token is validated via `validate_share_token()` — rejects invalid/expired/mismatched tokens
- Keyword and hidden_node_types filters from the token are applied to all returned data
- MCP Orbis ID in the frontend uses the share token ID instead of a client-side filter hash
- Removes the old `_check_visibility` approach (was only blocking private/restricted but allowing unfiltered public access)

Closes #251

## Security Changes
- **Before**: MCP tools accepted only `orb_id`, no authentication, no filtering
- **After**: MCP tools require `orb_id` + `token`, token is validated server-side, filters enforced

## Documentation
- `docs/api.md` may need updating to reflect new MCP tool parameters

## Test plan
- [ ] MCP tool without token → returns error
- [ ] MCP tool with invalid token → returns error
- [ ] MCP tool with valid token for different orb → returns error
- [ ] MCP tool with valid token → returns filtered data
- [ ] Hidden node types are excluded from results
- [ ] Keyword-matched nodes are excluded from results
- [ ] Frontend MCP Orbis ID shows `orb://orbid+tokenid` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)