### PR TITLE
feat: add people search bar by Orbis ID in navbar

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
 import UserMenu from './UserMenu';
 
 interface NavbarProps {
@@ -10,6 +12,17 @@ interface NavbarProps {
 
 export default function Navbar({ center, rightBefore }: NavbarProps) {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
+  const [searchValue, setSearchValue] = useState('');
+  const [searchExpanded, setSearchExpanded] = useState(false);
+
+  const handleSearch = () => {
+    const orbId = searchValue.trim();
+    if (!orbId) return;
+    setSearchValue('');
+    setSearchExpanded(false);
+    navigate(`/${orbId}`);
+  };
 
   return (
     <div className="absolute top-0 left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3">
@@ -32,6 +45,42 @@ export default function Navbar({ center, rightBefore }: NavbarProps) {
         {/* Right */}
         <div className="flex items-center gap-2">
           {rightBefore}
+
+          {/* Search by Orbis ID — authenticated only */}
+          {user && (
+            <>
+              {/* Mobile: icon toggle */}
+              <button
+                onClick={() => setSearchExpanded((v) => !v)}
+                className="sm:hidden w-8 h-8 rounded-full flex items-center justify-center bg-white/10 hover:bg-white/20 border border-white/15 text-white/50 hover:text-white transition-all"
+                title="Search by Orbis ID"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              </button>
+
+              {/* Desktop: always visible */}
+              <form
+                onSubmit={(e) => { e.preventDefault(); handleSearch(); }}
+                className={`items-center gap-1.5 ${searchExpanded ? 'flex' : 'hidden sm:flex'}`}
+              >
+                <div className="flex items-center bg-white/10 border border-white/15 rounded-lg px-2.5 py-1.5 focus-within:border-purple-500/50 focus-within:bg-white/15 transition-all">
+                  <svg className="w-3.5 h-3.5 text-white/40 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                  <input
+                    value={searchValue}
+                    onChange={(e) => setSearchValue(e.target.value)}
+                    placeholder="Search Orbis ID..."
+                    className="bg-transparent text-white text-xs placeholder-white/30 focus:outline-none ml-2 w-28 sm:w-36"
+                    onBlur={() => { if (!searchValue) setSearchExpanded(false); }}
+                  />
+                </div>
+              </form>
+            </>
+          )}
+
           <UserMenu />
         </div>
       </div>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1211,6 +1211,7 @@ export default function OrbViewPage() {
   const isPendingDeletion = user?.deletion_days_remaining != null;
   const [showInput, setShowInput] = useState(false);
   const [showShare, setShowShare] = useState(false);
+  const [orbSearchValue, setOrbSearchValue] = useState('');
   const [showDiscoverUses, setShowDiscoverUses] = useState(false);
   const [showDrafts, setShowDrafts] = useState(false);
   const [cameraDistance] = useState(getSavedCameraDistance);
@@ -1880,6 +1881,23 @@ export default function OrbViewPage() {
                 </div>
               )}
 
+              <div className="w-px h-5 bg-white/10 mx-1 hidden sm:block" />
+              <form
+                onSubmit={(e) => { e.preventDefault(); const v = orbSearchValue.trim(); if (v) { navigate(`/${v}`); setOrbSearchValue(''); } }}
+                className="hidden sm:flex items-center"
+              >
+                <div className="flex items-center bg-white/10 border border-white/15 rounded-lg px-2.5 py-1.5 focus-within:border-purple-500/50 focus-within:bg-white/15 transition-all">
+                  <svg className="w-3.5 h-3.5 text-white/40 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                  <input
+                    value={orbSearchValue}
+                    onChange={(e) => setOrbSearchValue(e.target.value)}
+                    placeholder="Search Orbis ID..."
+                    className="bg-transparent text-white text-xs placeholder-white/30 focus:outline-none ml-2 w-28 sm:w-36"
+                  />
+                </div>
+              </form>
               <div className="w-px h-5 bg-white/10 mx-1 hidden sm:block" />
               <div data-tour="user-menu">
                 <UserMenu


### PR DESCRIPTION
## Summary
- Search input on the right side of the navbar (before user menu)
- Only shows when the user is authenticated
- Type an Orbis ID and press Enter to navigate to `/{orbId}`
- Mobile: collapses to a search icon button, expands on tap
- Desktop: always visible inline with search icon

Closes #285

## Documentation
No doc changes needed

## Test plan
- [ ] Logged in → search bar visible in navbar
- [ ] Logged out → search bar not visible
- [ ] Type "alessandroberti" + Enter → navigates to /alessandroberti
- [ ] Input clears after navigation
- [ ] Mobile: shows icon, tap expands input

🤖 Generated with [Claude Code](https://claude.com/claude-code)