### PR TITLE
fix: animate progress bar during CV classification step

### DIFF
--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -459,15 +459,51 @@ function ProgressSteps({ progress }: { progress: CVProgressData | null }) {
     ? 'Ready to review'
     : STEPS.find((s) => s.key === currentStep)?.label || 'Working...';
   const statusText = detail || currentStepLabel;
-  const displayPercent = currentStep === 'done'
+
+  // Smooth progress: 50% → 99% over 7 minutes during classifying/parsing
+  const [classifyStart, setClassifyStart] = useState<number | null>(null);
+  const [smoothExtra, setSmoothExtra] = useState(0);
+  const prevStep = useRef(currentStep);
+
+  useEffect(() => {
+    if (prevStep.current !== currentStep) {
+      prevStep.current = currentStep;
+      if (currentStep === 'classifying' || currentStep === 'parsing_response') {
+        if (!classifyStart) setClassifyStart(Date.now());
+      } else {
+        setClassifyStart(null);
+        setSmoothExtra(0);
+      }
+    }
+  }, [currentStep, classifyStart]);
+
+  useEffect(() => {
+    if (!classifyStart || currentStep === 'done') return;
+    const maxMs = 7 * 60 * 1000; // 7 minutes
+    const maxExtra = 49; // 50% → 99%
+    const timer = setInterval(() => {
+      const elapsed = Date.now() - classifyStart;
+      const progress = Math.min(elapsed / maxMs, 1);
+      // Ease-out curve so it starts faster and slows down
+      const eased = 1 - Math.pow(1 - progress, 2);
+      setSmoothExtra(Math.round(eased * maxExtra));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [classifyStart, currentStep]);
+
+  const basePercent = currentStep === 'done'
     ? 100
     : Math.round((completedSteps / STEPS.length) * 100);
+  const displayPercent = currentStep === 'done'
+    ? 100
+    : Math.min(basePercent + (currentStep === 'classifying' || currentStep === 'parsing_response' ? smoothExtra : 0), 99);
 
   return (
     <div className="w-full max-w-md mx-auto rounded-xl border border-white/10 bg-black/20 px-4 py-4 sm:px-5 sm:py-5">
       <div className="text-left">
         <p className="text-sm font-semibold text-white">Processing your CV</p>
         <p className="text-[11px] text-white/45 mt-0.5">We are preparing your orbis from the uploaded document.</p>
+        <p className="text-[10px] text-white/30 mt-1 italic">Processing time varies depending on the length of your CV.</p>
       </div>
 
       {/* Steps */}


### PR DESCRIPTION
## Summary

### Progress bar fix (#295)
- Smooth progress from 50%→99% over 7 minutes during classification (ease-out curve)
- "Processing time varies depending on the length of your CV" message
- Capped at 99% until done, resets on step change

### Profile fields fix (#298)
- CV extraction returns headline, location, social URLs but they were never sent to the backend on confirm
- Added `profile` to `ExtractedData` interface, `confirmCV`, `confirmImport`, `ExtractedDataReview`, and both call sites

### Improved LLM prompt for skill relationships
- Explicit vs implicit skill detection instructions
- Guidance to create missing skill nodes when referenced in descriptions
- Concrete multi-skill linking example with from_index/to_index
- Common mistakes to avoid (skipping publications, ignoring implicit skills)
- Same prompt used for both Claude and Ollama

Closes #295
Closes #298

## Test plan
- [ ] Upload CV → progress bar smoothly advances past 50%
- [ ] After CV import → headline and location populated
- [ ] After CV import → social URLs populated if found in CV
- [ ] Re-import CV → more USED_SKILL relationships created
- [ ] Publications/outreach linked to relevant skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)