### PR TITLE
security: LOW findings — decryption markers, admin pagination, consent gate, key rotation docs

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -53,6 +53,13 @@ class AccessCodeUpdate(BaseModel):
     active: bool
 
 
+class AccessCodesPage(BaseModel):
+    items: list[AccessCodeResponse]
+    total: int
+    offset: int
+    limit: int
+
+
 class BetaConfigResponse(BaseModel):
     invite_code_required: bool
     updated_at: str
@@ -137,6 +144,13 @@ class UserResponse(BaseModel):
     signup_code: str | None = None
     activated_at: str | None = None
     created_at: str = ""
+
+
+class UsersPage(BaseModel):
+    items: list[UserResponse]
+    total: int
+    offset: int
+    limit: int
 
 
 class ProcessingRecordInfo(BaseModel):

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from neo4j import AsyncDriver
 
 from app.admin.models import (
     AccessCodeBatchCreate,
     AccessCodeCreate,
     AccessCodeResponse,
+    AccessCodesPage,
     AccessCodeUpdate,
     BatchActivateRequest,
     BetaConfigResponse,
@@ -24,6 +25,7 @@ from app.admin.models import (
     StatsResponse,
     UserDetailResponse,
     UserResponse,
+    UsersPage,
 )
 from app.admin.service import (
     activate_user_by_admin,
@@ -207,12 +209,22 @@ async def patch_beta_config(
 # ── AccessCode ──
 
 
-@router.get("/access-codes", response_model=list[AccessCodeResponse])
+@router.get("/access-codes", response_model=AccessCodesPage)
 async def list_codes(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
     _admin: dict = Depends(require_admin),
     db: AsyncDriver = Depends(get_db),
 ):
-    return [_serialize_access_code(c) for c in await list_access_codes(db)]
+    """List access codes with pagination. ``limit`` is capped at 200 to
+    bound the response size even for an admin caller."""
+    items, total = await list_access_codes(db, offset=offset, limit=limit)
+    return AccessCodesPage(
+        items=[_serialize_access_code(c) for c in items],
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @router.post("/access-codes", response_model=AccessCodeResponse, status_code=201)
@@ -290,12 +302,21 @@ async def get_pending_users(
 # ── User Management ──
 
 
-@router.get("/users", response_model=list[UserResponse])
+@router.get("/users", response_model=UsersPage)
 async def list_users(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
     _admin: dict = Depends(require_admin),
     db: AsyncDriver = Depends(get_db),
 ):
-    return [_serialize_user(u) for u in await list_all_users(db)]
+    """List registered users with pagination. ``limit`` is capped at 200."""
+    items, total = await list_all_users(db, offset=offset, limit=limit)
+    return UsersPage(
+        items=[_serialize_user(u) for u in items],
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @router.get("/users/{user_id}", response_model=UserDetailResponse)

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -24,6 +24,7 @@ from app.graph.queries import (
     CODE_EFFICIENCY,
     CONSUME_ACCESS_CODE,
     COUNT_ACCESS_CODES,
+    COUNT_ALL_PERSONS,
     COUNT_PENDING_PERSONS,
     COUNT_PERSONS,
     CREATE_ACCESS_CODE,
@@ -212,11 +213,21 @@ async def get_access_code(db: AsyncDriver, code: str) -> dict | None:
         return dict(record["a"]) if record else None
 
 
-async def list_access_codes(db: AsyncDriver) -> list[dict]:
+async def list_access_codes(
+    db: AsyncDriver, *, offset: int = 0, limit: int = 50
+) -> tuple[list[dict], int]:
+    """Return a page of access codes plus the total count.
+
+    ``offset`` / ``limit`` are clamped by the caller (the admin router)
+    to protect against huge page requests.
+    """
     async with db.session() as session:
-        result = await session.run(LIST_ACCESS_CODES)
+        result = await session.run(LIST_ACCESS_CODES, offset=offset, limit=limit)
         records = [r async for r in result]
-    return [dict(r["a"]) for r in records]
+        total_result = await session.run(COUNT_ACCESS_CODES)
+        total_record = await total_result.single()
+    total = int(total_record["total"]) if total_record else 0
+    return [dict(r["a"]) for r in records], total
 
 
 async def set_access_code_active(
@@ -294,11 +305,16 @@ async def create_batch_access_codes(
 # ── User management ──
 
 
-async def list_all_users(db: AsyncDriver) -> list[dict]:
-    """Return all registered users with decrypted emails."""
+async def list_all_users(
+    db: AsyncDriver, *, offset: int = 0, limit: int = 50
+) -> tuple[list[dict], int]:
+    """Return a page of registered users with decrypted emails + total count."""
     async with db.session() as session:
-        result = await session.run(LIST_ALL_PERSONS)
+        result = await session.run(LIST_ALL_PERSONS, offset=offset, limit=limit)
         records = [r async for r in result]
+        total_result = await session.run(COUNT_ALL_PERSONS)
+        total_record = await total_result.single()
+    total = int(total_record["total"]) if total_record else 0
     out = []
     for r in records:
         person = dict(r["p"])
@@ -307,7 +323,7 @@ async def list_all_users(db: AsyncDriver) -> list[dict]:
             with contextlib.suppress(Exception):
                 email = decrypt_value(email)
         out.append({**person, "email": email})
-    return out
+    return out, total
 
 
 async def get_user_detail(db: AsyncDriver, user_id: str) -> dict | None:

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -21,7 +21,7 @@ from app.cv_storage.storage import (
     evict_oldest_if_at_limit,
     load_document,
 )
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_current_user, get_db, require_gdpr_consent
 from app.graph.encryption import encrypt_properties, encrypt_value
 from app.graph.llm_usage import record_llm_usage
 from app.graph.node_schema import sanitize_node_properties
@@ -44,28 +44,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/cv", tags=["cv"])
 
 
-async def _require_consent(current_user: dict, db: AsyncDriver) -> None:
-    """Raise 403 if user hasn't given GDPR consent."""
-    async with db.session() as session:
-        result = await session.run(
-            "MATCH (p:Person {user_id: $user_id}) RETURN p.gdpr_consent AS consent",
-            user_id=current_user["user_id"],
-        )
-        record = await result.single()
-        if not record or not record["consent"]:
-            raise HTTPException(status_code=403, detail="GDPR consent required")
-
-
 @router.post("/upload", response_model=ExtractedData)
 @limiter.limit("3/minute")
 async def upload_cv(
     request: Request,
     file: UploadFile = File(...),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Upload a PDF CV: extract text via Docling, classify via LLM."""
-    await _require_consent(current_user, db)
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -247,11 +234,10 @@ ALLOWED_EXTENSIONS = {".pdf", ".docx", ".txt", ".text"}
 async def import_document(
     request: Request,
     file: UploadFile = File(...),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Import a supplementary document (PDF, DOCX, TXT) to enrich the orb."""
-    await _require_consent(current_user, db)
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -332,11 +318,10 @@ async def import_document(
 @router.post("/import-confirm")
 async def import_confirm(
     data: ConfirmRequest,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Merge imported nodes into existing orb (no deletion of existing data)."""
-    await _require_consent(current_user, db)
     user_id = current_user["user_id"]
 
     if data.document_id:
@@ -560,11 +545,10 @@ def _build_person_updates(data: ConfirmRequest) -> dict:
 @router.post("/confirm")
 async def confirm_cv(
     data: ConfirmRequest,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Persist confirmed CV nodes to Neo4j with dedup and cross-entity linking."""
-    await _require_consent(current_user, db)
     user_id = current_user["user_id"]
 
     # Auto-snapshot before destructive CV import

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -84,3 +84,26 @@ async def require_admin(
         if record is None or not record["is_admin"]:
             raise HTTPException(status_code=403, detail="Admin access required")
     return current_user
+
+
+async def require_gdpr_consent(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+) -> dict:
+    """Block any write / LLM endpoint until the user has granted GDPR consent.
+
+    Used on endpoints that process or store user-controlled data: the CV
+    pipeline, the LLM note enhancer, the orb node CRUD, and anything
+    else that persists beyond the session. Returns ``current_user`` so
+    consuming endpoints can drop-in replace ``Depends(get_current_user)``.
+    """
+    async with db.session() as session:
+        result = await session.run(
+            "MATCH (p:Person {user_id: $user_id}) "
+            "RETURN coalesce(p.gdpr_consent, false) AS consent",
+            user_id=current_user["user_id"],
+        )
+        record = await result.single()
+    if record is None or not record["consent"]:
+        raise HTTPException(status_code=403, detail="GDPR consent required")
+    return current_user

--- a/backend/app/graph/encryption.py
+++ b/backend/app/graph/encryption.py
@@ -93,6 +93,11 @@ def _get_multi() -> MultiFernet:
 
 ENCRYPTED_FIELDS = {"email", "phone", "address"}
 
+# Marker surfaced to API consumers when a ciphertext fails to decrypt.
+# Callers should hide the field from the UI rather than display raw
+# ciphertext or a confusing empty value. See L1 in security audit #253.
+DECRYPTION_FAILED_MARKER = "__decryption_failed__"
+
 
 def encrypt_value(value: str) -> str:
     return _get_primary().encrypt(value.encode()).decode()
@@ -119,11 +124,24 @@ def encrypt_properties(properties: dict) -> dict:
 
 
 def decrypt_properties(properties: dict) -> dict:
+    """Decrypt known-encrypted fields in place.
+
+    On failure the plaintext field is replaced with ``None`` and a
+    companion ``_decryption_failed`` list is added listing the affected
+    field names. This is strictly better than the previous "leave the
+    ciphertext in place" behavior, which let gibberish leak to the UI
+    and made silent ``email == ciphertext`` comparisons always fail.
+    """
     result = dict(properties)
+    failed: list[str] = []
     for field in ENCRYPTED_FIELDS:
         if field in result and result[field]:
             try:
                 result[field] = decrypt_value(result[field])
             except Exception as e:
                 logger.warning("Failed to decrypt field '%s': %s", field, e)
+                result[field] = None
+                failed.append(field)
+    if failed:
+        result["_decryption_failed"] = failed
     return result

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -266,6 +266,8 @@ LIST_ACCESS_CODES = """
 MATCH (a:AccessCode)
 RETURN a
 ORDER BY a.created_at DESC
+SKIP $offset
+LIMIT $limit
 """
 
 SET_ACCESS_CODE_ACTIVE = """
@@ -361,6 +363,13 @@ LIST_ALL_PERSONS = """
 MATCH (p:Person)
 RETURN p
 ORDER BY p.created_at DESC
+SKIP $offset
+LIMIT $limit
+"""
+
+COUNT_ALL_PERSONS = """
+MATCH (p:Person)
+RETURN count(p) AS total
 """
 
 GET_PERSON_DETAIL = """

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from neo4j import AsyncDriver
 
 from app.config import settings
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_db, require_gdpr_consent
 from app.graph.llm_usage import record_llm_usage
 from app.graph.queries import NODE_TYPE_LABELS
 from app.notes.models import EnhanceNoteRequest, EnhanceNoteResponse
@@ -206,7 +206,7 @@ def _parse_enhance_result(  # noqa: C901
 async def enhance_note(
     request: Request,
     req: EnhanceNoteRequest,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Enhance a draft note using LLM: translate, improve, extract fields, suggest links."""

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -12,7 +12,12 @@ from neo4j.time import Time as Neo4jTime
 from pydantic import BaseModel
 
 from app.config import settings
-from app.dependencies import get_current_user, get_current_user_optional, get_db
+from app.dependencies import (
+    get_current_user,
+    get_current_user_optional,
+    get_db,
+    require_gdpr_consent,
+)
 from app.email.service import send_access_grant_email
 from app.graph.encryption import decrypt_properties, encrypt_properties
 from app.graph.node_schema import LABEL_TO_NODE_TYPE, sanitize_node_properties
@@ -187,7 +192,7 @@ async def get_my_orb(
 @router.put("/me")
 async def update_my_profile(
     data: PersonUpdate,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     props = {k: v for k, v in data.model_dump().items() if v is not None}
@@ -245,7 +250,7 @@ async def update_visibility(
 @router.post("/me/profile-image")
 async def upload_profile_image(
     file: UploadFile = File(...),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     """Upload a profile picture. Stored as base64 on the Person node."""
@@ -294,7 +299,7 @@ async def delete_profile_image(
 @router.post("/me/nodes")
 async def add_node(
     data: NodeCreate,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     if data.node_type not in NODE_TYPE_LABELS:
@@ -327,7 +332,7 @@ async def add_node(
 async def update_node(
     uid: str,
     data: NodeUpdate,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
     async with db.session() as session:

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_current_user, get_db, require_gdpr_consent
 from app.main import app
 from app.rate_limit import limiter
 
@@ -80,11 +80,19 @@ def empty_async_result():
 
 @pytest.fixture
 def client(mock_db, mock_neo4j_driver):
+    """Default ``TestClient`` with auth + consent short-circuited.
+
+    Most tests don't care about the GDPR gate and would otherwise need
+    to remember to mock a ``{"consent": True}`` row before any write
+    endpoint. This override bypasses the ``require_gdpr_consent`` DB
+    lookup entirely; tests that actually exercise the consent path
+    (``test_gdpr_consent.py``) delete the override with
+    ``app.dependency_overrides.pop(require_gdpr_consent, None)``.
+    """
+    fake_user = {"user_id": "test-user", "email": "test@example.com"}
     app.dependency_overrides[get_db] = lambda: mock_db
-    app.dependency_overrides[get_current_user] = lambda: {
-        "user_id": "test-user",
-        "email": "test@example.com",
-    }
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    app.dependency_overrides[require_gdpr_consent] = lambda: fake_user
 
     with TestClient(app) as c:
         yield c

--- a/backend/tests/unit/test_admin_users.py
+++ b/backend/tests/unit/test_admin_users.py
@@ -71,15 +71,46 @@ def admin_client(mock_db, mock_neo4j_driver):
 def test_list_users(admin_client):
     with patch(
         "app.admin.router.list_all_users",
-        AsyncMock(return_value=[SAMPLE_USER, PENDING_USER]),
+        AsyncMock(return_value=([SAMPLE_USER, PENDING_USER], 2)),
     ):
         response = admin_client.get("/admin/users")
 
     assert response.status_code == 200
     body = response.json()
-    assert len(body) == 2
-    assert body[0]["user_id"] == "google-111"
-    assert body[1]["signup_code"] is None
+    assert body["total"] == 2
+    assert body["offset"] == 0
+    assert body["limit"] == 50
+    assert len(body["items"]) == 2
+    assert body["items"][0]["user_id"] == "google-111"
+    assert body["items"][1]["signup_code"] is None
+
+
+def test_list_users_pagination_params(admin_client):
+    with patch(
+        "app.admin.router.list_all_users",
+        AsyncMock(return_value=([SAMPLE_USER], 42)),
+    ) as mock:
+        response = admin_client.get("/admin/users?offset=20&limit=10")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 42
+    assert body["offset"] == 20
+    assert body["limit"] == 10
+    # Service layer is called with keyword args matching the query params.
+    mock.assert_awaited_once()
+    _, kwargs = mock.call_args
+    assert kwargs == {"offset": 20, "limit": 10}
+
+
+def test_list_users_caps_limit_at_200(admin_client):
+    with patch(
+        "app.admin.router.list_all_users",
+        AsyncMock(return_value=([], 0)),
+    ):
+        # 999 exceeds the Query(le=200) bound, FastAPI rejects with 422
+        response = admin_client.get("/admin/users?limit=999")
+    assert response.status_code == 422
 
 
 # ── GET /admin/users/{user_id} ──

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -84,12 +84,10 @@ def test_get_processing_count(mock_counter, client):
 
 
 def test_confirm_cv_success(client, mock_db):
-    # Mock multiple run results
+    # Mock multiple run results. Consent is gated by the require_gdpr_consent
+    # dependency which the client fixture overrides, so no consent-query
+    # entry is needed in the side_effect list.
     run_mock = mock_db.session.return_value.__aenter__.return_value.run
-
-    # We need to return an object that has a .single() method which is an AsyncMock
-    result_mock_consent = MagicMock()
-    result_mock_consent.single = AsyncMock(return_value={"consent": True})
 
     # Auto-snapshot GET_FULL_ORB returns None (no existing orb), caught by try/except
     result_mock_snapshot = MagicMock()
@@ -113,8 +111,7 @@ def test_confirm_cv_success(client, mock_db):
     result_mock_5.single = AsyncMock(return_value=None)
 
     run_mock.side_effect = [
-        result_mock_consent,  # _require_consent
-        result_mock_snapshot,  # auto-snapshot GET_FULL_ORB (returns None -> ValueError caught)
+        result_mock_snapshot,  # auto-snapshot GET_FULL_ORB
         result_mock_1,  # DELETE_USER_GRAPH
         result_mock_2,  # UPDATE_PERSON
         result_mock_3,  # ADD_NODE 1
@@ -141,11 +138,10 @@ def test_confirm_cv_success(client, mock_db):
 
 
 def test_confirm_cv_partial_link_failure(client, mock_db):
-    # Node creation succeeds but LINK_SKILL fails (work_experience -> skill)
+    # Node creation succeeds but LINK_SKILL fails (work_experience -> skill).
+    # Consent is gated by the require_gdpr_consent dependency (overridden in
+    # the client fixture) so no consent-query entry is in the side_effect.
     run_mock = mock_db.session.return_value.__aenter__.return_value.run
-
-    res_consent = MagicMock()
-    res_consent.single = AsyncMock(return_value={"consent": True})
 
     # Auto-snapshot GET_FULL_ORB returns None (no existing orb), caught by try/except
     res_snapshot = MagicMock()
@@ -163,8 +159,7 @@ def test_confirm_cv_partial_link_failure(client, mock_db):
     res_node_2.single = AsyncMock(return_value=node_rec_2)
 
     run_mock.side_effect = [
-        res_consent,  # _require_consent
-        res_snapshot,  # auto-snapshot GET_FULL_ORB (returns None -> ValueError caught)
+        res_snapshot,  # auto-snapshot GET_FULL_ORB
         res_ok,  # DELETE_USER_GRAPH
         res_node_1,  # MERGE (work_experience)
         res_node_2,  # MERGE (skill)

--- a/backend/tests/unit/test_encryption.py
+++ b/backend/tests/unit/test_encryption.py
@@ -93,12 +93,40 @@ class TestEncryptDecryptProperties:
         encrypt_properties(props)
         assert props["email"] == original_email
 
-    def test_decrypt_handles_corrupt_ciphertext(self):
+    def test_decrypt_marks_corrupt_ciphertext(self):
+        """L1: decryption failure must be visible to the caller.
+
+        Pre-L1 behavior was to leave the ciphertext in place and log a
+        warning, which silently leaked gibberish into API responses and
+        made equality checks against the plaintext always fail. Now the
+        field is blanked and ``_decryption_failed`` lists it.
+        """
         props = {"email": "not-a-valid-ciphertext", "name": "Dave"}
         result = decrypt_properties(props)
-        # Should keep the corrupt value and not raise
-        assert result["email"] == "not-a-valid-ciphertext"
+        assert result["email"] is None
         assert result["name"] == "Dave"
+        assert result["_decryption_failed"] == ["email"]
+
+    def test_decrypt_successful_does_not_set_marker(self):
+        props = {"email": "alice@example.com", "name": "Alice"}
+        encrypted = encrypt_properties(props)
+        result = decrypt_properties(encrypted)
+        assert "_decryption_failed" not in result
+        assert result["email"] == "alice@example.com"
+
+    def test_decrypt_mixed_success_and_failure(self):
+        """If some encrypted fields decrypt and others don't, only the
+        failing ones are listed in the marker."""
+        good = encrypt_properties({"email": "alice@example.com"})["email"]
+        props = {
+            "email": good,
+            "phone": "corrupt-phone-ciphertext",
+            "name": "Alice",
+        }
+        result = decrypt_properties(props)
+        assert result["email"] == "alice@example.com"
+        assert result["phone"] is None
+        assert result["_decryption_failed"] == ["phone"]
 
 
 # ── Fernet initialization ──

--- a/backend/tests/unit/test_gdpr_consent.py
+++ b/backend/tests/unit/test_gdpr_consent.py
@@ -1,6 +1,10 @@
 from io import BytesIO
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from app.dependencies import require_gdpr_consent
+from app.main import app
 from tests.unit.conftest import MockNode
 
 
@@ -8,6 +12,16 @@ def _patch_invite():
     return patch(
         "app.auth.router.is_invite_code_required", AsyncMock(return_value=False)
     )
+
+
+@pytest.fixture
+def consent_gated_client(client):
+    """Client fixture that exercises the real ``require_gdpr_consent`` DB
+    lookup instead of the default override used by the rest of the
+    suite. Used only in this file to assert the 403 response."""
+    app.dependency_overrides.pop(require_gdpr_consent, None)
+    yield client
+    # ``client`` teardown re-clears all overrides anyway, but be explicit.
 
 
 def test_grant_gdpr_consent(client, mock_db):
@@ -57,7 +71,7 @@ def test_get_me_defaults_consent_to_false(client, mock_db):
 @patch("app.cv.router.classify_entries")
 @patch("app.cv.router.counter")
 def test_upload_cv_rejected_without_consent(
-    mock_counter, mock_classify, mock_docling, client, mock_db
+    mock_counter, mock_classify, mock_docling, consent_gated_client, mock_db
 ):
     session_mock = mock_db.session.return_value.__aenter__.return_value
     session_mock.run.return_value.single = AsyncMock(return_value={"consent": False})
@@ -65,20 +79,56 @@ def test_upload_cv_rejected_without_consent(
     file_content = b"%PDF-1.4 test content"
     file = BytesIO(file_content)
 
-    response = client.post(
+    response = consent_gated_client.post(
         "/cv/upload", files={"file": ("test.pdf", file, "application/pdf")}
     )
     assert response.status_code == 403
     assert "GDPR consent required" in response.json()["detail"]
 
 
-def test_confirm_cv_rejected_without_consent(client, mock_db):
+def test_confirm_cv_rejected_without_consent(consent_gated_client, mock_db):
     session_mock = mock_db.session.return_value.__aenter__.return_value
     session_mock.run.return_value.single = AsyncMock(return_value={"consent": False})
 
-    response = client.post(
+    response = consent_gated_client.post(
         "/cv/confirm",
         json={"nodes": [], "relationships": []},
     )
+    assert response.status_code == 403
+    assert "GDPR consent required" in response.json()["detail"]
+
+
+def test_notes_enhance_rejected_without_consent(consent_gated_client, mock_db):
+    """L3: /notes/enhance was missing the consent gate before this fix."""
+    session_mock = mock_db.session.return_value.__aenter__.return_value
+    session_mock.run.return_value.single = AsyncMock(return_value={"consent": False})
+
+    response = consent_gated_client.post(
+        "/notes/enhance",
+        json={"text": "led team", "target_language": "en", "existing_skills": []},
+    )
+    assert response.status_code == 403
+    assert "GDPR consent required" in response.json()["detail"]
+
+
+def test_orbs_add_node_rejected_without_consent(consent_gated_client, mock_db):
+    """L3: POST /orbs/me/nodes was missing the consent gate."""
+    session_mock = mock_db.session.return_value.__aenter__.return_value
+    session_mock.run.return_value.single = AsyncMock(return_value={"consent": False})
+
+    response = consent_gated_client.post(
+        "/orbs/me/nodes",
+        json={"node_type": "skill", "properties": {"name": "Python"}},
+    )
+    assert response.status_code == 403
+    assert "GDPR consent required" in response.json()["detail"]
+
+
+def test_orbs_update_profile_rejected_without_consent(consent_gated_client, mock_db):
+    """L3: PUT /orbs/me was missing the consent gate."""
+    session_mock = mock_db.session.return_value.__aenter__.return_value
+    session_mock.run.return_value.single = AsyncMock(return_value={"consent": False})
+
+    response = consent_gated_client.put("/orbs/me", json={"headline": "New headline"})
     assert response.status_code == 403
     assert "GDPR consent required" in response.json()["detail"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,6 +70,92 @@ All configuration is via environment variables. See `.env.example` for the full 
 
 Optional: set `ENCRYPTION_KEYS_HISTORIC` to a comma-separated list of previous Fernet keys when rotating. New writes use `ENCRYPTION_KEY`; reads transparently try the historic keys for legacy ciphertext.
 
+### Rotating the Fernet encryption key
+
+PII fields (`email`, `phone`, `address` on `Person` nodes; PDF bytes in `backend/data/cv_files/`) are encrypted at rest with the active `ENCRYPTION_KEY`. The application supports zero-downtime key rotation via a dual-key window driven by `ENCRYPTION_KEYS_HISTORIC`. Rotate whenever you have reason to believe the current key has been leaked, or on a scheduled cadence (recommended: annually, or when offboarding anyone with production access).
+
+The rotation is four phases. Each phase maps to a single config change + restart; nothing in the database is touched until the opportunistic re-encryption script in phase 3.
+
+**Phase 0 — prepare a fresh key.** On a trusted workstation:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Call the output `NEW_KEY`. Record it in your secret manager alongside the current `OLD_KEY` (the value currently in `ENCRYPTION_KEY`).
+
+**Phase 1 — deploy with both keys, old still primary.** Set environment:
+
+```
+ENCRYPTION_KEY=<OLD_KEY>
+ENCRYPTION_KEYS_HISTORIC=<NEW_KEY>
+```
+
+Restart the backend. This phase changes nothing functionally — `MultiFernet` still decrypts with `OLD_KEY` first — but it verifies every node in your cluster has loaded the new key before you promote it. Watch the logs for `Ignoring invalid key in ENCRYPTION_KEYS_HISTORIC` warnings; if any appear, fix `NEW_KEY` and redo this phase before continuing.
+
+**Phase 2 — promote `NEW_KEY` as primary.** Swap:
+
+```
+ENCRYPTION_KEY=<NEW_KEY>
+ENCRYPTION_KEYS_HISTORIC=<OLD_KEY>
+```
+
+Restart. New writes are encrypted with `NEW_KEY`; existing ciphertext still decrypts because `OLD_KEY` is in the historic list. This is the longest-lived phase — it stays in place until every PII field has been re-encrypted with the new key, which happens opportunistically on any read-modify-write path, plus explicitly via the script in phase 3.
+
+**Phase 3 — bulk re-encrypt to close the window.** To force every remaining `OLD_KEY` ciphertext to migrate, run the following admin one-shot from a backend shell (e.g., `uv run python`):
+
+```python
+import asyncio
+from app.graph.encryption import decrypt_value, encrypt_value, ENCRYPTED_FIELDS
+from app.graph.neo4j_client import get_driver
+
+async def re_encrypt_all_persons() -> int:
+    driver = await get_driver()
+    updated = 0
+    async with driver.session() as session:
+        result = await session.run("MATCH (p:Person) RETURN p.user_id AS uid, p AS node")
+        records = [r async for r in result]
+    for r in records:
+        user_id = r["uid"]
+        node = dict(r["node"])
+        new_props: dict = {}
+        for field in ENCRYPTED_FIELDS:
+            ct = node.get(field)
+            if not ct:
+                continue
+            try:
+                pt = decrypt_value(ct)
+            except Exception:
+                # Already failed under the historic key — leave it alone.
+                continue
+            # encrypt_value always uses the primary (NEW) key.
+            new_props[field] = encrypt_value(pt)
+        if new_props:
+            async with driver.session() as session:
+                await session.run(
+                    "MATCH (p:Person {user_id: $uid}) SET p += $props",
+                    uid=user_id, props=new_props,
+                )
+            updated += 1
+    await driver.close()
+    return updated
+
+print(asyncio.run(re_encrypt_all_persons()))
+```
+
+For the encrypted CV files on disk (`backend/data/cv_files/*.pdf.enc`), the same pattern applies with `decrypt_bytes` / `encrypt_bytes` — there are rarely many of these, so a shell loop is usually enough.
+
+**Phase 4 — drop the old key.** After the script reports a stable zero-delta run (no more ciphertext can still be decrypted by `OLD_KEY` alone) and after your backup retention window has rolled over the old ciphertext, remove `OLD_KEY` from the environment:
+
+```
+ENCRYPTION_KEY=<NEW_KEY>
+ENCRYPTION_KEYS_HISTORIC=
+```
+
+Restart. Rotation complete. Revoke `OLD_KEY` in your secret manager.
+
+If any of the above goes wrong mid-flight, rolling back is always "put the old key back in `ENCRYPTION_KEYS_HISTORIC` and restart" — `MultiFernet` will find it again on the next read.
+
 ### Optional
 
 | Variable | Default | Purpose |

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -64,8 +64,12 @@ export async function updateBetaConfig(
 // ── Access Codes ──
 
 export async function listAccessCodes(): Promise<AccessCode[]> {
-  const { data } = await client.get('/admin/access-codes');
-  return data;
+  // Backend is paginated (L2 fix). Hit the cap so the admin dashboard
+  // keeps showing everything until proper pagination UI lands.
+  const { data } = await client.get('/admin/access-codes', {
+    params: { limit: 200 },
+  });
+  return data.items;
 }
 
 export async function createAccessCode(
@@ -149,8 +153,13 @@ export interface AdminUserDetail extends AdminUser {
 }
 
 export async function listUsers(): Promise<AdminUser[]> {
-  const { data } = await client.get('/admin/users');
-  return data;
+  // Backend is paginated (L2 fix). Hit the cap to preserve the existing
+  // "show everything" admin-dashboard behavior; swap to real pagination
+  // UI once the user base grows past 200.
+  const { data } = await client.get('/admin/users', {
+    params: { limit: 200 },
+  });
+  return data.items;
 }
 
 export async function getUser(userId: string): Promise<AdminUserDetail> {


### PR DESCRIPTION
Addresses all **LOW** findings from issue #253. One commit per finding so each can be reviewed and reverted in isolation.

## Summary

| # | Finding | Fix | Commit |
|---|---------|-----|--------|
| L1 | `decrypt_properties` swallowed Fernet exceptions, logged a warning, and left the raw ciphertext in the returned dict. UI layers rendered base64 gibberish; ``email == expected`` comparisons silently failed. | Failed fields become `None` and a companion `_decryption_failed: [...]` list is added to the result so callers can detect and surface the error. | `0f39785` |
| L2 | `GET /admin/users` and `GET /admin/access-codes` did an unbounded full-table scan, decrypting every email for the response. Fine at 100 users, DoS-shaped at 10k. | Added `offset` / `limit` query params (default 50, capped at 200 via FastAPI `Query(le=200)`). New `UsersPage` / `AccessCodesPage` response models carry `{items, total, offset, limit}`. Frontend API helpers request `limit=200` so the current admin dashboard behavior is preserved until a proper pagination UI lands. | `69d010c` |
| L3 | The GDPR consent gate was a private helper inside `cv/router.py` and only applied to the CV pipeline. `/notes/enhance`, `/orbs/me/nodes` (POST/PUT), `/orbs/me` (profile update), and `/orbs/me/profile-image` all processed user-controlled data without checking consent. | New `require_gdpr_consent` FastAPI dependency in `app/dependencies.py`. Applied to every write endpoint that persists user data or feeds the LLM pipeline. Reads (`GET /orbs/me`, versions, share tokens, connection requests) stay open so a user can always see what we hold on them (GDPR Article 15). DELETE paths stay open so the right-to-erasure flow isn't blocked by a missing consent. | `6a11979` |
| L4 | No documented key-rotation procedure, even though C2 already wired `MultiFernet` + `ENCRYPTION_KEYS_HISTORIC` for the decrypt side. | `docs/deployment.md` gains a four-phase rotation playbook (add historic → promote primary → bulk re-encrypt → drop old) plus an inline Python snippet that walks every `Person` node, decrypts each PII field, and re-encrypts with the new primary key. No new code. | `34df334` |

## Architectural note on L3

The new dependency is deliberately scoped only to write and LLM endpoints. The GET side of the API stays open for three reasons:

1. **Right of access (GDPR Art. 15)**: a user who has withdrawn consent must still be able to read what the platform has on them before the erasure flow runs.
2. **Right to erasure (Art. 17)**: DELETE endpoints must not themselves require consent, or we'd trap users into a state where they can't remove their data.
3. **Bootstrap**: `GET /auth/me` has to return the current consent state even when consent hasn't been given yet — otherwise the frontend can't render the consent dialog.

The consent marker itself (`_decryption_failed`) from L1 intentionally uses a key prefixed with `_` so any Pydantic response model with `extra="forbid"` would reject it — the response models in this codebase all use the permissive default, so the marker flows through to the client where the frontend can check for it. If we ever tighten the response contracts, the marker becomes a compile-time reminder to decide what to do with failed decryptions.

## Documentation

- `docs/deployment.md`: new "Rotating the Fernet encryption key" section (L4). No CLAUDE.md changes — the new `require_gdpr_consent` dependency and the `_decryption_failed` marker are internal primitives that don't change developer-facing conventions.

## That closes #253

With this PR merged, every finding from the audit issue has been either fixed or explicitly accepted with a documented rationale:

- **Critical** C1-C4 → merged via #260
- **High** H3/H6/H7/H8 → merged via #266
- **High** H1/H2/H5 → merged via #269 (cookie auth + refresh rotation + MCP API keys)
- **High** H4 → closed by the C3 node-property allowlist (noted in #260)
- **Medium** M1-M5/M7 → pending in #270
- **Medium** M6 → accepted risk with rationale, [comment here](https://github.com/Brotherhood94/orb_project/issues/253#issuecomment-4230457871)
- **Low** L1-L4 → this PR
