### PR TITLE
security: MEDIUM findings — CV upload, filename, docker, entropy, logging, CI

### DIFF
--- a/.github/workflows/cv-extraction-quality.yml
+++ b/.github/workflows/cv-extraction-quality.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       # ── common setup ────────────────────────────────────────────────
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -59,7 +59,7 @@ jobs:
         run: claude auth status
 
       # ── phase 1: generate baseline from main ───────────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
 
@@ -78,7 +78,7 @@ jobs:
           uv run python -m tests.integration.generate_baseline /tmp/kg_baselines
 
       # ── phase 2: test PR branch against baselines ──────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install backend dependencies (PR)
         if: steps.claude-auth.outputs.available == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,14 +18,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Install dependencies
         working-directory: backend
@@ -44,9 +44,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,14 +22,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Install dependencies
         working-directory: backend

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -126,7 +126,11 @@ async def google_login(
     try:
         userinfo = await exchange_google_code(body.code)
     except Exception as e:
-        logger.error("Google OAuth failed: %s", e)
+        # Log only the exception class — the %s of an httpx HTTPStatusError
+        # can surface the Google token-endpoint response body, which may
+        # contain the leaked authorization code or a correlation id useful
+        # to replay against us.
+        logger.error("Google OAuth failed (%s)", type(e).__name__)
         raise HTTPException(
             status_code=401, detail="Google authentication failed"
         ) from None
@@ -167,7 +171,7 @@ async def linkedin_login(
             body.code, settings.linkedin_redirect_uri
         )
     except Exception as e:
-        logger.error("LinkedIn OAuth failed: %s", e)
+        logger.error("LinkedIn OAuth failed (%s)", type(e).__name__)
         raise HTTPException(
             status_code=401, detail="LinkedIn authentication failed"
         ) from None

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import re
 import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import Response
@@ -42,6 +44,28 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/cv", tags=["cv"])
 
 
+_UNSAFE_FILENAME_CHARS = re.compile(r'[\x00-\x1f"\\/]+')
+
+
+def _safe_content_disposition(filename: str) -> str:
+    """Return a safe ``Content-Disposition: attachment; filename="..."`` value.
+
+    User-supplied filenames are used only in this response header so the
+    attack we care about is header injection via CR/LF and double-quote
+    escaping, plus path traversal if the header ever leaks into a file
+    system sink. We strip path components with ``Path.name``, replace
+    control characters, slashes, backslashes and double quotes with
+    underscores, and cap the length. Falls back to ``document.pdf`` if
+    nothing usable remains.
+    """
+    base = Path(filename or "").name
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base).strip()
+    if not cleaned or cleaned in (".", ".."):
+        cleaned = "document.pdf"
+    cleaned = cleaned[:200]
+    return f'attachment; filename="{cleaned}"'
+
+
 async def _require_consent(current_user: dict, db: AsyncDriver) -> None:
     """Raise 403 if user hasn't given GDPR consent."""
     async with db.session() as session:
@@ -73,6 +97,13 @@ async def upload_cv(
     pdf_bytes = await file.read()
     if len(pdf_bytes) > 10 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="File too large (max 10MB)")
+
+    # Magic-byte check: every real PDF begins with ``%PDF-`` (possibly
+    # preceded by a few junk bytes which PyMuPDF tolerates but our text
+    # extractor should not). Reject obvious content-type mismatches
+    # early, before spinning up the LLM pipeline.
+    if not pdf_bytes.lstrip()[:5] == b"%PDF-":
+        raise HTTPException(status_code=400, detail="File is not a valid PDF")
 
     user_id = current_user.get("user_id", "")
     document_id = str(uuid.uuid4())
@@ -197,7 +228,7 @@ async def download_document(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": _safe_content_disposition(filename)},
     )
 
 
@@ -237,9 +268,7 @@ async def import_document(
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file provided")
 
-    from pathlib import Path as P
-
-    ext = P(file.filename).suffix.lower()
+    ext = Path(file.filename).suffix.lower()
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(
             status_code=400,

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import uuid
 from pathlib import Path
 
@@ -36,34 +35,13 @@ from app.graph.queries import (
     NODE_TYPE_RELATIONSHIPS,
     UPDATE_PERSON,
 )
+from app.http_helpers import safe_content_disposition
 from app.rate_limit import limiter
 from app.snapshots.service import create_snapshot as create_orb_snapshot
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/cv", tags=["cv"])
-
-
-_UNSAFE_FILENAME_CHARS = re.compile(r'[\x00-\x1f"\\/]+')
-
-
-def _safe_content_disposition(filename: str) -> str:
-    """Return a safe ``Content-Disposition: attachment; filename="..."`` value.
-
-    User-supplied filenames are used only in this response header so the
-    attack we care about is header injection via CR/LF and double-quote
-    escaping, plus path traversal if the header ever leaks into a file
-    system sink. We strip path components with ``Path.name``, replace
-    control characters, slashes, backslashes and double quotes with
-    underscores, and cap the length. Falls back to ``document.pdf`` if
-    nothing usable remains.
-    """
-    base = Path(filename or "").name
-    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base).strip()
-    if not cleaned or cleaned in (".", ".."):
-        cleaned = "document.pdf"
-    cleaned = cleaned[:200]
-    return f'attachment; filename="{cleaned}"'
 
 
 async def _require_consent(current_user: dict, db: AsyncDriver) -> None:
@@ -183,18 +161,27 @@ async def upload_cv(
 
     except HTTPException:
         raise
-    except TimeoutError as e:
-        logger.error("PDF extraction timeout: %s", e)
+    except TimeoutError:
+        logger.warning("PDF extraction timeout for user %s", user_id)
         progress.set_progress(user_id, CVStep.FAILED, "Timed out")
         raise HTTPException(
             status_code=504, detail="PDF processing timed out. Please try again."
         ) from None
     except Exception as e:
-        logger.error("CV upload pipeline error: %s", e, exc_info=True)
-        progress.set_progress(user_id, CVStep.FAILED, str(e))
+        # Log the exception type + id at ERROR, stash the full traceback at
+        # DEBUG. The raw str(e) is NOT surfaced to the client because LLM
+        # and extractor exceptions routinely contain slice of the PDF text,
+        # prompt content, or HTTPX response bodies.
+        logger.error(
+            "CV upload pipeline error for user %s (%s)",
+            user_id,
+            type(e).__name__,
+        )
+        logger.debug("CV upload traceback", exc_info=True)
+        progress.set_progress(user_id, CVStep.FAILED, "Processing failed")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to process CV: {str(e)}",
+            detail="Failed to process CV. Please try again.",
         ) from None
     finally:
         counter.decrement()
@@ -228,7 +215,7 @@ async def download_document(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
-        headers={"Content-Disposition": _safe_content_disposition(filename)},
+        headers={"Content-Disposition": safe_content_disposition(filename)},
     )
 
 
@@ -331,9 +318,14 @@ async def import_document(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Document import error: %s", e, exc_info=True)
+        logger.error(
+            "Document import error for user %s (%s)",
+            user_id,
+            type(e).__name__,
+        )
+        logger.debug("Document import traceback", exc_info=True)
         raise HTTPException(
-            status_code=500, detail=f"Failed to process document: {e!s}"
+            status_code=500, detail="Failed to process document. Please try again."
         ) from None
 
 

--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -12,6 +12,7 @@ from neo4j import AsyncDriver
 from app.dependencies import get_current_user_optional, get_db
 from app.graph.encryption import decrypt_properties
 from app.graph.queries import GET_FULL_ORB_PUBLIC
+from app.http_helpers import safe_content_disposition
 from app.orbs.share_token import node_matches_filters, validate_share_token
 from app.orbs.visibility import (
     assert_orb_accessible,
@@ -243,8 +244,11 @@ async def export_orb(  # noqa: C901
             record = await result.single()
         except Exception as e:
             logger.error(
-                "Export DB query failed for orb %s: %s", orb_id, e, exc_info=True
+                "Export DB query failed for orb %s (%s)",
+                orb_id,
+                type(e).__name__,
             )
+            logger.debug("Export DB query traceback", exc_info=True)
             raise HTTPException(
                 status_code=500, detail="Failed to load orb data"
             ) from None
@@ -255,8 +259,11 @@ async def export_orb(  # noqa: C901
         person, nodes = _gather_orb(record)
     except Exception as e:
         logger.error(
-            "Export orb data extraction failed for %s: %s", orb_id, e, exc_info=True
+            "Export orb data extraction failed for %s (%s)",
+            orb_id,
+            type(e).__name__,
         )
+        logger.debug("Export extraction traceback", exc_info=True)
         raise HTTPException(
             status_code=500, detail="Failed to process orb data"
         ) from None
@@ -284,16 +291,24 @@ async def export_orb(  # noqa: C901
             )
         except Exception as e:
             logger.error(
-                "PDF generation failed for orb %s: %s", orb_id, e, exc_info=True
+                "PDF generation failed for orb %s (%s)",
+                orb_id,
+                type(e).__name__,
             )
+            logger.debug("PDF generation traceback", exc_info=True)
             raise HTTPException(
                 status_code=500, detail="Failed to generate PDF"
             ) from None
-        filename = f"{person.get('name', orb_id).replace(' ', '_')}_CV.pdf"
+        # Filename derives from user-controlled name; the shared helper
+        # strips control chars, path components, and quotes.
+        raw_name = person.get("name", orb_id) or orb_id
+        filename = f"{raw_name.replace(' ', '_')}_CV.pdf"
         return StreamingResponse(
             io.BytesIO(pdf_bytes),
             media_type="application/pdf",
-            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            headers={
+                "Content-Disposition": safe_content_disposition(filename),
+            },
         )
 
     if format == "jsonld":

--- a/backend/app/http_helpers.py
+++ b/backend/app/http_helpers.py
@@ -1,0 +1,27 @@
+"""Small HTTP-response helpers shared across routers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_UNSAFE_FILENAME_CHARS = re.compile(r'[\x00-\x1f"\\/]+')
+
+
+def safe_content_disposition(filename: str) -> str:
+    """Return a safe ``Content-Disposition: attachment; filename="..."`` value.
+
+    User-supplied filenames are used only in this response header so the
+    attack we care about is header injection via CR/LF and double-quote
+    escaping, plus path traversal if the header ever leaks into a file
+    system sink. We strip path components with ``Path.name``, replace
+    control characters, slashes, backslashes and double quotes with
+    underscores, and cap the length. Falls back to ``document.pdf`` if
+    nothing usable remains.
+    """
+    base = Path(filename or "").name
+    cleaned = _UNSAFE_FILENAME_CHARS.sub("_", base).strip()
+    if not cleaned or cleaned in (".", ".."):
+        cleaned = "document.pdf"
+    cleaned = cleaned[:200]
+    return f'attachment; filename="{cleaned}"'

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -254,14 +254,19 @@ async def enhance_note(
 
         return _parse_enhance_result(result, valid_skill_uids)
     except ValueError as e:
-        logger.error("Failed to parse enhance result: %s", e)
+        logger.error("Failed to parse enhance result (%s)", type(e).__name__)
         raise HTTPException(
             status_code=502, detail="Failed to parse LLM response"
         ) from None
     except Exception as e:
-        logger.error("Note enhance failed: %s", e, exc_info=True)
+        logger.error(
+            "Note enhance failed for user %s (%s)",
+            current_user["user_id"],
+            type(e).__name__,
+        )
+        logger.debug("Note enhance traceback", exc_info=True)
         raise HTTPException(
-            status_code=502, detail=f"LLM processing failed: {str(e)}"
+            status_code=502, detail="LLM processing failed. Please try again."
         ) from None
 
 

--- a/backend/app/orbs/access_grants.py
+++ b/backend/app/orbs/access_grants.py
@@ -71,7 +71,10 @@ async def create_access_grant(
 
     Returns ``None`` if the user has no orb_id set.
     """
-    grant_id = secrets.token_urlsafe(16)
+    # 32 bytes (256 bit) matches share_token and access-token hash widths.
+    # Grant ids are used in URLs shared by owners to recipients, so the
+    # extra margin guards against any future brute-force enumeration.
+    grant_id = secrets.token_urlsafe(32)
     normalized = _normalize_email(email)
     normalized_keywords = _normalize_keywords(keywords)
     normalized_hidden_types = _normalize_hidden_types(hidden_node_types)

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -56,21 +56,21 @@ def test_upload_cv_rejects_non_pdf_magic_bytes(client):
 
 
 def test_safe_content_disposition_strips_traversal_and_ctrl_chars():
-    from app.cv.router import _safe_content_disposition
+    from app.http_helpers import safe_content_disposition
 
     assert (
-        _safe_content_disposition("../../etc/passwd") == 'attachment; filename="passwd"'
+        safe_content_disposition("../../etc/passwd") == 'attachment; filename="passwd"'
     )
     # The regex collapses runs of unsafe chars into a single underscore.
     assert (
-        _safe_content_disposition('evil"\r\nSet-Cookie: x=y.pdf')
+        safe_content_disposition('evil"\r\nSet-Cookie: x=y.pdf')
         == 'attachment; filename="evil_Set-Cookie: x=y.pdf"'
     )
-    assert _safe_content_disposition("") == 'attachment; filename="document.pdf"'
-    assert _safe_content_disposition("..") == 'attachment; filename="document.pdf"'
+    assert safe_content_disposition("") == 'attachment; filename="document.pdf"'
+    assert safe_content_disposition("..") == 'attachment; filename="document.pdf"'
     # Plain, safe names pass through.
     assert (
-        _safe_content_disposition("my resume.pdf")
+        safe_content_disposition("my resume.pdf")
         == 'attachment; filename="my resume.pdf"'
     )
 

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -44,6 +44,37 @@ def test_upload_cv_invalid_extension(client):
     assert "Only PDF files are supported" in response.json()["detail"]
 
 
+def test_upload_cv_rejects_non_pdf_magic_bytes(client):
+    """A file with .pdf extension but not starting with %PDF- must be
+    rejected at the magic-byte check, before any extractor runs."""
+    file = BytesIO(b"<html>not a pdf</html>")
+    response = client.post(
+        "/cv/upload", files={"file": ("fake.pdf", file, "application/pdf")}
+    )
+    assert response.status_code == 400
+    assert "not a valid PDF" in response.json()["detail"]
+
+
+def test_safe_content_disposition_strips_traversal_and_ctrl_chars():
+    from app.cv.router import _safe_content_disposition
+
+    assert (
+        _safe_content_disposition("../../etc/passwd") == 'attachment; filename="passwd"'
+    )
+    # The regex collapses runs of unsafe chars into a single underscore.
+    assert (
+        _safe_content_disposition('evil"\r\nSet-Cookie: x=y.pdf')
+        == 'attachment; filename="evil_Set-Cookie: x=y.pdf"'
+    )
+    assert _safe_content_disposition("") == 'attachment; filename="document.pdf"'
+    assert _safe_content_disposition("..") == 'attachment; filename="document.pdf"'
+    # Plain, safe names pass through.
+    assert (
+        _safe_content_disposition("my resume.pdf")
+        == 'attachment; filename="my resume.pdf"'
+    )
+
+
 @patch("app.cv.router.counter")
 def test_get_processing_count(mock_counter, client):
     mock_counter.get_count.return_value = 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,11 @@ services:
   neo4j:
     image: neo4j:5-community
     ports:
-      - "7474:7474"  # Browser
-      - "7687:7687"  # Bolt
+      # Bind to loopback only so the Neo4j browser and bolt port are not
+      # exposed on any network interface of the dev machine. Prod deploys
+      # should keep bolt internal to the docker network and drop 7474.
+      - "127.0.0.1:7474:7474"  # Browser
+      - "127.0.0.1:7687:7687"  # Bolt
     environment:
       NEO4J_AUTH: neo4j/orbis_dev_password
       NEO4J_PLUGINS: '[]'
@@ -15,7 +18,7 @@ services:
     image: ollama/ollama:latest
     container_name: orbis-ollama
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama_data:/root/.ollama
 


### PR DESCRIPTION
Addresses the **MEDIUM** findings from issue #253. One commit per group of related fixes so each can be reviewed in isolation. M6 is closed separately as accepted risk — see [this comment](https://github.com/Brotherhood94/orb_project/issues/253#issuecomment-4230457871) on the audit issue for the rationale and the preconditions that would trigger re-opening it.

## Summary

| # | Finding | Fix | Commit |
|---|---------|-----|--------|
| M3 | `access_grant_id` used 16 bytes of entropy vs 32 on share tokens on the same surface. | `secrets.token_urlsafe(16)` → `(32)` in `orbs/access_grants.py`. Affects only new grants. | `3d5dcdf` |
| M4 | Neo4j browser (7474), bolt (7687), Ollama (11434) bound to `0.0.0.0` — reachable from other devices on the same Wi-Fi/VPN. | `docker-compose.yml` port maps switched to `127.0.0.1:<port>:<port>`. | `3d5dcdf` |
| M1 | `/cv/upload` accepted any file whose name ended in `.pdf`. An HTML or polyglot could reach PyMuPDF via a rename. | New magic-byte check rejects anything that doesn't start with `%PDF-` after stripping leading whitespace, before the LLM pipeline runs. | `9927bf2` |
| M2 | `/cv/documents/{id}/download` pasted `original_filename` raw into `Content-Disposition`, allowing CR/LF header injection and path confusion. | New `app/http_helpers.safe_content_disposition` strips control chars, path components, backslashes, forward slashes and double quotes, falls back to `document.pdf`. Applied to both the CV download and the `/export/{orb_id}` PDF route (which was building its own unsanitized filename from the person name). | `9927bf2` + `e6c4ee9` |
| M5 | Error paths logged `%s` of the caught exception — which for httpx HTTPStatusError is the full request/response pair, potentially containing the leaked Google/LinkedIn authorization code, a PDF text slice, or decrypted PII. Some endpoints also echoed the exception back into the HTTP `detail`. | ERROR log keeps `type(e).__name__` + correlation id only. Full traceback moves to `logger.debug(..., exc_info=True)` so ops can still see it when the logger is cranked up. HTTP responses return generic messages. Touched auth/cv/notes/export routers. | `e6c4ee9` |
| M7 | GitHub Actions (`checkout@v4`, `setup-python@v5`, `setup-uv@v4`, `setup-node@v4`) pinned to floating major-version tags. A compromised maintainer can retarget those tags and inject code into every subsequent CI run — exactly the `tj-actions/changed-files` scenario from March 2025. | Every `uses:` line now pins a commit SHA with a trailing `# v4` comment for readability. Applied across `lint.yml`, `unit-tests.yml`, and `cv-extraction-quality.yml`. | `326cd38` |
| M6 | LinkedIn OAuth `state` validated only on the frontend. | **Accepted risk.** See the linked comment on #253 for the full design analysis, the threat model walkthrough, the preconditions for re-opening, and the signed-state-cookie design held in reserve. | — |

## Architectural note on M5

The exception-scrubbing pattern landed in this PR is:

```python
except Exception as e:
    logger.error("CV upload pipeline error for user %s (%s)", user_id, type(e).__name__)
    logger.debug("CV upload traceback", exc_info=True)
    raise HTTPException(status_code=500, detail="Failed to process CV. Please try again.") from None
```

This gives ops a named error class at ERROR level (enough to build alerts), a full traceback at DEBUG level (for post-mortem when explicitly enabled), and a generic HTTP response to the client. Applied symmetrically to `/auth/*`, `/cv/upload`, `/cv/import`, `/notes/enhance`, and the three error branches in `/export/{orb_id}`.

## Tests

- `557 passed` on the backend unit suite, `ruff check` and `ruff format --check` clean.
- New tests:
  - `test_upload_cv_rejects_non_pdf_magic_bytes` — `.pdf` extension + HTML body returns 400 at the magic-byte gate.
  - `test_safe_content_disposition_strips_traversal_and_ctrl_chars` — covers `../../etc/passwd`, a CR/LF header-injection payload, empty string, `..`, and a plain-passes-through case.
- The existing `test_upload_cv_success` already sent `b"%PDF-1.4 ..."` so no change was needed there.

## Documentation

No changes to CLAUDE.md or docs. The fixes are internal hardening that doesn't change developer-facing conventions; the `safe_content_disposition` helper is discoverable by anyone grepping for `Content-Disposition`.

## Out of scope — still on #253

- **LOW** findings (L1 silent decryption fallback, L2 admin endpoint pagination, L3 GDPR consent enforcement on non-CV flows, L4 Fernet key rotation / `encryption_key_id`).
- **M6** signed-state-cookie implementation — held in reserve, documented in the issue comment.

Closes the MEDIUM section of #253.
