### PR TITLE
fix: backend quality — search batching, image compression, CSP, cookie warning

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -105,6 +105,15 @@ class Settings(BaseSettings):
                 + "\n  - ".join(errors)
                 + "\nRefusing to start. See .env.example for guidance."
             )
+        if not self.cookie_domain:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "COOKIE_DOMAIN is empty in ENV=%s. Cookies will be host-only "
+                "and won't work if frontend and API are on different "
+                "subdomains. Set COOKIE_DOMAIN to the parent domain.",
+                self.env,
+            )
         return self
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -146,7 +146,7 @@ _SECURITY_HEADERS = {
     # base64 images. Loosen per-route if an integration breaks.
     "Content-Security-Policy": (
         "default-src 'self'; "
-        "img-src 'self' data: https:; "
+        "img-src 'self' data:; "
         "style-src 'self' 'unsafe-inline'; "
         "script-src 'self'; "
         "connect-src 'self'; "

--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -247,23 +247,52 @@ async def update_visibility(
         return {"visibility": data.visibility}
 
 
+_PROFILE_MAX_DIM = 256
+_PROFILE_JPEG_QUALITY = 80
+_PROFILE_MAX_UPLOAD = 5 * 1024 * 1024  # accept up to 5MB raw, compress down
+
+
+def _compress_profile_image(raw_bytes: bytes) -> str:
+    """Resize to max 256×256 and compress to JPEG. Returns a data URI.
+
+    The previous implementation stored the raw upload (up to 2MB) as a
+    base64 data URI on the Person node, bloating Neo4j and slowing every
+    GET_FULL_ORB. Compressing to a ~20-50KB JPEG thumbnail keeps the
+    simple data-URI-on-node architecture without the performance cost.
+    """
+    import io
+
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(raw_bytes))
+    img.thumbnail((_PROFILE_MAX_DIM, _PROFILE_MAX_DIM), Image.LANCZOS)
+    if img.mode in ("RGBA", "P"):
+        img = img.convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=_PROFILE_JPEG_QUALITY, optimize=True)
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
 @router.post("/me/profile-image")
 async def upload_profile_image(
     file: UploadFile = File(...),
     current_user: dict = Depends(require_gdpr_consent),
     db: AsyncDriver = Depends(get_db),
 ):
-    """Upload a profile picture. Stored as base64 on the Person node."""
+    """Upload a profile picture. Resized to 256×256 JPEG and stored as a
+    compressed data URI on the Person node (~20-50KB instead of up to 2MB)."""
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File must be an image")
 
     image_bytes = await file.read()
-    max_size = 2 * 1024 * 1024  # 2MB
-    if len(image_bytes) > max_size:
-        raise HTTPException(status_code=400, detail="Image too large (max 2MB)")
+    if len(image_bytes) > _PROFILE_MAX_UPLOAD:
+        raise HTTPException(status_code=400, detail="Image too large (max 5MB)")
 
-    b64 = base64.b64encode(image_bytes).decode("ascii")
-    data_uri = f"data:{file.content_type};base64,{b64}"
+    try:
+        data_uri = _compress_profile_image(image_bytes)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Could not process image") from None
 
     async with db.session() as session:
         result = await session.run(

--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -193,71 +193,74 @@ async def text_search(  # noqa: C901
     if not terms:
         terms = [raw_term]
 
-    # First: exact substring match via Cypher
+    # First: exact substring match via a single UNION query (one round-trip
+    # to Neo4j instead of one per label type).
     results = []
     seen_uids: set[str] = set()
 
+    union_parts = []
+    for label, fields in _SEARCH_FIELDS.items():
+        where = " OR ".join(f"toLower(toString(n.{f})) CONTAINS $term" for f in fields)
+        union_parts.append(
+            f"MATCH (p:Person {{user_id: $user_id}})-[]->(n:{label}) "
+            f"WHERE {where} "
+            f"RETURN n, labels(n) AS node_labels"
+        )
+    cypher_exact = " UNION ALL ".join(union_parts)
+
     async with db.session() as session:
-        for label, fields in _SEARCH_FIELDS.items():
-            where_clauses = " OR ".join(
-                f"toLower(toString(n.{f})) CONTAINS $term" for f in fields
+        try:
+            result = await session.run(
+                cypher_exact, user_id=current_user["user_id"], term=raw_term
             )
-            cypher = (
-                f"MATCH (p:Person {{user_id: $user_id}})-[r]->(n:{label}) "
-                f"WHERE {where_clauses} "
-                f"RETURN n, labels(n) AS node_labels"
-            )
+            async for record in result:
+                node = dict(record["n"])
+                node.pop("embedding", None)
+                node_labels = record["node_labels"]
+                node["_labels"] = node_labels
+                label = node_labels[0] if node_labels else ""
+                fields = _SEARCH_FIELDS.get(label, [])
+                node["score"] = _node_match_score(node, fields, raw_term, terms)
+                uid = node.get("uid", "")
+                if uid not in seen_uids:
+                    seen_uids.add(uid)
+                    results.append(node)
+        except Exception as e:
+            logger.warning("Text search exact query failed: %s", type(e).__name__)
+
+    # Second: if few results, fetch all user nodes in one query and fuzzy-match client-side
+    if len(results) < 3:
+        fuzzy_cypher = (
+            "MATCH (p:Person {user_id: $user_id})-[]->(n) "
+            "RETURN n, labels(n) AS node_labels"
+        )
+        async with db.session() as session:
             try:
                 result = await session.run(
-                    cypher, user_id=current_user["user_id"], term=raw_term
+                    fuzzy_cypher, user_id=current_user["user_id"]
                 )
                 async for record in result:
                     node = dict(record["n"])
-                    node.pop("embedding", None)
-                    node["_labels"] = record["node_labels"]
-                    node["score"] = _node_match_score(node, fields, raw_term, terms)
-                    if node.get("uid") not in seen_uids:
-                        seen_uids.add(node.get("uid", ""))
+                    uid = node.get("uid", "")
+                    if uid in seen_uids:
+                        continue
+                    node_labels = record["node_labels"]
+                    label = node_labels[0] if node_labels else ""
+                    fields = _SEARCH_FIELDS.get(label, [])
+                    if not fields:
+                        continue
+                    matched = any(
+                        node.get(f) and _fuzzy_match(str(node[f]), terms)
+                        for f in fields
+                    )
+                    if matched:
+                        node.pop("embedding", None)
+                        node["_labels"] = node_labels
+                        node["score"] = _node_match_score(node, fields, raw_term, terms)
+                        seen_uids.add(uid)
                         results.append(node)
             except Exception as e:
-                logger.warning("Text search query failed for label %s: %s", label, e)
-                continue
-
-    # Second: if few results, do fuzzy matching on all nodes
-    if len(results) < 3:
-        async with db.session() as session:
-            for label, fields in _SEARCH_FIELDS.items():
-                cypher = (
-                    f"MATCH (p:Person {{user_id: $user_id}})-[r]->(n:{label}) "
-                    f"RETURN n, labels(n) AS node_labels"
-                )
-                try:
-                    result = await session.run(cypher, user_id=current_user["user_id"])
-                    async for record in result:
-                        node = dict(record["n"])
-                        uid = node.get("uid", "")
-                        if uid in seen_uids:
-                            continue
-                        # Check fuzzy match against all searchable fields
-                        matched = False
-                        for f in fields:
-                            val = node.get(f)
-                            if val and _fuzzy_match(str(val), terms):
-                                matched = True
-                                break
-                        if matched:
-                            node.pop("embedding", None)
-                            node["_labels"] = record["node_labels"]
-                            node["score"] = _node_match_score(
-                                node, fields, raw_term, terms
-                            )
-                            seen_uids.add(uid)
-                            results.append(node)
-                except Exception as e:
-                    logger.warning(
-                        "Fuzzy search query failed for label %s: %s", label, e
-                    )
-                    continue
+                logger.warning("Fuzzy search query failed: %s", type(e).__name__)
 
     results.sort(key=lambda n: n.get("score", 0), reverse=True)
     return results
@@ -320,85 +323,81 @@ async def public_text_search(  # noqa: C901
     results = []
     seen_uids: set[str] = set()
 
+    # Single UNION query instead of one per label type
+    union_parts = []
+    for label, fields in _SEARCH_FIELDS.items():
+        where = " OR ".join(f"toLower(toString(n.{f})) CONTAINS $term" for f in fields)
+        union_parts.append(
+            f"MATCH (p:Person {{orb_id: $orb_id}})-[]->(n:{label}) "
+            f"WHERE {where} "
+            f"RETURN n, labels(n) AS node_labels"
+        )
+    cypher_exact = " UNION ALL ".join(union_parts)
+
     async with db.session() as session:
-        for label, fields in _SEARCH_FIELDS.items():
-            where_clauses = " OR ".join(
-                f"toLower(toString(n.{f})) CONTAINS $term" for f in fields
+        try:
+            result = await session.run(cypher_exact, orb_id=data.orb_id, term=raw_term)
+            async for record in result:
+                node = dict(record["n"])
+                node.pop("embedding", None)
+                node_labels = record["node_labels"]
+                node["_labels"] = node_labels
+                label = node_labels[0] if node_labels else ""
+                fields = _SEARCH_FIELDS.get(label, [])
+                node["score"] = _node_match_score(node, fields, raw_term, terms)
+                uid = node.get("uid", "")
+                if uid not in seen_uids:
+                    if hidden_types and set(node_labels) & hidden_types:
+                        continue
+                    if filter_keywords and node_matches_filters(node, filter_keywords):
+                        continue
+                    seen_uids.add(uid)
+                    results.append(node)
+        except Exception as e:
+            logger.warning(
+                "Public text search failed for orb %s: %s",
+                data.orb_id,
+                type(e).__name__,
             )
-            cypher = (
-                f"MATCH (p:Person {{orb_id: $orb_id}})-[r]->(n:{label}) "
-                f"WHERE {where_clauses} "
-                f"RETURN n, labels(n) AS node_labels"
-            )
+
+    if len(results) < 3:
+        fuzzy_cypher = (
+            "MATCH (p:Person {orb_id: $orb_id})-[]->(n) "
+            "RETURN n, labels(n) AS node_labels"
+        )
+        async with db.session() as session:
             try:
-                result = await session.run(cypher, orb_id=data.orb_id, term=raw_term)
+                result = await session.run(fuzzy_cypher, orb_id=data.orb_id)
                 async for record in result:
                     node = dict(record["n"])
-                    node.pop("embedding", None)
-                    node["_labels"] = record["node_labels"]
-                    node["score"] = _node_match_score(node, fields, raw_term, terms)
-                    if node.get("uid") not in seen_uids:
-                        node_labels = set(node.get("_labels", []))
-                        if hidden_types and node_labels & hidden_types:
-                            continue
-                        if filter_keywords and node_matches_filters(
-                            node, filter_keywords
-                        ):
-                            continue
-                        seen_uids.add(node.get("uid", ""))
+                    uid = node.get("uid", "")
+                    if uid in seen_uids:
+                        continue
+                    node_labels = record["node_labels"]
+                    label = node_labels[0] if node_labels else ""
+                    fields = _SEARCH_FIELDS.get(label, [])
+                    if not fields:
+                        continue
+                    if hidden_types and set(node_labels) & hidden_types:
+                        continue
+                    if filter_keywords and node_matches_filters(node, filter_keywords):
+                        continue
+                    matched = any(
+                        node.get(f) and _fuzzy_match(str(node[f]), terms)
+                        for f in fields
+                    )
+                    if matched:
+                        node.pop("embedding", None)
+                        node["_labels"] = node_labels
+                        node["score"] = _node_match_score(node, fields, raw_term, terms)
+                        seen_uids.add(uid)
                         results.append(node)
             except Exception as e:
                 logger.warning(
-                    "Public text search failed for label %s on orb %s: %s",
-                    label,
+                    "Public fuzzy search failed for orb %s: %s",
                     data.orb_id,
-                    e,
+                    type(e).__name__,
                 )
-                continue
-
-    if len(results) < 3:
-        async with db.session() as session:
-            for label, fields in _SEARCH_FIELDS.items():
-                cypher = (
-                    f"MATCH (p:Person {{orb_id: $orb_id}})-[r]->(n:{label}) "
-                    f"RETURN n, labels(n) AS node_labels"
-                )
-                try:
-                    result = await session.run(cypher, orb_id=data.orb_id)
-                    async for record in result:
-                        node = dict(record["n"])
-                        uid = node.get("uid", "")
-                        if uid in seen_uids:
-                            continue
-                        node_labels = set(record.get("node_labels", []))
-                        if hidden_types and node_labels & hidden_types:
-                            continue
-                        if filter_keywords and node_matches_filters(
-                            node, filter_keywords
-                        ):
-                            continue
-                        matched = False
-                        for f in fields:
-                            val = node.get(f)
-                            if val and _fuzzy_match(str(val), terms):
-                                matched = True
-                                break
-                        if matched:
-                            node.pop("embedding", None)
-                            node["_labels"] = record["node_labels"]
-                            node["score"] = _node_match_score(
-                                node, fields, raw_term, terms
-                            )
-                            seen_uids.add(uid)
-                            results.append(node)
-                except Exception as e:
-                    logger.warning(
-                        "Public fuzzy search failed for label %s on orb %s: %s",
-                        label,
-                        data.orb_id,
-                        e,
-                    )
-                    continue
 
     results.sort(key=lambda n: n.get("score", 0), reverse=True)
     return results

--- a/backend/tests/unit/test_search_router.py
+++ b/backend/tests/unit/test_search_router.py
@@ -2,7 +2,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.search.router import _SEARCH_FIELDS
 from tests.unit.conftest import MockNode
 
 
@@ -125,8 +124,8 @@ def test_public_text_search_fuzzy_trigger(
     result_full.__aiter__ = mock_async_iter_full
 
     run_mock = mock_db.session.return_value.__aenter__.return_value.run
-    n_labels = len(_SEARCH_FIELDS)
-    run_mock.side_effect = [result_empty] * n_labels + [result_full] * n_labels
+    # 1 call for the exact UNION, 1 for the fuzzy all-nodes query
+    run_mock.side_effect = [result_empty, result_full]
 
     payload = {"query": "Javscript", "orb_id": "test-orb", "token": "valid-token"}
     response = client.post("/search/text/public", json=payload)
@@ -231,15 +230,13 @@ def test_text_search_query_skipped_on_error(client, mock_db):
 
 
 def test_text_search_fuzzy_trigger(client, mock_db):
-    # Mock first query (substring) returns empty, triggers second query (fuzzy)
+    """Exact UNION returns empty → fuzzy all-nodes query fires and finds a match."""
     node_data = {"uid": "node-fuzzy", "name": "Javascript"}
     node_mock = MockNode(node_data, ["Skill"])
 
-    # First call: empty result
-    # Second call: returns all nodes for fuzzy match
     async def mock_async_iter_empty(*args, **kwargs):
         if False:
-            yield  # Generator
+            yield
         return
 
     async def mock_async_iter_full(*args, **kwargs):
@@ -252,9 +249,8 @@ def test_text_search_fuzzy_trigger(client, mock_db):
     result_full.__aiter__ = mock_async_iter_full
 
     run_mock = mock_db.session.return_value.__aenter__.return_value.run
-
-    n_labels = len(_SEARCH_FIELDS)
-    run_mock.side_effect = [result_empty] * n_labels + [result_full] * n_labels
+    # 1 call for the exact UNION, 1 for the fuzzy all-nodes query
+    run_mock.side_effect = [result_empty, result_full]
 
     response = client.post("/search/text", json={"query": "Javscript"})  # Typo
     assert response.status_code == 200


### PR DESCRIPTION
Backend quality improvements addressing remaining findings from #228 and #181.

## Commits

| Commit | Finding | Description |
|--------|---------|-------------|
| `deb90eb` | #228 medium, audit | **Search query batching**: text_search and public_text_search consolidated from 8 per-label round-trips to 1 UNION ALL + 1 fuzzy fallback. **CSP**: removed blanket `https:` from `img-src`. **Cookie domain**: warn in prod if `COOKIE_DOMAIN` is empty. |
| `0ac66fc` | #181.6 | **Profile image compression**: uploads are resized to 256×256 JPEG at 80% quality via Pillow before storing as data URI. Typical output ~30KB vs the previous 500KB-2MB raw. Accepts up to 5MB raw input (was 2MB), always stores the compressed thumbnail. |

## Tests

581 passed, ruff clean. Search mock patterns updated for the new 2-call (UNION + fuzzy) pattern.

## Still open from #228 / #181 (frontend PRs)

| Finding | Description |
|---------|-------------|
| #228.5 | orbStore full re-fetch → patch locally |
| #228 medium | Undo store mutation bug, date normalization DRY |
| #181.7 | OrbViewPage / CvExportPage decomposition |
| #228.10 / #181.8 | Frontend tests |
| #228.9 | Canvas texture atlas (Three.js) |
| #181.12 | Real embeddings (feature) |
