### PR TITLE
fix: CV profile persistence and improved skill relationship extraction

### DIFF
--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -113,12 +113,58 @@ Valid node_types and their expected properties:
 - Education: only extract actual degrees (BSc, MSc, PhD, etc.), not workshops or short courses.
 - If something does not clearly fit any node_type, put the raw text in the "unmatched" array.
 
-## Relationships
+## Relationships (USED_SKILL)
 
-For each skill mentioned in the context of a work_experience, project, education,
-publication, patent, award, outreach, or training entry, include a relationship entry linking
-the source node (by its index in the nodes array) to the skill node (by its index).
-Use type "USED_SKILL".
+This is the most important part. You MUST create USED_SKILL relationships to connect
+skill nodes to the entries where those skills were used or referenced.
+
+### How to detect skills in entries
+
+For EVERY work_experience, project, education, publication, patent, award, outreach,
+and training entry, carefully read its title, description, and all properties. Then:
+
+1. **Explicit skills**: if the entry explicitly mentions a technology, tool, language,
+   framework, methodology, or domain (e.g. "developed in Python using TensorFlow"),
+   create USED_SKILL links to those skill nodes.
+
+2. **Implicit/inferred skills**: if the entry's topic clearly implies a skill even without
+   naming it explicitly, create the link. For example:
+   - A publication about "Quantum Gate Compilation" → link to "Quantum Computing"
+   - A work experience as "iOS Developer" → link to "Swift" or "iOS"
+   - A project about "blockchain-based voting" → link to "Blockchain", "Smart Contracts"
+   - An outreach talk at "PyCon" → link to "Python"
+
+3. **Create missing skill nodes**: if a skill is referenced in an entry but no
+   corresponding skill node exists yet in your nodes array, CREATE a new skill node
+   for it AND then create the USED_SKILL relationship. Do not skip a relationship
+   just because the skill node doesn't exist yet.
+
+### Relationship format
+
+Each relationship uses `from_index` (the source entry) and `to_index` (the skill node),
+both referring to positions in the `nodes` array. Type is always "USED_SKILL".
+
+### Example
+
+If nodes[0] is a work_experience "ML Engineer at Google" describing "Built recommendation
+systems using Python, TensorFlow, and BigQuery", and nodes[5] is skill "Python",
+nodes[6] is skill "TensorFlow", nodes[7] is skill "BigQuery", then:
+
+```
+"relationships": [
+  {"from_index": 0, "to_index": 5, "type": "USED_SKILL"},
+  {"from_index": 0, "to_index": 6, "type": "USED_SKILL"},
+  {"from_index": 0, "to_index": 7, "type": "USED_SKILL"}
+]
+```
+
+### Common mistakes to avoid
+
+- Do NOT skip relationships. Every entry should have at least one USED_SKILL link if
+  it involves any technology, tool, language, methodology, or domain.
+- Do NOT forget to link publications and outreach entries to their relevant skills.
+  A paper about "Quantum Algorithms" MUST link to the "Quantum Computing" skill.
+- Do NOT link only explicitly listed skills. Read descriptions carefully for implicit ones.
 
 ## Output Format
 
@@ -135,12 +181,17 @@ You MUST return valid JSON in exactly this format:
   "website_url": "https://...",
   "scholar_url": "https://scholar.google.com/...",
   "nodes": [
-    {"node_type": "work_experience", "properties": {"company": "...", "title": "...", ...}},
+    {"node_type": "work_experience", "properties": {"company": "Google", "title": "ML Engineer", ...}},
     {"node_type": "skill", "properties": {"name": "Python", "category": "Programming"}},
+    {"node_type": "skill", "properties": {"name": "TensorFlow", "category": "Framework"}},
+    {"node_type": "publication", "properties": {"title": "Quantum Gate Synthesis", ...}},
+    {"node_type": "skill", "properties": {"name": "Quantum Computing", "category": "Research Area"}},
     ...
   ],
   "relationships": [
     {"from_index": 0, "to_index": 1, "type": "USED_SKILL"},
+    {"from_index": 0, "to_index": 2, "type": "USED_SKILL"},
+    {"from_index": 3, "to_index": 4, "type": "USED_SKILL"},
     ...
   ],
   "unmatched": [

--- a/frontend/src/api/cv.ts
+++ b/frontend/src/api/cv.ts
@@ -11,6 +11,18 @@ interface SkippedNode {
   reason: string;
 }
 
+export interface ExtractedProfile {
+  headline?: string;
+  location?: string;
+  email?: string;
+  phone?: string;
+  linkedin_url?: string;
+  github_url?: string;
+  twitter_url?: string;
+  website_url?: string;
+  scholar_url?: string;
+}
+
 export interface ExtractedData {
   nodes: Array<{
     node_type: string;
@@ -21,6 +33,7 @@ export interface ExtractedData {
   relationships?: ExtractedRelationship[];
   truncated?: boolean;
   cv_owner_name?: string | null;
+  profile?: ExtractedProfile | null;
   document_id?: string | null;
 }
 
@@ -53,11 +66,13 @@ export async function confirmCV(
   original_filename?: string | null,
   file_size_bytes?: number | null,
   page_count?: number | null,
+  profile?: ExtractedProfile | null,
 ): Promise<void> {
   await client.post('/cv/confirm', {
     nodes,
     relationships: relationships || [],
     cv_owner_name: cv_owner_name || null,
+    profile: profile || null,
     document_id: document_id || null,
     original_filename: original_filename || null,
     file_size_bytes: file_size_bytes || null,
@@ -97,11 +112,13 @@ export async function confirmImport(
   original_filename?: string | null,
   file_size_bytes?: number | null,
   page_count?: number | null,
+  profile?: ExtractedProfile | null,
 ): Promise<void> {
   await client.post('/cv/import-confirm', {
     nodes,
     relationships: relationships || [],
     cv_owner_name: cv_owner_name || null,
+    profile: profile || null,
     document_id: document_id || null,
     original_filename: original_filename || null,
     file_size_bytes: file_size_bytes || null,

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { uploadCV, getCVProgress, getDocuments, discardCVProgress } from '../../api/cv';
-import type { ExtractedData, ExtractedRelationship, CVProgressData } from '../../api/cv';
+import type { ExtractedData, ExtractedProfile, ExtractedRelationship, CVProgressData } from '../../api/cv';
 import { useAuthStore } from '../../stores/authStore';
 import { loadDraftNotes, saveDraftNotes } from '../drafts/DraftNotes';
 import ExtractedDataReview from './ExtractedDataReview';
@@ -48,6 +48,7 @@ export default function CVUploadOnboarding() {
     nodes: ExtractedData['nodes'];
     relationships: ExtractedRelationship[];
     cvOwnerName: string | null;
+    profile: ExtractedProfile | null;
     unmatchedCount: number;
     skippedCount: number;
     truncated: boolean;
@@ -129,6 +130,7 @@ export default function CVUploadOnboarding() {
           nodes: data.nodes,
           relationships: data.relationships || [],
           cvOwnerName: data.cv_owner_name || null,
+          profile: data.profile || null,
           unmatchedCount,
           skippedCount: data.skipped_nodes?.length || 0,
           truncated: data.truncated || false,
@@ -215,6 +217,7 @@ export default function CVUploadOnboarding() {
         initialNodes={extractedData.nodes}
         initialRelationships={extractedData.relationships}
         cvOwnerName={extractedData.cvOwnerName}
+        profile={extractedData.profile}
         unmatchedCount={extractedData.unmatchedCount}
         skippedCount={extractedData.skippedCount}
         truncated={extractedData.truncated}

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { confirmCV } from '../../api/cv';
 import { enhanceNote, getMyOrb } from '../../api/orbs';
-import type { ExtractedData, ExtractedRelationship } from '../../api/cv';
+import type { ExtractedData, ExtractedProfile, ExtractedRelationship } from '../../api/cv';
 import { NODE_TYPE_COLORS, NODE_TYPE_LABELS } from '../graph/NodeColors';
 import NodeForm from '../editor/NodeForm';
 import { useAuthStore } from '../../stores/authStore';
@@ -48,6 +48,7 @@ interface ExtractedDataReviewProps {
   initialNodes: ExtractedData['nodes'];
   initialRelationships: ExtractedRelationship[];
   cvOwnerName: string | null;
+  profile?: ExtractedProfile | null;
   unmatchedCount: number;
   skippedCount: number;
   truncated: boolean;
@@ -66,6 +67,7 @@ interface ExtractedDataReviewProps {
     originalFilename?: string | null,
     fileSizeBytes?: number | null,
     pageCount?: number | null,
+    profile?: ExtractedProfile | null,
   ) => Promise<void>;
   /** Extra content rendered below the header (e.g., checkbox) */
   children?: React.ReactNode;
@@ -75,6 +77,7 @@ export default function ExtractedDataReview({
   initialNodes,
   initialRelationships,
   cvOwnerName,
+  profile,
   unmatchedCount,
   truncated,
   onReset,
@@ -138,9 +141,9 @@ export default function ExtractedDataReview({
     try {
       const replaced = existingNodeCount ?? 0;
       if (onConfirmOverride) {
-        await onConfirmOverride(extractedNodes, relationships, cvOwnerName, documentId, originalFilename, fileSizeBytes, pageCount);
+        await onConfirmOverride(extractedNodes, relationships, cvOwnerName, documentId, originalFilename, fileSizeBytes, pageCount, profile);
       } else {
-        await confirmCV(extractedNodes, relationships, cvOwnerName, documentId, originalFilename, fileSizeBytes, pageCount);
+        await confirmCV(extractedNodes, relationships, cvOwnerName, documentId, originalFilename, fileSizeBytes, pageCount, profile);
       }
       await fetchUser();
       if (isReplaceMode && replaced > 0) {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1286,6 +1286,7 @@ export default function OrbViewPage() {
     nodes: Array<{ node_type: string; properties: Record<string, unknown> }>;
     relationships: Array<{ from_index: number; to_index: number; type: string }>;
     cvOwnerName: string | null;
+    profile: import('../../api/cv').ExtractedProfile | null;
     unmatchedCount: number;
     skippedCount: number;
     file: File;
@@ -1626,6 +1627,7 @@ export default function OrbViewPage() {
           nodes: result.nodes,
           relationships: result.relationships || [],
           cvOwnerName: result.cv_owner_name || null,
+          profile: result.profile || null,
           unmatchedCount: result.unmatched?.length || 0,
           skippedCount: result.skipped_nodes?.length || 0,
           file,
@@ -2085,13 +2087,14 @@ export default function OrbViewPage() {
             initialNodes={extractedImport.nodes}
             initialRelationships={extractedImport.relationships}
             cvOwnerName={extractedImport.cvOwnerName}
+            profile={extractedImport.profile}
             unmatchedCount={extractedImport.unmatchedCount}
             skippedCount={extractedImport.skippedCount}
             truncated={false}
             onReset={() => setExtractedImport(null)}
             resetLabel="Cancel import"
-            onConfirm={async (nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount) => {
-              await confirmImport(nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount);
+            onConfirm={async (nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount, profile) => {
+              await confirmImport(nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount, profile);
               fetchDocuments();
             }}
             documentId={extractedImport.documentId}


### PR DESCRIPTION
## Summary

### Profile fields fix (#298)
- CV extraction returns headline, location, social URLs but they were never sent to the backend on confirm
- Added `ExtractedProfile` interface and `profile` field to the entire confirm flow
- After CV import, headline, location, LinkedIn, GitHub, Twitter, Website, Scholar URLs now persist

### Improved LLM prompt for USED_SKILL relationships
- Explicit vs implicit skill detection instructions
- Guidance to create missing skill nodes when referenced in descriptions
- Concrete multi-skill linking example
- Common mistakes to avoid (skipping publications, ignoring implicit skills)
- Same prompt shared by both Claude and Ollama

Closes #298

## Test plan
- [ ] Upload CV → headline and location populated after import
- [ ] Social URLs populated if found in CV
- [ ] More USED_SKILL relationships created (publications linked to skills, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)