### PR TITLE
feat: add Training node type for courses and workshops

### DIFF
--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -93,6 +93,15 @@ Valid node_types and their expected properties:
     venue (string), date (string), description (string or null),
     role (string, e.g. "Speaker", "Organizer", "Panelist"),
     url (string or null)
+    NOTE: Outreach is ONLY for activities where the person is a speaker, organizer,
+    panelist, or contributor. Courses and workshops ATTENDED as a participant should
+    be classified as "training", NOT "outreach".
+
+- training:
+    title (string), provider (string, e.g. "Coursera", "Udemy", "Frontend Masters"),
+    date (string), description (string or null), url (string or null)
+    NOTE: Use this for courses, workshops, bootcamps, and seminars the person
+    attended as a participant. Do NOT use "outreach" for attended courses.
 
 ## Rules
 
@@ -107,7 +116,7 @@ Valid node_types and their expected properties:
 ## Relationships
 
 For each skill mentioned in the context of a work_experience, project, education,
-publication, patent, award, or outreach entry, include a relationship entry linking
+publication, patent, award, outreach, or training entry, include a relationship entry linking
 the source node (by its index in the nodes array) to the skill node (by its index).
 Use type "USED_SKILL".
 
@@ -157,6 +166,7 @@ REQUIRED_FIELDS: dict[str, list[str]] = {
     "patent": ["title"],
     "award": ["name"],
     "outreach": ["title"],
+    "training": ["title"],
 }
 
 # ── Date fields that should be normalized ──

--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -107,6 +107,7 @@ def _generate_pdf(  # noqa: C901
         ("Patent", "Patents"),
         ("Award", "Awards"),
         ("Outreach", "Outreach"),
+        ("Training", "Training"),
         ("Skill", "Skills"),
         ("Language", "Languages"),
     ]
@@ -335,6 +336,7 @@ async def export_orb(  # noqa: C901
             "Language": "Language",
             "Award": "MonetaryGrant",
             "Outreach": "Event",
+            "Training": "Course",
         }
 
         for node in nodes:

--- a/backend/app/graph/node_schema.py
+++ b/backend/app/graph/node_schema.py
@@ -71,6 +71,7 @@ ALLOWED_NODE_PROPERTIES: dict[str, frozenset[str]] = {
     ),
     "award": frozenset({"name", "issuer", "date", "description"}),
     "outreach": frozenset({"title", "venue", "date", "description", "url"}),
+    "training": frozenset({"title", "provider", "date", "description", "url"}),
 }
 
 # Inverse lookup for update paths that only have the Neo4j label.

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -151,6 +151,7 @@ NODE_TYPE_LABELS = {
     "patent": "Patent",
     "award": "Award",
     "outreach": "Outreach",
+    "training": "Training",
 }
 
 NODE_TYPE_RELATIONSHIPS = {
@@ -164,6 +165,7 @@ NODE_TYPE_RELATIONSHIPS = {
     "patent": "HAS_PATENT",
     "award": "HAS_AWARD",
     "outreach": "HAS_OUTREACH",
+    "training": "HAS_TRAINING",
 }
 
 # ── Generic Node CRUD ──
@@ -199,6 +201,7 @@ NODE_TYPE_MERGE_KEYS: dict[str, list[str]] = {
     "patent": ["title"],
     "award": ["name"],
     "outreach": ["title", "venue"],
+    "training": ["title", "provider"],
 }
 
 # ── Cross-node relationships ──

--- a/backend/tests/unit/test_parser.py
+++ b/backend/tests/unit/test_parser.py
@@ -325,8 +325,8 @@ Developer
         handled_by_patterns = set(SECTION_PATTERNS.keys())
         all_node_types = set(NODE_TYPE_LABELS.keys())
         missing = all_node_types - handled_by_patterns
-        assert missing == {"patent", "award", "outreach"}, (
-            f"Expected patent/award/outreach to be missing from SECTION_PATTERNS, "
+        assert missing == {"patent", "award", "outreach", "training"}, (
+            f"Expected patent/award/outreach/training to be missing from SECTION_PATTERNS, "
             f"got: {missing}"
         )
 

--- a/backend/tests/unit/test_queries.py
+++ b/backend/tests/unit/test_queries.py
@@ -109,6 +109,7 @@ class TestFullOrbExclusions:
             "patent",
             "award",
             "outreach",
+            "training",
         }
         assert set(NODE_TYPE_LABELS.keys()) == expected
 

--- a/frontend/src/components/drafts/DraftNotes.tsx
+++ b/frontend/src/components/drafts/DraftNotes.tsx
@@ -12,6 +12,7 @@ const HEADING_FIELDS: Record<string, string[]> = {
   patent: ['title', 'patent_number'],
   award: ['name', 'issuing_organization'],
   outreach: ['title', 'venue'],
+  training: ['title', 'provider'],
   skill: ['name', 'category'],
   language: ['name', 'proficiency'],
 };

--- a/frontend/src/components/editor/NodeForm.tsx
+++ b/frontend/src/components/editor/NodeForm.tsx
@@ -70,6 +70,11 @@ const LAYOUT_CONFIG: Record<string, {
     main: ['title', 'type', 'venue', 'role'],
     extra: ['description', 'url'],
   },
+  training: {
+    left: ['date'],
+    main: ['title', 'provider'],
+    extra: ['description', 'url'],
+  },
 };
 
 // Date pair validation rules per node type
@@ -244,6 +249,7 @@ const REQUIRED_FIELDS: Record<string, string[]> = {
   patent: ['title', 'patent_number'],
   award: ['name'],
   outreach: ['title', 'venue'],
+  training: ['title', 'provider'],
 };
 
 // Additional fields that should be required whenever they exist in the active modal.

--- a/frontend/src/components/graph/NodeColors.ts
+++ b/frontend/src/components/graph/NodeColors.ts
@@ -12,6 +12,7 @@ export const NODE_COLORS: Record<string, string> = {
   Patent: '#DC267F',       // Magenta (IBM)
   Award: '#FFB000',        // Gold (IBM)
   Outreach: '#20B2AA',     // Light Sea Green — distinct from Project vermillion
+  Training: '#FF6B6B',     // Coral Red — courses and workshops attended
 };
 
 export function getNodeColor(labels: string[]): string {
@@ -32,6 +33,7 @@ export const NODE_TYPE_COLORS: Record<string, string> = {
   patent: '#DC267F',
   award: '#FFB000',
   outreach: '#20B2AA',
+  training: '#FF6B6B',
 };
 
 export const NODE_TYPE_LABELS: Record<string, string> = {
@@ -45,6 +47,7 @@ export const NODE_TYPE_LABELS: Record<string, string> = {
   patent: 'Patent',
   award: 'Award',
   outreach: 'Outreach',
+  training: 'Training',
 };
 
 // Secondary visual cues — shape markers so color is never the sole differentiator.
@@ -60,5 +63,6 @@ export const NODE_SHAPE_MARKERS: Record<string, string> = {
   Patent: '\u2B1F',        // ⬟ pentagon
   Award: '\u2606',         // ☆ open star
   Outreach: '\u25E3',      // ◣ triangle (lower left)
+  Training: '\u25C8',      // ◈ diamond with dot
 };
 

--- a/frontend/src/components/graph/NodeLegend.tsx
+++ b/frontend/src/components/graph/NodeLegend.tsx
@@ -13,6 +13,7 @@ const TYPE_KEY_MAP: Record<string, string> = {
   Patent: 'patent',
   Award: 'award',
   Outreach: 'outreach',
+  Training: 'training',
 };
 
 const LEGEND_TYPES = Object.keys(TYPE_KEY_MAP);

--- a/frontend/src/components/graph/NodeTooltip.tsx
+++ b/frontend/src/components/graph/NodeTooltip.tsx
@@ -18,6 +18,7 @@ const TITLE_FIELD: Record<string, string> = {
   Patent: 'title',
   Award: 'name',
   Outreach: 'title',
+  Training: 'title',
 };
 
 // Which fields to show as the "subtitle"
@@ -32,6 +33,7 @@ const SUBTITLE_FIELD: Record<string, string> = {
   Patent: 'patent_number',
   Award: 'issuing_organization',
   Outreach: 'venue',
+  Training: 'provider',
 };
 
 // Nice display labels
@@ -47,6 +49,7 @@ const DISPLAY_LABELS: Record<string, string> = {
   Patent: 'Patent',
   Award: 'Award',
   Outreach: 'Outreach',
+  Training: 'Training',
 };
 
 // Map PascalCase label to snake_case for color lookup
@@ -61,6 +64,7 @@ const LABEL_TO_TYPE: Record<string, string> = {
   Patent: 'patent',
   Award: 'award',
   Outreach: 'outreach',
+  Training: 'training',
 };
 
 // Fields to show in the detail section (ordered)
@@ -76,6 +80,7 @@ const DETAIL_FIELDS: Record<string, string[]> = {
   Language: ['proficiency'],
   Award: ['issuing_organization', 'date'],
   Outreach: ['type', 'role', 'date'],
+  Training: ['provider', 'date'],
 };
 
 function formatDate(val: unknown): string {

--- a/frontend/src/components/graph/NodeTypeFilter.tsx
+++ b/frontend/src/components/graph/NodeTypeFilter.tsx
@@ -12,6 +12,7 @@ const TYPE_KEY_MAP: Record<string, string> = {
   Patent: 'patent',
   Award: 'award',
   Outreach: 'outreach',
+  Training: 'training',
 };
 
 const ALL_TYPES = Object.keys(TYPE_KEY_MAP);

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -20,6 +20,7 @@ const REVIEW_REQUIRED_FIELDS: Record<string, string[]> = {
   patent: ['title'],
   award: ['name'],
   outreach: ['title', 'venue'],
+  training: ['title', 'provider'],
 };
 
 function normalizeNodeType(type: string) {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1231,7 +1231,7 @@ function HeaderBtn({ onClick, children, variant = 'ghost' }: {
 
 // ── Constants ──
 
-const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach'];
+const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach', 'Training'];
 const DEFAULT_CAMERA_DISTANCE = 200;
 const CAMERA_DISTANCE_KEY = 'orbis_camera_distance';
 
@@ -1436,7 +1436,7 @@ export default function OrbViewPage() {
     const typeMap: Record<string, string> = {
       Education: 'education', WorkExperience: 'work_experience', Certification: 'certification',
       Language: 'language', Publication: 'publication', Project: 'project',
-      Skill: 'skill', Patent: 'patent', Award: 'award', Outreach: 'outreach',
+      Skill: 'skill', Patent: 'patent', Award: 'award', Outreach: 'outreach', Training: 'training',
     };
     const nodeType = typeMap[labels[0]];
     if (!nodeType) return;

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -10,7 +10,7 @@ import type { ChatMessage } from '../components/chat/ChatBox';
 import DateRangeSlider from '../components/graph/DateRangeSlider';
 import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
 
-const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach'];
+const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach', 'Training'];
 
 export default function SharedOrbPage() {
   const { orbId } = useParams<{ orbId: string }>();

--- a/infra/neo4j/init.cypher
+++ b/infra/neo4j/init.cypher
@@ -34,6 +34,10 @@ CREATE VECTOR INDEX project_embedding IF NOT EXISTS
   FOR (p:Project) ON (p.embedding)
   OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}};
 
+CREATE VECTOR INDEX training_embedding IF NOT EXISTS
+  FOR (t:Training) ON (t.embedding)
+  OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}};
+
 // Ontology versioning
 CREATE CONSTRAINT ontology_version_id IF NOT EXISTS FOR (ov:OntologyVersion) REQUIRE ov.version_id IS UNIQUE;
 CREATE INDEX ontology_content_hash IF NOT EXISTS FOR (ov:OntologyVersion) ON (ov.content_hash);


### PR DESCRIPTION
## Summary
Adds a new **Training** node type for courses, workshops, bootcamps, and seminars the user attended as a participant.

This clarifies the distinction:
- **Training** = courses/workshops the user attended
- **Outreach** = activities where the user is a speaker/organizer/contributor
- **Education** = formal degrees

### Changes across 16 files

**Backend:**
- Node type registered in queries, schema, export
- LLM prompt updated: Training type defined, Outreach clarified as speaker-only
- REQUIRED_FIELDS and ALLOWED_NODE_PROPERTIES updated

**Frontend:**
- NodeForm layout, colors (coral #FF6B6B), tooltip, filters, legend, type filter
- OrbViewPage and SharedOrbPage filterable types
- ExtractedDataReview and DraftNotes headings

**Infrastructure:**
- Vector index for Training embedding

### Training Node Properties
| Property | Required | Description |
|----------|----------|-------------|
| `title` | yes | Name of the course/workshop |
| `provider` | no | Organization (Coursera, Udemy, etc.) |
| `date` | no | Completion date |
| `description` | no | Details |
| `url` | no | Link to course |

Closes #273

## Documentation
- CLAUDE.md may need updating to mention Training node type

## Test plan
- [x] 574 unit tests pass
- [x] Frontend type-check clean
- [x] Ruff lint clean
- [ ] Upload CV with courses → classified as Training, not Outreach
- [ ] Create Training node manually → appears with coral color
- [ ] Filter Training nodes in type filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)