### PR TITLE
fix: hide search bar on admin dashboard

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -8,9 +8,11 @@ interface NavbarProps {
   center?: React.ReactNode;
   /** Optional right content placed before the user menu */
   rightBefore?: React.ReactNode;
+  /** Hide the Orbis ID search bar */
+  hideSearch?: boolean;
 }
 
-export default function Navbar({ center, rightBefore }: NavbarProps) {
+export default function Navbar({ center, rightBefore, hideSearch }: NavbarProps) {
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const [searchValue, setSearchValue] = useState('');
@@ -46,8 +48,8 @@ export default function Navbar({ center, rightBefore }: NavbarProps) {
         <div className="flex items-center gap-2">
           {rightBefore}
 
-          {/* Search by Orbis ID — authenticated only */}
-          {user && (
+          {/* Search by Orbis ID — authenticated only, hidden on some pages */}
+          {user && !hideSearch && (
             <>
               {/* Mobile: icon toggle */}
               <button

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -572,7 +572,7 @@ export default function AdminPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar center={
+      <Navbar hideSearch center={
         <div className="flex items-center gap-3">
           <span className="text-white/50 text-sm font-medium">Admin Dashboard</span>
           {user?.name && <span className="text-green-400/70 text-xs">Logged as {user.name}</span>}


### PR DESCRIPTION
## Summary
- Added `hideSearch` prop to Navbar component
- Admin page passes `hideSearch` to remove the Orbis ID search bar

Closes #301

## Test plan
- [ ] Admin dashboard: no search bar visible
- [ ] Other pages: search bar still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)