### PR TITLE
Enforce explicit waitlist join and align admin pending states

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -142,6 +142,8 @@ class UserResponse(BaseModel):
     provider: str = ""
     is_admin: bool = False
     signup_code: str | None = None
+    waitlist_joined: bool = False
+    waitlist_joined_at: str | None = None
     activated_at: str | None = None
     created_at: str = ""
 

--- a/backend/app/admin/router.py
+++ b/backend/app/admin/router.py
@@ -98,6 +98,10 @@ def _serialize_user(node: dict) -> UserResponse:
         provider=node.get("provider", "") or "",
         is_admin=bool(node.get("is_admin", False)),
         signup_code=node.get("signup_code"),
+        waitlist_joined=bool(node.get("waitlist_joined", False)),
+        waitlist_joined_at=(
+            str(node["waitlist_joined_at"]) if node.get("waitlist_joined_at") else None
+        ),
         activated_at=str(node["activated_at"]) if node.get("activated_at") else None,
         created_at=str(node.get("created_at", "")),
     )
@@ -111,6 +115,10 @@ def _serialize_user_detail(node: dict) -> UserDetailResponse:
         provider=node.get("provider", "") or "",
         is_admin=bool(node.get("is_admin", False)),
         signup_code=node.get("signup_code"),
+        waitlist_joined=bool(node.get("waitlist_joined", False)),
+        waitlist_joined_at=(
+            str(node["waitlist_joined_at"]) if node.get("waitlist_joined_at") else None
+        ),
         activated_at=str(node["activated_at"]) if node.get("activated_at") else None,
         created_at=str(node.get("created_at", "")),
         orb_id=node.get("orb_id", "") or "",

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -10,6 +10,8 @@ class UserInfo(BaseModel):
     gdpr_consent: bool = False
     is_admin: bool = False
     activated: bool = False
+    waitlist_joined: bool = False
+    waitlist_joined_at: str | None = None
     deletion_requested_at: str | None = None
     deletion_days_remaining: int | None = None
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -233,6 +233,12 @@ async def get_me(
             gdpr_consent=bool(person.get("gdpr_consent", False)),
             is_admin=is_admin_user,
             activated=activated,
+            waitlist_joined=bool(person.get("waitlist_joined", True)),
+            waitlist_joined_at=(
+                str(person["waitlist_joined_at"])
+                if person.get("waitlist_joined_at")
+                else None
+            ),
             deletion_requested_at=str(deletion_at) if deletion_at else None,
             deletion_days_remaining=days_left,
         )
@@ -380,6 +386,34 @@ async def grant_gdpr_consent(
             now=datetime.now(timezone.utc).isoformat(),
         )
     return {"status": "ok"}
+
+
+@router.post("/waitlist/join")
+@limiter.limit("10/minute")
+async def join_waitlist(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Explicitly opt into the waitlist for non-activated users."""
+    async with db.session() as session:
+        result = await session.run(
+            "MATCH (p:Person {user_id: $user_id}) "
+            "SET p.waitlist_joined = true, "
+            "    p.waitlist_joined_at = coalesce(p.waitlist_joined_at, datetime()), "
+            "    p.updated_at = datetime() "
+            "RETURN p.waitlist_joined_at AS joined_at",
+            user_id=current_user["user_id"],
+        )
+        record = await result.single()
+        if record is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+    joined_at = record.get("joined_at")
+    return {
+        "status": "joined",
+        "waitlist_joined_at": str(joined_at) if joined_at else None,
+    }
 
 
 # ── MCP API keys (machine credentials for the MCP server) ────────────

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -224,6 +224,11 @@ async def get_me(
         deletion_at = person.get("deletion_requested_at")
         days_left = _days_remaining(str(deletion_at)) if deletion_at else None
 
+        raw_waitlist_joined = person.get("waitlist_joined")
+        waitlist_joined = (
+            raw_waitlist_joined if isinstance(raw_waitlist_joined, bool) else False
+        )
+
         return UserInfo(
             user_id=person["user_id"],
             email=current_user["email"],
@@ -233,7 +238,7 @@ async def get_me(
             gdpr_consent=bool(person.get("gdpr_consent", False)),
             is_admin=is_admin_user,
             activated=activated,
-            waitlist_joined=bool(person.get("waitlist_joined", True)),
+            waitlist_joined=waitlist_joined,
             waitlist_joined_at=(
                 str(person["waitlist_joined_at"])
                 if person.get("waitlist_joined_at")

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -11,6 +11,8 @@ CREATE (p:Person {
     picture: $picture,
     provider: $provider,
     signup_code: $signup_code,
+    waitlist_joined: false,
+    waitlist_joined_at: null,
     is_admin: false,
     headline: '',
     location: '',
@@ -297,19 +299,23 @@ RETURN
 """
 
 # Pending users: registered but not yet activated (no signup_code, not admin).
-# These replace the old Waitlist concept — since everyone now registers, the
-# "waiting" users are simply Persons without a code.
+# Users explicitly join via the waitlist CTA. For backward compatibility,
+# older records without this flag are treated as already joined.
 
 LIST_PENDING_PERSONS = """
 MATCH (p:Person)
-WHERE p.signup_code IS NULL AND coalesce(p.is_admin, false) = false
+WHERE p.signup_code IS NULL
+  AND coalesce(p.is_admin, false) = false
+  AND coalesce(p.waitlist_joined, true) = true
 RETURN p
 ORDER BY p.created_at DESC
 """
 
 COUNT_PENDING_PERSONS = """
 MATCH (p:Person)
-WHERE p.signup_code IS NULL AND coalesce(p.is_admin, false) = false
+WHERE p.signup_code IS NULL
+  AND coalesce(p.is_admin, false) = false
+  AND coalesce(p.waitlist_joined, true) = true
 RETURN count(p) AS total
 """
 

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -298,15 +298,14 @@ RETURN
     count(CASE WHEN a.used_at IS NULL AND a.active = true THEN 1 END) AS available
 """
 
-# Pending users: registered but not yet activated (no signup_code, not admin).
-# Users explicitly join via the waitlist CTA. For backward compatibility,
-# older records without this flag are treated as already joined.
+# Pending users: registered but not yet activated (no signup_code, not admin),
+# and explicitly opted into the waitlist via CTA.
 
 LIST_PENDING_PERSONS = """
 MATCH (p:Person)
 WHERE p.signup_code IS NULL
   AND coalesce(p.is_admin, false) = false
-  AND coalesce(p.waitlist_joined, true) = true
+  AND coalesce(p.waitlist_joined, false) = true
 RETURN p
 ORDER BY p.created_at DESC
 """
@@ -315,7 +314,7 @@ COUNT_PENDING_PERSONS = """
 MATCH (p:Person)
 WHERE p.signup_code IS NULL
   AND coalesce(p.is_admin, false) = false
-  AND coalesce(p.waitlist_joined, true) = true
+  AND coalesce(p.waitlist_joined, false) = true
 RETURN count(p) AS total
 """
 

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -197,6 +197,68 @@ def test_me_not_activated_when_no_code_and_required(client, mock_db):
     assert response.json()["activated"] is False
 
 
+def test_me_waitlist_defaults_to_not_joined_when_flag_missing(client, mock_db):
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(
+            return_value={"p": MockNode({"user_id": "test-user", "name": "Test User"})}
+        )
+    )
+
+    with patch("app.auth.router.is_invite_code_required", AsyncMock(return_value=True)):
+        response = client.get("/auth/me")
+
+    assert response.status_code == 200
+    assert response.json()["waitlist_joined"] is False
+
+
+def test_me_waitlist_uses_boolean_value_only(client, mock_db):
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(
+            return_value={
+                "p": MockNode(
+                    {
+                        "user_id": "test-user",
+                        "name": "Test User",
+                        "waitlist_joined": "true",
+                    }
+                )
+            }
+        )
+    )
+
+    with patch("app.auth.router.is_invite_code_required", AsyncMock(return_value=True)):
+        response = client.get("/auth/me")
+
+    assert response.status_code == 200
+    assert response.json()["waitlist_joined"] is False
+
+
+def test_join_waitlist_requires_explicit_post(client, mock_db):
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value={"joined_at": "2026-04-12T10:00:00Z"})
+    )
+
+    response = client.post("/auth/waitlist/join")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "joined"
+    assert body["waitlist_joined_at"] == "2026-04-12T10:00:00Z"
+
+    run_mock = mock_db.session.return_value.__aenter__.return_value.run
+    called_query = run_mock.await_args.args[0]
+    assert "SET p.waitlist_joined = true" in called_query
+
+
+def test_join_waitlist_returns_404_when_user_missing(client, mock_db):
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value=None)
+    )
+
+    response = client.post("/auth/waitlist/join")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "User not found"
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Admin endpoints
 # ─────────────────────────────────────────────────────────────────────────

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -123,6 +123,8 @@ export interface AdminUser {
   provider: string;
   is_admin: boolean;
   signup_code: string | null;
+  waitlist_joined: boolean;
+  waitlist_joined_at?: string | null;
   activated_at: string | null;
   created_at: string;
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -9,6 +9,8 @@ export interface UserInfo {
   gdpr_consent: boolean;
   is_admin: boolean;
   activated: boolean;
+  waitlist_joined: boolean;
+  waitlist_joined_at?: string | null;
   deletion_requested_at?: string | null;
   deletion_days_remaining?: number | null;
 }
@@ -52,6 +54,11 @@ export async function activateAccount(
 
 export async function grantGdprConsent(): Promise<void> {
   await client.post('/auth/gdpr-consent');
+}
+
+export async function joinWaitlist(): Promise<{ status: string; waitlist_joined_at: string | null }> {
+  const { data } = await client.post('/auth/waitlist/join');
+  return data;
 }
 
 export async function recoverAccount(): Promise<void> {

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -151,28 +151,40 @@ export default function ActivatePage() {
         )}
 
         {/* Waitlist opt-in */}
-        <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl px-5 py-4 mb-4 text-left">
-          <p className="text-white/50 text-xs leading-relaxed mb-3">
-            Don&apos;t have a code yet? Join the waiting list and we&apos;ll contact you as soon as access opens.
-          </p>
-          {joinedWaitlist ? (
-            <div className="inline-flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-              <span className="h-2 w-2 rounded-full bg-emerald-400" />
-              <span className="text-emerald-200 text-xs font-medium">You&apos;re on the waiting list</span>
+        <div className="relative overflow-hidden rounded-2xl border border-white/[0.09] bg-gradient-to-br from-white/[0.06] via-white/[0.03] to-transparent px-5 py-5 mb-5 text-left backdrop-blur-sm">
+          <div className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-emerald-400/10 blur-2xl" />
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.12),transparent_45%)]" />
+
+          <div className="relative z-10">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 mb-3">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" />
+              <span className="text-[10px] font-semibold tracking-[0.14em] text-white/65">WAITLIST</span>
             </div>
-          ) : (
-            <button
-              type="button"
-              onClick={handleJoinWaitlist}
-              disabled={joiningWaitlist}
-              className="bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-semibold rounded-xl px-4 py-2.5 transition-colors"
-            >
-              {joiningWaitlist ? 'Joining...' : 'Join waiting list'}
-            </button>
-          )}
-          {waitlistError && (
-            <p className="text-amber-300/90 text-xs mt-3">{waitlistError}</p>
-          )}
+
+            <p className="text-white/70 text-sm leading-relaxed mb-4">
+              Don&apos;t have a code yet? Join the waiting list and we&apos;ll contact you as soon as access opens.
+            </p>
+
+            {joinedWaitlist ? (
+              <div className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/35 bg-emerald-500/12 px-3.5 py-2.5">
+                <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_10px_rgba(52,211,153,0.8)]" />
+                <span className="text-emerald-100 text-sm font-medium">You&apos;re on the waiting list</span>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={handleJoinWaitlist}
+                disabled={joiningWaitlist}
+                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl border border-emerald-300/35 bg-gradient-to-r from-emerald-500 to-emerald-400 hover:from-emerald-400 hover:to-emerald-300 disabled:opacity-50 disabled:cursor-not-allowed text-emerald-950 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(16,185,129,0.9)] transition-all"
+              >
+                {joiningWaitlist ? 'Joining...' : 'Join waiting list'}
+              </button>
+            )}
+
+            {waitlistError && (
+              <p className="text-amber-300/90 text-xs mt-3">{waitlistError}</p>
+            )}
+          </div>
         </div>
 
         {/* Logout link */}

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -175,7 +175,7 @@ export default function ActivatePage() {
                 type="button"
                 onClick={handleJoinWaitlist}
                 disabled={joiningWaitlist}
-                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl border border-emerald-300/35 bg-gradient-to-r from-emerald-500 to-emerald-400 hover:from-emerald-400 hover:to-emerald-300 disabled:opacity-50 disabled:cursor-not-allowed text-emerald-950 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(16,185,129,0.9)] transition-all"
+                className="w-full flex items-center justify-center rounded-xl border border-emerald-300/35 bg-gradient-to-r from-emerald-500 to-emerald-400 hover:from-emerald-400 hover:to-emerald-300 disabled:opacity-50 disabled:cursor-not-allowed text-emerald-950 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(16,185,129,0.9)] transition-all"
               >
                 {joiningWaitlist ? 'Joining...' : 'Join waiting list'}
               </button>

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import axios from 'axios';
-import { activateAccount, getMe } from '../api/auth';
+import { activateAccount, getMe, joinWaitlist } from '../api/auth';
 import { useAuthStore } from '../stores/authStore';
 import { hasOrbContent } from '../api/orbs';
 
@@ -18,7 +18,14 @@ export default function ActivatePage() {
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [joiningWaitlist, setJoiningWaitlist] = useState(false);
+  const [joinedWaitlist, setJoinedWaitlist] = useState<boolean>(Boolean(user?.waitlist_joined));
+  const [waitlistError, setWaitlistError] = useState<string | null>(null);
   const navigatingRef = useRef(false);
+
+  useEffect(() => {
+    setJoinedWaitlist(Boolean(user?.waitlist_joined));
+  }, [user?.waitlist_joined]);
 
   const goToApp = useCallback(async () => {
     if (navigatingRef.current) return;
@@ -63,6 +70,21 @@ export default function ActivatePage() {
   const handleLogout = () => {
     logout();
     navigate('/', { replace: true });
+  };
+
+  const handleJoinWaitlist = async () => {
+    if (joinedWaitlist || joiningWaitlist) return;
+    setWaitlistError(null);
+    setJoiningWaitlist(true);
+    try {
+      await joinWaitlist();
+      setJoinedWaitlist(true);
+      await fetchUser();
+    } catch {
+      setWaitlistError('Could not join the waiting list. Please try again.');
+    } finally {
+      setJoiningWaitlist(false);
+    }
   };
 
   return (
@@ -128,11 +150,29 @@ export default function ActivatePage() {
           </motion.div>
         )}
 
-        {/* Waitlist info */}
+        {/* Waitlist opt-in */}
         <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl px-5 py-4 mb-4 text-left">
-          <p className="text-white/50 text-xs leading-relaxed">
-            Don&apos;t have a code? No problem — by signing up you&apos;ve been added to our waiting list. We&apos;ll reach out as soon as your access is enabled.
+          <p className="text-white/50 text-xs leading-relaxed mb-3">
+            Don&apos;t have a code yet? Join the waiting list and we&apos;ll contact you as soon as access opens.
           </p>
+          {joinedWaitlist ? (
+            <div className="inline-flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <span className="h-2 w-2 rounded-full bg-emerald-400" />
+              <span className="text-emerald-200 text-xs font-medium">You&apos;re on the waiting list</span>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleJoinWaitlist}
+              disabled={joiningWaitlist}
+              className="bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-semibold rounded-xl px-4 py-2.5 transition-colors"
+            >
+              {joiningWaitlist ? 'Joining...' : 'Join waiting list'}
+            </button>
+          )}
+          {waitlistError && (
+            <p className="text-amber-300/90 text-xs mt-3">{waitlistError}</p>
+          )}
         </div>
 
         {/* Logout link */}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -216,6 +216,10 @@ export default function AdminPage() {
     failed: { name: string; reason: string }[];
   } | null>(null);
 
+  const isPendingWaitlistUser = (
+    u: Pick<AdminUser, 'signup_code' | 'is_admin' | 'waitlist_joined'>,
+  ) => !u.signup_code && !u.is_admin && u.waitlist_joined;
+
   const refresh = useCallback(async () => {
     try {
       const [s, c, p, u, id, f, ins] = await Promise.all([
@@ -403,7 +407,7 @@ export default function AdminPage() {
 
   const handleBatchActivate = () => {
     const pending = Array.from(selectedUsers).filter((id) =>
-      users.find((u) => u.user_id === id && !u.signup_code && !u.is_admin),
+      users.find((u) => u.user_id === id && isPendingWaitlistUser(u)),
     );
     if (pending.length === 0) return;
     setConfirmAction({
@@ -536,7 +540,7 @@ export default function AdminPage() {
   };
 
   const hasPendingSelected = Array.from(selectedUsers).some((id) =>
-    users.find((u) => u.user_id === id && !u.signup_code && !u.is_admin),
+    users.find((u) => u.user_id === id && isPendingWaitlistUser(u)),
   );
 
   const filteredUsers = users.filter((u) => {
@@ -547,7 +551,7 @@ export default function AdminPage() {
       u.user_id.toLowerCase().includes(userSearch.toLowerCase());
     if (!matchesSearch) return false;
     if (userFilter === 'active') return u.signup_code !== null || u.is_admin;
-    if (userFilter === 'pending') return u.signup_code === null && !u.is_admin;
+    if (userFilter === 'pending') return isPendingWaitlistUser(u);
     if (userFilter === 'admin') return u.is_admin;
     return true;
   });
@@ -902,7 +906,7 @@ export default function AdminPage() {
                       <tr><td colSpan={8} className="text-center text-white/20 py-8">No users found.</td></tr>
                     )}
                     {filteredUsers.map((u) => {
-                      const isPending = !u.signup_code && !u.is_admin;
+                      const isPending = isPendingWaitlistUser(u);
                       return (
                         <tr key={u.user_id} className="border-b border-white/[0.03] hover:bg-white/[0.02]">
                           <td className="px-4 py-2.5">
@@ -927,8 +931,10 @@ export default function AdminPage() {
                               <span className="text-xs bg-purple-500/15 text-purple-400 px-2 py-0.5 rounded-md">admin</span>
                             ) : u.signup_code ? (
                               <span className="text-xs bg-green-500/10 text-green-400 px-2 py-0.5 rounded-md">active</span>
-                            ) : (
+                            ) : isPending ? (
                               <span className="text-xs bg-amber-500/10 text-amber-400 px-2 py-0.5 rounded-md">pending</span>
+                            ) : (
+                              <span className="text-xs bg-white/[0.06] text-white/40 px-2 py-0.5 rounded-md">registered</span>
                             )}
                           </td>
                           <td className="px-4 py-2.5 text-white/30 font-mono text-xs">{u.signup_code || '—'}</td>
@@ -1368,8 +1374,10 @@ export default function AdminPage() {
                       <span className="text-xs bg-purple-500/15 text-purple-400 px-2 py-0.5 rounded-md">admin</span>
                     ) : userDetail.signup_code ? (
                       <span className="text-xs bg-green-500/10 text-green-400 px-2 py-0.5 rounded-md">active</span>
-                    ) : (
+                    ) : userDetail.waitlist_joined ? (
                       <span className="text-xs bg-amber-500/10 text-amber-400 px-2 py-0.5 rounded-md">pending</span>
+                    ) : (
+                      <span className="text-xs bg-white/[0.06] text-white/40 px-2 py-0.5 rounded-md">registered</span>
                     )}
                   </div>
                 </div>
@@ -1488,7 +1496,7 @@ export default function AdminPage() {
 
               {/* Actions */}
               <div className="flex gap-2 mt-5 pt-4 border-t border-white/[0.06]">
-                {!userDetail.signup_code && !userDetail.is_admin && (
+                {isPendingWaitlistUser(userDetail) && (
                   <button
                     onClick={() => { setShowDetail(false); handleActivateUser(userDetail.user_id, userDetail.name); }}
                     className="text-xs bg-green-600 hover:bg-green-500 text-white font-medium px-3 py-1.5 rounded-lg transition-colors"


### PR DESCRIPTION
## Summary
This PR enforces explicit waitlist opt-in and aligns admin reporting/UI with that behavior.

## What changed
- Added explicit waitlist fields on `Person` creation:
  - `waitlist_joined = false`
  - `waitlist_joined_at = null`
- Added backend endpoint `POST /auth/waitlist/join` for idempotent opt-in
- Extended `/auth/me` payload with waitlist metadata
- Enforced strict defaults so users are **not** considered joined unless explicitly set to boolean `true`
- Updated pending-user queries to include only explicit waitlist joins

### Activation Page UX
- Added explicit green **Join waiting list** CTA flow
- Added clear success and error states
- Polished waitlist card styling to better integrate with the page
- Updated CTA layout to be centered and full-width horizontally

### Admin Dashboard alignment
- `Pending activation` stats and `Waiting List` tab already use explicit waitlist-join data
- Updated **Users tab** so `pending` status/filter/actions now require explicit waitlist join as well
- Added `waitlist_joined` and `waitlist_joined_at` to admin user payloads used by the Users tab/detail modal
- Non-activated users who did not join waitlist now show as `registered` (instead of `pending`) in Users views

## Validation
- `npm --prefix frontend run lint -- src/pages/ActivatePage.tsx src/api/auth.ts`
- `npm --prefix frontend run lint -- src/pages/AdminPage.tsx src/api/admin.ts`
- `PYTHONPATH=backend python3 -m py_compile backend/app/auth/models.py backend/app/auth/router.py backend/app/graph/queries.py`
- `PYTHONPATH=backend python3 -m py_compile backend/app/admin/models.py backend/app/admin/router.py`

Closes #291
