### PR TITLE
fix: save uploaded CV to disk so downloads work

### DIFF
--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -20,6 +20,7 @@ from app.cv_storage import db as cv_db
 from app.cv_storage.storage import (
     evict_oldest_if_at_limit,
     load_document,
+    save_document,
 )
 from app.dependencies import get_current_user, get_db, require_gdpr_consent
 from app.graph.encryption import encrypt_properties, encrypt_value
@@ -72,6 +73,16 @@ async def upload_cv(
 
     user_id = current_user.get("user_id", "")
     document_id = str(uuid.uuid4())
+
+    # Store the original PDF (encrypted) before processing
+    evict_oldest_if_at_limit(user_id)
+    save_document(
+        user_id=user_id,
+        document_id=document_id,
+        pdf_bytes=pdf_bytes,
+        filename=file.filename or "cv-upload.pdf",
+        page_count=0,
+    )
 
     counter.increment()
     try:
@@ -254,6 +265,17 @@ async def import_document(
 
     user_id = current_user.get("user_id", "")
     document_id = str(uuid.uuid4())
+
+    # Store the original document (encrypted) before processing
+    evict_oldest_if_at_limit(user_id)
+    save_document(
+        user_id=user_id,
+        document_id=document_id,
+        pdf_bytes=file_bytes,
+        filename=file.filename or "document",
+        page_count=0,
+    )
+
     try:
         progress.set_progress(user_id, CVStep.EXTRACTING_TEXT, file.filename)
         raw_text = await multi_extract(file_bytes, file.filename)


### PR DESCRIPTION
## Summary

CV downloads failed with "Failed to download document" because the uploaded PDF was never saved to disk.

### Root Cause
Both `upload_cv` and `import_document` endpoints:
1. Read the file bytes ✅
2. Extract text and classify ✅
3. Record metadata in SQLite ✅
4. **Never called `save_document()` to encrypt and persist the file to disk** ❌

The SQLite record existed so the document appeared in the list, but the actual `.pdf.enc` file was missing from `data/cv_files/`.

### Fix
- Import `save_document` from `cv_storage.storage`
- Call `save_document()` immediately after generating `document_id`, before processing
- Call `evict_oldest_if_at_limit()` before saving to respect the 3-document limit
- Applied to both `upload_cv` (PDF) and `import_document` (PDF/DOCX/TXT)

Closes #281

## Test plan
- [ ] Upload a CV → file appears in `data/cv_files/`
- [ ] Click download in user menu → PDF downloads successfully
- [ ] Import a document → same download flow works
- [ ] 3-document limit still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)