### PR TITLE
fix: orbStore local patching + undoStore mutation bug (#228)

### DIFF
--- a/frontend/src/stores/orbStore.ts
+++ b/frontend/src/stores/orbStore.ts
@@ -51,7 +51,11 @@ export const useOrbStore = create<OrbState>((set, get) => ({
   addNode: async (nodeType: string, properties: Record<string, unknown>) => {
     try {
       const node = await orbsApi.addNode(nodeType, properties);
-      await get().fetchOrb();
+      // Patch locally instead of re-fetching the entire graph (#228.5).
+      const data = get().data;
+      if (data) {
+        set({ data: { ...data, nodes: [...data.nodes, node] } });
+      }
       useToastStore.getState().addToast('Entry added to your orbis', 'success');
       useUndoStore.getState().pushUndo({
         type: 'add',
@@ -68,8 +72,17 @@ export const useOrbStore = create<OrbState>((set, get) => ({
 
   updateNode: async (uid: string, properties: Record<string, unknown>) => {
     try {
-      await orbsApi.updateNode(uid, properties);
-      await get().fetchOrb();
+      const updated = await orbsApi.updateNode(uid, properties);
+      // Patch the node in place instead of full re-fetch.
+      const data = get().data;
+      if (data) {
+        set({
+          data: {
+            ...data,
+            nodes: data.nodes.map((n) => (n.uid === uid ? { ...n, ...updated } : n)),
+          },
+        });
+      }
       useToastStore.getState().addToast('Entry updated', 'success');
     } catch (e) {
       useToastStore.getState().addToast('Failed to update entry', 'error');
@@ -80,7 +93,17 @@ export const useOrbStore = create<OrbState>((set, get) => ({
   deleteNode: async (uid: string, nodeType?: string, properties?: Record<string, unknown>, relationships?: Array<{ source: string; target: string; type: string }>) => {
     try {
       await orbsApi.deleteNode(uid);
-      await get().fetchOrb();
+      // Remove the node and any links referencing it.
+      const data = get().data;
+      if (data) {
+        set({
+          data: {
+            ...data,
+            nodes: data.nodes.filter((n) => n.uid !== uid),
+            links: data.links.filter((l) => l.source !== uid && l.target !== uid),
+          },
+        });
+      }
       useToastStore.getState().addToast('Entry deleted', 'success');
       if (nodeType && properties) {
         useUndoStore.getState().pushUndo({
@@ -100,7 +123,11 @@ export const useOrbStore = create<OrbState>((set, get) => ({
   updateVisibility: async (visibility: OrbVisibility) => {
     try {
       await orbsApi.updateVisibility(visibility);
-      await get().fetchOrb();
+      // Patch person.visibility locally.
+      const data = get().data;
+      if (data) {
+        set({ data: { ...data, person: { ...data.person, visibility } } });
+      }
     } catch (e) {
       useToastStore.getState().addToast('Failed to update visibility', 'error');
       throw e;

--- a/frontend/src/stores/undoStore.ts
+++ b/frontend/src/stores/undoStore.ts
@@ -35,14 +35,15 @@ export const useUndoStore = create<UndoState>((set, get) => ({
     const { undoStack } = get();
     if (undoStack.length === 0) return;
 
-    const entry = undoStack[undoStack.length - 1];
+    // Clone so we never mutate the stack entry in place (#228 undo bug).
+    let redoEntry = { ...undoStack[undoStack.length - 1] };
 
-    if (entry.type === 'add') {
-      await orbsApi.deleteNode(entry.nodeUid);
+    if (redoEntry.type === 'add') {
+      await orbsApi.deleteNode(redoEntry.nodeUid);
     } else {
-      const node = await orbsApi.addNode(entry.nodeType, entry.properties);
-      if (entry.relationships) {
-        for (const rel of entry.relationships) {
+      const node = await orbsApi.addNode(redoEntry.nodeType, redoEntry.properties);
+      if (redoEntry.relationships) {
+        for (const rel of redoEntry.relationships) {
           if (rel.type === 'USED_SKILL') {
             try {
               await orbsApi.linkSkill(node.uid, rel.target);
@@ -50,12 +51,12 @@ export const useUndoStore = create<UndoState>((set, get) => ({
           }
         }
       }
-      entry.nodeUid = node.uid;
+      redoEntry = { ...redoEntry, nodeUid: node.uid };
     }
 
     set((state) => ({
       undoStack: state.undoStack.slice(0, -1),
-      redoStack: [...state.redoStack, entry],
+      redoStack: [...state.redoStack, redoEntry],
     }));
   },
 
@@ -63,18 +64,18 @@ export const useUndoStore = create<UndoState>((set, get) => ({
     const { redoStack } = get();
     if (redoStack.length === 0) return;
 
-    const entry = redoStack[redoStack.length - 1];
+    let undoEntry = { ...redoStack[redoStack.length - 1] };
 
-    if (entry.type === 'add') {
-      const node = await orbsApi.addNode(entry.nodeType, entry.properties);
-      entry.nodeUid = node.uid;
+    if (undoEntry.type === 'add') {
+      const node = await orbsApi.addNode(undoEntry.nodeType, undoEntry.properties);
+      undoEntry = { ...undoEntry, nodeUid: node.uid };
     } else {
-      await orbsApi.deleteNode(entry.nodeUid);
+      await orbsApi.deleteNode(undoEntry.nodeUid);
     }
 
     set((state) => ({
       redoStack: state.redoStack.slice(0, -1),
-      undoStack: [...state.undoStack, entry],
+      undoStack: [...state.undoStack, undoEntry],
     }));
   },
 


### PR DESCRIPTION
## Fixes

1. **orbStore full re-fetch → local patching** (#228.5): `addNode`, `updateNode`, `deleteNode`, and `updateVisibility` no longer call `fetchOrb()` which re-downloaded the entire graph after every mutation. Instead they immutably patch the Zustand state with the API response.

2. **undoStore state mutation** (#228 medium): `undo()` and `redo()` mutated stack entries in place with `entry.nodeUid = node.uid`. Now entries are cloned via spread before modification.

Note: date normalization duplication (#228 medium) was investigated and found to be a false positive — `dateFilterStore.normalizeDate()` (parsing for filtering) and `NodeForm.maskDateInput()` (keystroke masking) serve different purposes and are not duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)