### PR TITLE
test: frontend unit tests for Zustand stores (#228, #181)

### DIFF
--- a/frontend/src/stores/dateFilterStore.test.ts
+++ b/frontend/src/stores/dateFilterStore.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getNodeDates } from './dateFilterStore';
+
+describe('getNodeDates', () => {
+  it('extracts YYYY-MM from ISO dates', () => {
+    const node = { start_date: '2023-06-15', end_date: '2024-01-01' };
+    const dates = getNodeDates(node);
+    expect(dates).toContain('2023-06');
+    expect(dates).toContain('2024-01');
+  });
+
+  it('handles YYYY format', () => {
+    const dates = getNodeDates({ start_date: '2020' });
+    expect(dates).toContain('2020-01');
+  });
+
+  it('handles MM/YYYY format', () => {
+    const dates = getNodeDates({ start_date: '06/2023' });
+    expect(dates).toContain('2023-06');
+  });
+
+  it('skips "present" and empty values', () => {
+    const dates = getNodeDates({ start_date: '2020', end_date: 'present' });
+    expect(dates).toHaveLength(1);
+  });
+
+  it('returns empty for nodes with no date fields', () => {
+    expect(getNodeDates({ name: 'Python' })).toHaveLength(0);
+  });
+});

--- a/frontend/src/stores/filterStore.test.ts
+++ b/frontend/src/stores/filterStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFilterStore, computeFilteredNodeIds } from './filterStore';
+
+describe('filterStore', () => {
+  beforeEach(() => {
+    useFilterStore.setState({ keywords: [], activeKeywords: [] });
+  });
+
+  it('addKeyword adds a new keyword', () => {
+    useFilterStore.getState().addKeyword('python');
+    expect(useFilterStore.getState().keywords).toContain('python');
+  });
+
+  it('addKeyword trims and lowercases', () => {
+    useFilterStore.getState().addKeyword('  Python  ');
+    expect(useFilterStore.getState().keywords).toContain('python');
+  });
+
+  it('addKeyword ignores duplicates', () => {
+    useFilterStore.getState().addKeyword('python');
+    useFilterStore.getState().addKeyword('python');
+    expect(useFilterStore.getState().keywords).toHaveLength(1);
+  });
+
+  it('removeKeyword removes from both lists', () => {
+    useFilterStore.setState({
+      keywords: ['python', 'react'],
+      activeKeywords: ['python'],
+    });
+    useFilterStore.getState().removeKeyword('python');
+    expect(useFilterStore.getState().keywords).toEqual(['react']);
+    expect(useFilterStore.getState().activeKeywords).toEqual([]);
+  });
+
+  it('toggleKeyword activates and deactivates', () => {
+    useFilterStore.setState({ keywords: ['python'], activeKeywords: [] });
+
+    useFilterStore.getState().toggleKeyword('python');
+    expect(useFilterStore.getState().activeKeywords).toContain('python');
+
+    useFilterStore.getState().toggleKeyword('python');
+    expect(useFilterStore.getState().activeKeywords).not.toContain('python');
+  });
+});
+
+describe('computeFilteredNodeIds', () => {
+  it('returns matching node uids when keywords are active', () => {
+    const nodes = [
+      { uid: '1', name: 'Python Developer' },
+      { uid: '2', name: 'React Engineer' },
+      { uid: '3', company: 'Python Corp' },
+    ];
+    const filtered = computeFilteredNodeIds(nodes, ['python']);
+    expect(filtered.has('1')).toBe(true);
+    expect(filtered.has('3')).toBe(true);
+    expect(filtered.has('2')).toBe(false);
+  });
+
+  it('returns empty set when no keywords active', () => {
+    const nodes = [{ uid: '1', name: 'Python' }];
+    expect(computeFilteredNodeIds(nodes, []).size).toBe(0);
+  });
+});

--- a/frontend/src/stores/orbStore.test.ts
+++ b/frontend/src/stores/orbStore.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useOrbStore } from './orbStore';
+import type { OrbData, OrbNode } from '../api/orbs';
+
+// Mock the API module
+vi.mock('../api/orbs', () => ({
+  getMyOrb: vi.fn(),
+  getPublicOrb: vi.fn(),
+  addNode: vi.fn(),
+  updateNode: vi.fn(),
+  deleteNode: vi.fn(),
+  updateVisibility: vi.fn(),
+}));
+
+vi.mock('./toastStore', () => ({
+  useToastStore: { getState: () => ({ addToast: vi.fn() }) },
+}));
+
+vi.mock('./undoStore', () => ({
+  useUndoStore: { getState: () => ({ pushUndo: vi.fn() }) },
+}));
+
+import * as orbsApi from '../api/orbs';
+
+const MOCK_NODE: OrbNode = { uid: 'node-1', _labels: ['Skill'], name: 'Python' };
+const MOCK_DATA: OrbData = {
+  person: { name: 'Test' },
+  nodes: [MOCK_NODE],
+  links: [{ source: 'node-1', target: 'node-2', type: 'USED_SKILL' }],
+};
+
+describe('orbStore', () => {
+  beforeEach(() => {
+    useOrbStore.setState({ data: null, loading: false, error: null });
+    vi.clearAllMocks();
+  });
+
+  it('fetchOrb populates data on success', async () => {
+    vi.mocked(orbsApi.getMyOrb).mockResolvedValue(MOCK_DATA);
+    await useOrbStore.getState().fetchOrb();
+    expect(useOrbStore.getState().data).toEqual(MOCK_DATA);
+    expect(useOrbStore.getState().loading).toBe(false);
+  });
+
+  it('fetchOrb sets error on failure', async () => {
+    vi.mocked(orbsApi.getMyOrb).mockRejectedValue(new Error('fail'));
+    await useOrbStore.getState().fetchOrb();
+    expect(useOrbStore.getState().error).toBe('fail');
+    expect(useOrbStore.getState().data).toBeNull();
+  });
+
+  it('addNode calls API and refreshes orb', async () => {
+    useOrbStore.setState({ data: { ...MOCK_DATA, nodes: [] } });
+    const newNode: OrbNode = { uid: 'node-new', _labels: ['Skill'], name: 'React' };
+    vi.mocked(orbsApi.addNode).mockResolvedValue(newNode);
+    vi.mocked(orbsApi.getMyOrb).mockResolvedValue({
+      ...MOCK_DATA,
+      nodes: [newNode],
+    });
+
+    const result = await useOrbStore.getState().addNode('skill', { name: 'React' });
+    expect(result.uid).toBe('node-new');
+    expect(orbsApi.addNode).toHaveBeenCalledWith('skill', { name: 'React' });
+  });
+
+  it('updateNode calls API', async () => {
+    useOrbStore.setState({ data: MOCK_DATA });
+    const updated: OrbNode = { uid: 'node-1', _labels: ['Skill'], name: 'Python 3' };
+    vi.mocked(orbsApi.updateNode).mockResolvedValue(updated);
+    vi.mocked(orbsApi.getMyOrb).mockResolvedValue({
+      ...MOCK_DATA,
+      nodes: [updated],
+    });
+
+    await useOrbStore.getState().updateNode('node-1', { name: 'Python 3' });
+    expect(orbsApi.updateNode).toHaveBeenCalledWith('node-1', { name: 'Python 3' });
+  });
+
+  it('deleteNode calls API', async () => {
+    useOrbStore.setState({ data: MOCK_DATA });
+    vi.mocked(orbsApi.deleteNode).mockResolvedValue(undefined);
+    vi.mocked(orbsApi.getMyOrb).mockResolvedValue({
+      ...MOCK_DATA,
+      nodes: [],
+      links: [],
+    });
+
+    await useOrbStore.getState().deleteNode('node-1');
+    expect(orbsApi.deleteNode).toHaveBeenCalledWith('node-1');
+  });
+
+  it('updateVisibility calls API', async () => {
+    useOrbStore.setState({ data: MOCK_DATA });
+    vi.mocked(orbsApi.updateVisibility).mockResolvedValue(undefined);
+    vi.mocked(orbsApi.getMyOrb).mockResolvedValue({
+      ...MOCK_DATA,
+      person: { ...MOCK_DATA.person, visibility: 'public' },
+    });
+
+    await useOrbStore.getState().updateVisibility('public');
+    expect(orbsApi.updateVisibility).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stores/undoStore.test.ts
+++ b/frontend/src/stores/undoStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useUndoStore } from './undoStore';
+
+vi.mock('../api/orbs', () => ({
+  addNode: vi.fn(),
+  deleteNode: vi.fn(),
+  linkSkill: vi.fn(),
+}));
+
+import * as orbsApi from '../api/orbs';
+
+describe('undoStore', () => {
+  beforeEach(() => {
+    useUndoStore.setState({ undoStack: [], redoStack: [] });
+    vi.clearAllMocks();
+  });
+
+  it('pushUndo adds to stack and clears redo', () => {
+    useUndoStore.setState({ redoStack: [{ type: 'add', nodeUid: 'x', nodeType: 'skill', properties: {} }] });
+    useUndoStore.getState().pushUndo({
+      type: 'add',
+      nodeUid: 'node-1',
+      nodeType: 'skill',
+      properties: { name: 'Python' },
+    });
+
+    const { undoStack, redoStack } = useUndoStore.getState();
+    expect(undoStack).toHaveLength(1);
+    expect(undoStack[0].nodeUid).toBe('node-1');
+    expect(redoStack).toHaveLength(0);
+  });
+
+  it('undo of add calls deleteNode', async () => {
+    vi.mocked(orbsApi.deleteNode).mockResolvedValue(undefined);
+    useUndoStore.setState({
+      undoStack: [{ type: 'add', nodeUid: 'node-1', nodeType: 'skill', properties: { name: 'Python' } }],
+    });
+
+    await useUndoStore.getState().undo();
+
+    expect(orbsApi.deleteNode).toHaveBeenCalledWith('node-1');
+    expect(useUndoStore.getState().undoStack).toHaveLength(0);
+    expect(useUndoStore.getState().redoStack).toHaveLength(1);
+  });
+
+  it('undo of delete calls addNode and updates uid in redo stack', async () => {
+    vi.mocked(orbsApi.addNode).mockResolvedValue({
+      uid: 'node-new',
+      _labels: ['Skill'],
+      name: 'Python',
+    });
+    useUndoStore.setState({
+      undoStack: [{
+        type: 'delete' as const,
+        nodeUid: 'node-old',
+        nodeType: 'skill',
+        properties: { name: 'Python' },
+      }],
+    });
+
+    await useUndoStore.getState().undo();
+
+    expect(orbsApi.addNode).toHaveBeenCalledWith('skill', { name: 'Python' });
+    // The redo stack entry should have the NEW uid
+    expect(useUndoStore.getState().redoStack[0].nodeUid).toBe('node-new');
+  });
+
+  it('clear resets both stacks', () => {
+    useUndoStore.setState({
+      undoStack: [{ type: 'add', nodeUid: 'x', nodeType: 'skill', properties: {} }],
+      redoStack: [{ type: 'add', nodeUid: 'y', nodeType: 'skill', properties: {} }],
+    });
+
+    useUndoStore.getState().clear();
+
+    expect(useUndoStore.getState().undoStack).toHaveLength(0);
+    expect(useUndoStore.getState().redoStack).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #228.10 and #181.8 — the frontend had 1 test (Footer). Now has **23 tests** across 5 files covering the Zustand stores that drive the entire UI.

| File | Tests | Covers |
|------|-------|--------|
| orbStore.test.ts | 6 | fetch, add, update, delete, visibility |
| undoStore.test.ts | 4 | push, undo add/delete, clear |
| filterStore.test.ts | 7 | keyword CRUD, toggle, computeFilteredNodeIds |
| dateFilterStore.test.ts | 5 | getNodeDates for ISO/YYYY/MM-YYYY/present |
| Footer.test.tsx | 1 | (pre-existing) |

All 23 pass in 1.2s. Pure logic tests — no DOM rendering, fast, deterministic.

Utility function tests (cv-export-utils) will come once PR #287 (decomposition) merges and exports them.
