### PR TITLE
fix: update ontology.md and remove Collaborator from codebase

### DIFF
--- a/backend/app/graph/embeddings.py
+++ b/backend/app/graph/embeddings.py
@@ -51,7 +51,6 @@ def build_embedding_text(node_type: str, properties: dict) -> str:
         "publication": ["title", "venue", "abstract"],
         "project": ["name", "role", "description"],
         "skill": ["name", "category"],
-        "collaborator": ["name"],
         "language": ["name", "proficiency"],
     }
 

--- a/backend/app/notes/router.py
+++ b/backend/app/notes/router.py
@@ -63,9 +63,6 @@ Valid node_types and their expected properties:
     title (string), patent_number (string or null), filing_date (string or null),
     grant_date (string or null), description (string or null), url (string or null)
 
-- collaborator:
-    name (string), email (string or null)
-
 Rules:
 - Use ISO date format (YYYY-MM-DD, YYYY-MM, or YYYY)
 - If end_date is "Present", "Current", or ongoing, set it to null

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -67,7 +67,7 @@ async def orbis_get_full_orb(orb_id: str, token: str = "") -> dict:
 async def orbis_get_nodes_by_type(
     orb_id: str, node_type: str, token: str = ""
 ) -> list[dict]:
-    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, collaborator."""
+    """Get all nodes of a specific type from an orb. Valid node_types: education, work_experience, certification, language, publication, project, skill, patent, award, outreach, training."""
     driver = await _get_driver()
     return await get_nodes_by_type(driver, orb_id, node_type, token)
 

--- a/backend/tests/lib/graph_comparator.py
+++ b/backend/tests/lib/graph_comparator.py
@@ -22,7 +22,6 @@ KEY_PROPERTIES: dict[str, list[str]] = {
     "publication": ["title"],
     "project": ["name"],
     "patent": ["title"],
-    "collaborator": ["name"],
 }
 
 MATCH_THRESHOLD = 0.4

--- a/backend/tests/unit/test_parser.py
+++ b/backend/tests/unit/test_parser.py
@@ -317,10 +317,10 @@ Developer
         assert "work_experience" in types
         assert "education" in types
 
-    def test_section_patterns_missing_patent_and_collaborator(self):
-        """SECTION_PATTERNS lacks entries for 'patent' and 'collaborator',
-        so rule_based_extract can never produce these section types.
-        This documents the gap vs NODE_TYPE_LABELS.
+    def test_section_patterns_missing_patent(self):
+        """SECTION_PATTERNS lacks entries for 'patent', 'award', 'outreach',
+        and 'training', so rule_based_extract can never produce these
+        section types. This documents the gap vs NODE_TYPE_LABELS.
         """
         handled_by_patterns = set(SECTION_PATTERNS.keys())
         all_node_types = set(NODE_TYPE_LABELS.keys())

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1152,7 +1152,7 @@ export default function AdminPage() {
                       {insights.node_type_distribution.map((n) => {
                         const maxN = insights.node_type_distribution[0]?.count || 1;
                         const pct = (n.count / maxN) * 100;
-                        const colors: Record<string, string> = { Skill: 'bg-teal-500/50', WorkExperience: 'bg-indigo-500/50', Collaborator: 'bg-pink-500/50', Education: 'bg-amber-500/50', Project: 'bg-purple-500/50' };
+                        const colors: Record<string, string> = { Skill: 'bg-teal-500/50', WorkExperience: 'bg-indigo-500/50', Education: 'bg-amber-500/50', Project: 'bg-purple-500/50' };
                         return (
                           <div key={n.label}>
                             <div className="flex justify-between text-sm mb-1">

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -50,7 +50,7 @@ export default function PrivacyPolicyPage() {
                 </li>
                 <li>
                   <strong className="text-white/80">Manually entered data:</strong> Any professional information
-                  you add directly through the platform (nodes, notes, collaborators).
+                  you add directly through the platform (nodes, notes, and entries).
                 </li>
                 <li>
                   <strong className="text-white/80">Usage data:</strong> Anonymous analytics about how you

--- a/ontology.md
+++ b/ontology.md
@@ -1,6 +1,6 @@
 # Orb Knowledge Graph Ontology
 
-## Node Labels & Properties
+## Domain Nodes (extractable from CVs)
 
 ### Person (Root Node)
 - `user_id` (string) — unique user identifier
@@ -16,6 +16,10 @@
 - `scholar_url` (string)
 - `website_url` (string)
 - `open_to_work` (boolean)
+- `picture` (string) — profile picture URL
+- `visibility` (string) — orb visibility setting
+- `public_filter_keywords` (list[string]) — keywords for public filter
+- `public_filter_hidden_types` (list[string]) — node types hidden in public view
 - `created_at` (datetime)
 - `updated_at` (datetime)
 
@@ -37,6 +41,7 @@
 - `description` (string)
 - `start_date` (string)
 - `end_date` (string)
+- `company_url` (string)
 
 ### Skill
 - `uid` (string)
@@ -50,6 +55,9 @@
 - `name` (string)
 - `issuing_organization` (string)
 - `date` (string)
+- `credential_url` (string)
+- `issue_date` (string)
+- `expiry_date` (string)
 
 ### Language
 - `uid` (string)
@@ -62,6 +70,8 @@
 - `venue` (string)
 - `abstract` (string)
 - `description` (string)
+- `url` (string)
+- `doi` (string)
 - `embedding` (vector)
 
 ### Project
@@ -69,6 +79,9 @@
 - `name` (string)
 - `role` (string)
 - `description` (string)
+- `url` (string)
+- `start_date` (string)
+- `end_date` (string)
 - `embedding` (vector)
 
 ### Patent
@@ -79,13 +92,35 @@
 - `inventors` (string)
 - `filing_date` (string)
 - `grant_date` (string)
+- `url` (string)
 
-### Collaborator
+### Award
 - `uid` (string)
 - `name` (string)
-- `email` (string)
+- `issuing_organization` (string)
+- `date` (string)
 - `description` (string)
-- `affiliation` (string)
+- `url` (string)
+
+### Outreach
+- `uid` (string)
+- `title` (string)
+- `type` (string)
+- `venue` (string)
+- `date` (string)
+- `description` (string)
+- `role` (string)
+- `url` (string)
+
+### Training
+- `uid` (string)
+- `title` (string)
+- `provider` (string)
+- `date` (string)
+- `description` (string)
+- `url` (string)
+
+## System Nodes
 
 ### OntologyVersion
 - `version_id` (string)
@@ -106,27 +141,77 @@
 - `prompt_hash` (string)
 - `nodes_extracted` (integer)
 - `edges_extracted` (integer)
+- `cost_usd` (float)
+- `duration_ms` (integer)
+- `input_tokens` (integer)
+- `output_tokens` (integer)
 - `processed_at` (datetime)
+
+### ShareToken
+- `token_id` (string)
+- `orb_id` (string)
+- `keywords` (list[string])
+- `hidden_node_types` (list[string])
+- `label` (string)
+- `created_at` (datetime)
+- `expires_at` (datetime)
+- `revoked` (boolean)
+
+### AccessGrant
+- `grant_id` (string)
+- `orb_id` (string)
+- `email` (string)
+- `keywords` (list[string])
+- `hidden_node_types` (list[string])
+- `created_at` (datetime)
+- `revoked` (boolean)
+
+### ConnectionRequest
+- `request_id` (string)
+- `requester_user_id` (string)
+- `requester_email` (string)
+- `requester_name` (string)
+- `status` (string)
+- `created_at` (datetime)
+- `resolved_at` (datetime)
+
+### LLMUsage
+- `usage_id` (string)
+- `endpoint` (string)
+- `llm_provider` (string)
+- `llm_model` (string)
+- `input_tokens` (integer)
+- `output_tokens` (integer)
+- `total_tokens` (integer)
+- `cost_usd` (float)
+- `duration_ms` (integer)
+- `created_at` (datetime)
 
 ## Relationships
 
 ### Person → Node
-| Relationship        | Target Node    |
-|---------------------|----------------|
-| HAS_EDUCATION       | Education      |
-| HAS_WORK_EXPERIENCE | WorkExperience |
-| HAS_SKILL           | Skill          |
-| HAS_CERTIFICATION   | Certification  |
-| SPEAKS              | Language       |
-| HAS_PUBLICATION     | Publication    |
-| HAS_PROJECT         | Project        |
-| HAS_PATENT          | Patent         |
-| COLLABORATED_WITH   | Collaborator   |
+| Relationship           | Target Node       |
+|------------------------|-------------------|
+| HAS_EDUCATION          | Education         |
+| HAS_WORK_EXPERIENCE   | WorkExperience    |
+| HAS_SKILL              | Skill             |
+| HAS_CERTIFICATION      | Certification     |
+| SPEAKS                 | Language          |
+| HAS_PUBLICATION        | Publication       |
+| HAS_PROJECT            | Project           |
+| HAS_PATENT             | Patent            |
+| HAS_AWARD              | Award             |
+| HAS_OUTREACH           | Outreach          |
+| HAS_TRAINING           | Training          |
+| HAS_SHARE_TOKEN        | ShareToken        |
+| GRANTED_ACCESS         | AccessGrant       |
+| HAS_CONNECTION_REQUEST | ConnectionRequest |
+| HAS_LLM_USAGE         | LLMUsage          |
 
 ### Cross-node
-| Relationship | Source                                                      | Target |
-|--------------|-------------------------------------------------------------|--------|
-| USED_SKILL   | Education, WorkExperience, Publication, Project, Patent     | Skill  |
+| Relationship | Source                                                                       | Target |
+|--------------|------------------------------------------------------------------------------|--------|
+| USED_SKILL   | Education, WorkExperience, Publication, Project, Patent, Award, Outreach, Training | Skill  |
 
 ### Provenance
 | Relationship          | Source           | Target           |
@@ -135,4 +220,3 @@
 | USED_ONTOLOGY         | ProcessingRecord | OntologyVersion  |
 | EXTRACTED             | ProcessingRecord | (any domain node)|
 | SUPERSEDES            | OntologyVersion  | OntologyVersion  |
-


### PR DESCRIPTION
## Summary

### ontology.md rewritten
- Added missing domain nodes: **Award**, **Outreach**, **Training**
- Added missing system nodes: **ShareToken**, **AccessGrant**, **ConnectionRequest**, **LLMUsage**
- Updated existing nodes with new properties (company_url, credential_url, cost_usd, etc.)
- Updated relationships: added HAS_AWARD, HAS_OUTREACH, HAS_TRAINING and all system relationships
- Updated USED_SKILL sources to include Award, Outreach, Training
- Removed **Collaborator** node type entirely

### Collaborator removed from codebase (7 files)
- `notes/router.py` — removed from LLM enhance prompt
- `graph/embeddings.py` — removed from key_fields
- `mcp_server/server.py` — removed from tool docstring
- `tests/unit/test_parser.py` — updated test name and expectation
- `tests/lib/graph_comparator.py` — removed from KEY_PROPERTIES
- `AdminPage.tsx` — removed from color map
- `NodeForm.tsx` — removed from comment
- `PrivacyPolicyPage.tsx` — updated text

Closes #293

## Test plan
- [x] 584 unit tests pass
- [x] Frontend type-check clean
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)