### PR TITLE
feat: add Orbis Pulse evaluation dashboard metrics

### DIFF
--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { OrbData } from '../../api/orbs';
+import { computeOrbisStatsSummary } from './orbisStats';
+
+interface OrbisStatsOverlayProps {
+  data: OrbData;
+  filteredNodeIds?: Set<string>;
+  hiddenNodeTypes?: Set<string>;
+}
+
+interface OrbisPulsePanelProps {
+  stats: ReturnType<typeof computeOrbisStatsSummary>;
+}
+
+const COMPACT_BREAKPOINT_PX = 1280;
+
+function MetricInfo({ description, label }: { description: string; label: string }) {
+  return (
+    <div className="absolute right-1.5 top-1.5 pointer-events-auto">
+      <div className="group relative">
+        <button
+          type="button"
+          aria-label={`${label} metric info`}
+          className="h-[18px] w-[18px] rounded-full border border-white/20 bg-white/5 text-[10px] font-semibold text-white/75 flex items-center justify-center cursor-help"
+        >
+          i
+        </button>
+        <div className="pointer-events-none absolute right-0 top-6 z-10 w-56 rounded-lg border border-white/15 bg-black/90 px-2 py-1.5 text-[10px] leading-snug text-white/80 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+          {description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatPercent(value: number, digits = 0): string {
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatTypeLabel(type: string | null): string {
+  if (!type) return 'Node';
+  return type.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+function metricHint(active: number, total: number): string {
+  if (active === total) return 'All visible';
+  return `${active} of ${total}`;
+}
+
+function shareReadinessLabel(score: number): string {
+  if (score >= 0.8) return 'Excellent';
+  if (score >= 0.65) return 'Strong';
+  if (score >= 0.5) return 'Improving';
+  return 'Needs work';
+}
+
+function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
+  return (
+    <div className="w-[min(336px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md shadow-[0_20px_60px_rgba(0,0,0,0.45)] p-3.5">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em]" style={{ color: '#C43A82' }}>Orbis Pulse</p>
+          <p className="mt-1 text-xs text-white/70">
+            {metricHint(stats.activeNodes, stats.visibleNodes)} nodes in focus
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-white/8 bg-white/[0.03] p-2">
+          <p className="text-[10px] uppercase tracking-wide text-white/40">Active Nodes</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.activeNodes}</p>
+          <p className="mt-1 text-[10px] text-white/45">{stats.visibleNodes} visible</p>
+        </div>
+
+        <div className="rounded-lg border border-white/8 bg-white/[0.03] p-2">
+          <p className="text-[10px] uppercase tracking-wide text-white/40">Active Edges</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.activeLinks}</p>
+          <p className="mt-1 text-[10px] text-white/45">{stats.visibleLinks} visible</p>
+        </div>
+
+        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+          <MetricInfo
+            label="Density"
+            description="Active links divided by the maximum possible links among active nodes in the current view."
+          />
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Density</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.density, 1)}</p>
+          <p className="mt-1 text-[10px] text-white/45">{stats.avgLinksPerNode.toFixed(1)} links/node</p>
+        </div>
+
+        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+          <MetricInfo
+            label="Skill Coverage"
+            description="Share of active non-skill nodes connected to at least one skill through a USED_SKILL link."
+          />
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Skill Coverage</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.skillCoverageRate)}</p>
+          <p className="mt-1 text-[10px] text-white/45">
+            {stats.skillLinkedNodes}/{stats.skillEligibleNodes} linked
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-2.5 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
+        <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
+        <p className="mt-1 text-[10px] text-white/45">
+          {formatTypeLabel(stats.topHubType)} • {stats.topHubDegree} active links
+        </p>
+      </div>
+
+      <div className="relative mt-2.5 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <MetricInfo
+          label="Share Readiness"
+          description="Weighted score: 40% completeness, 25% skill coverage, 20% connectivity, 15% domain balance."
+        />
+        <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Share Readiness</p>
+        <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.shareReadinessScore)}</p>
+        <p className="mt-1 text-[10px] text-white/45">{shareReadinessLabel(stats.shareReadinessScore)}</p>
+      </div>
+
+    </div>
+  );
+}
+
+export default function OrbisStatsOverlay({
+  data,
+  filteredNodeIds = new Set(),
+  hiddenNodeTypes = new Set(),
+}: OrbisStatsOverlayProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isCompact, setIsCompact] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < COMPACT_BREAKPOINT_PX;
+  });
+  const [compactOpen, setCompactOpen] = useState(false);
+
+  const stats = useMemo(
+    () => computeOrbisStatsSummary(data, hiddenNodeTypes, filteredNodeIds),
+    [data, hiddenNodeTypes, filteredNodeIds],
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsCompact(window.innerWidth < COMPACT_BREAKPOINT_PX);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (!isCompact) setCompactOpen(false);
+  }, [isCompact]);
+
+  useEffect(() => {
+    if (!isCompact || !compactOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setCompactOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setCompactOpen(false);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [compactOpen, isCompact]);
+
+  return (
+    <div ref={containerRef} className="pointer-events-none fixed right-4 bottom-24 z-20 sm:right-6 sm:bottom-8">
+      {isCompact ? (
+        <div className="flex flex-col items-end gap-2">
+          {compactOpen && (
+            <div className="pointer-events-auto">
+              <OrbisPulsePanel stats={stats} />
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => setCompactOpen((prev) => !prev)}
+            aria-expanded={compactOpen}
+            className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/65 backdrop-blur-md px-3 py-1.5 text-xs font-semibold text-white/90 shadow-lg shadow-black/40 hover:bg-black/75 transition-colors"
+          >
+            <span style={{ color: '#C43A82' }}>Orbis Pulse</span>
+            <svg
+              className={`h-3.5 w-3.5 text-white/70 transition-transform ${compactOpen ? 'rotate-180' : ''}`}
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path d="M5 7l5 6 5-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <div className="pointer-events-auto">
+          <OrbisPulsePanel stats={stats} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/graph/orbisStats.test.ts
+++ b/frontend/src/components/graph/orbisStats.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { OrbData } from '../../api/orbs';
+import { computeOrbisStatsSummary } from './orbisStats';
+
+const baseData: OrbData = {
+  person: { user_id: 'person-1', name: 'Ada Lovelace' },
+  nodes: [
+    {
+      uid: 'work-1',
+      _labels: ['WorkExperience'],
+      title: 'Research Engineer',
+      company: 'OpenOrbis',
+      start_date: '2022-01',
+    },
+    { uid: 'skill-1', _labels: ['Skill'], name: 'TypeScript' },
+    { uid: 'skill-2', _labels: ['Skill'], name: 'Python' },
+    {
+      uid: 'project-1',
+      _labels: ['Project'],
+      title: 'Graph Insights',
+      description: 'Interactive graph analytics dashboard',
+      start_date: '2024-01',
+      end_date: '2025-06',
+    },
+    {
+      uid: 'edu-1',
+      _labels: ['Education'],
+      institution: 'University of Pisa',
+      degree: 'MSc AI',
+      start_date: '2018-09',
+      end_date: '2020-07',
+    },
+  ],
+  links: [
+    { source: 'person-1', target: 'work-1', type: 'HAS_WORK_EXPERIENCE' },
+    { source: 'person-1', target: 'project-1', type: 'HAS_PROJECT' },
+    { source: 'person-1', target: 'edu-1', type: 'HAS_EDUCATION' },
+    { source: 'work-1', target: 'skill-1', type: 'USED_SKILL' },
+    { source: 'project-1', target: 'skill-1', type: 'USED_SKILL' },
+    { source: 'project-1', target: 'skill-2', type: 'USED_SKILL' },
+    { source: 'work-1', target: 'project-1', type: 'RELATED_TO' },
+  ],
+};
+
+describe('computeOrbisStatsSummary', () => {
+  it('computes core vanity metrics for the active graph', () => {
+    const stats = computeOrbisStatsSummary(baseData, new Set(), new Set(), new Date('2026-04-14T00:00:00Z'));
+
+    expect(stats.visibleNodes).toBe(5);
+    expect(stats.activeNodes).toBe(5);
+    expect(stats.visibleLinks).toBe(7);
+    expect(stats.activeLinks).toBe(7);
+    expect(stats.typeDiversity).toBe(4);
+    expect(stats.skillEligibleNodes).toBe(3);
+    expect(stats.skillLinkedNodes).toBe(2);
+    expect(stats.skillCoverageRate).toBeCloseTo(2 / 3, 4);
+    expect(stats.topHubName).toBe('Graph Insights');
+    expect(stats.topHubDegree).toBe(4);
+    expect(stats.signatureSkillName).toBe('TypeScript');
+    expect(stats.signatureSkillLinks).toBe(2);
+    expect(stats.focusTopSkillEdges).toBe(3);
+    expect(stats.usedSkillEdges).toBe(3);
+    expect(stats.focusScore).toBe(1);
+    expect(stats.careerSpanHasData).toBe(true);
+    expect(stats.careerSpanYears).toBeCloseTo(6.75, 2);
+    expect(stats.recencyScore).toBeCloseTo(0.2, 3);
+    expect(stats.hubConcentration).toBeCloseTo(4 / 7, 3);
+    expect(stats.domainBalanceScore).toBeGreaterThan(0);
+    expect(stats.completenessRate).toBe(1);
+    expect(stats.completeNodes).toBe(5);
+    expect(stats.largestClusterRate).toBe(1);
+    expect(stats.largestClusterNodes).toBe(5);
+  });
+
+  it('updates active metrics when nodes are muted by filters', () => {
+    const stats = computeOrbisStatsSummary(
+      baseData,
+      new Set(),
+      new Set(['edu-1']),
+      new Date('2026-04-14T00:00:00Z'),
+    );
+
+    expect(stats.filtersActive).toBe(true);
+    expect(stats.mutedNodes).toBe(1);
+    expect(stats.activeNodes).toBe(4);
+    expect(stats.activeLinks).toBe(6);
+    expect(stats.connectivityRate).toBe(1);
+    expect(stats.filtersActive).toBe(true);
+    expect(stats.largestClusterRate).toBe(1);
+  });
+
+  it('drops hidden node types from visible metrics', () => {
+    const stats = computeOrbisStatsSummary(
+      baseData,
+      new Set(['Skill']),
+      new Set(),
+      new Date('2026-04-14T00:00:00Z'),
+    );
+
+    expect(stats.hiddenNodes).toBe(2);
+    expect(stats.visibleNodes).toBe(3);
+    expect(stats.visibleLinks).toBe(4);
+    expect(stats.skillEligibleNodes).toBe(3);
+    expect(stats.skillLinkedNodes).toBe(0);
+    expect(stats.skillCoverageRate).toBe(0);
+    expect(stats.signatureSkillName).toBe('No linked skill yet');
+    expect(stats.focusScore).toBe(0);
+  });
+});

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -1,0 +1,401 @@
+import type { OrbData, OrbNode } from '../../api/orbs';
+
+const SKILL_LABEL = 'Skill';
+const PERSON_LABEL = 'Person';
+const SKILL_LINK_TYPE = 'USED_SKILL';
+const DOMAIN_TYPE_UNIVERSE = [
+  'Education',
+  'WorkExperience',
+  'Certification',
+  'Language',
+  'Publication',
+  'Project',
+  'Skill',
+  'Patent',
+  'Award',
+  'Outreach',
+  'Training',
+] as const;
+
+const DATE_FIELDS = [
+  'start_date', 'end_date', 'date',
+  'issue_date', 'expiry_date',
+  'filing_date', 'grant_date',
+] as const;
+
+const REQUIRED_FIELDS_BY_TYPE: Record<string, string[]> = {
+  Education: ['institution', 'degree', 'start_date'],
+  WorkExperience: ['title', 'company', 'start_date'],
+  Certification: ['name', 'issuing_organization'],
+  Language: ['name', 'proficiency'],
+  Publication: ['title'],
+  Project: ['title', 'description'],
+  Skill: ['name'],
+  Patent: ['title'],
+  Award: ['title'],
+  Outreach: ['title'],
+  Training: ['title'],
+};
+
+export interface OrbisStatsSummary {
+  visibleNodes: number;
+  activeNodes: number;
+  visibleLinks: number;
+  activeLinks: number;
+  hiddenNodes: number;
+  mutedNodes: number;
+  typeDiversity: number;
+  avgLinksPerNode: number;
+  density: number;
+  connectivityRate: number;
+  skillCoverageRate: number;
+  skillLinkedNodes: number;
+  skillEligibleNodes: number;
+  topHubName: string;
+  topHubType: string | null;
+  topHubDegree: number;
+  signatureSkillName: string;
+  signatureSkillLinks: number;
+  usedSkillEdges: number;
+  focusTopSkillEdges: number;
+  focusScore: number;
+  careerSpanMonths: number;
+  careerSpanYears: number;
+  careerSpanHasData: boolean;
+  careerSpanLabel: string;
+  recencyScore: number;
+  recentActiveNodes: number;
+  hubConcentration: number;
+  domainBalanceScore: number;
+  completenessRate: number;
+  completeNodes: number;
+  largestClusterRate: number;
+  largestClusterNodes: number;
+  shareReadinessScore: number;
+  filtersActive: boolean;
+}
+
+const DISPLAY_FIELDS = [
+  'name',
+  'title',
+  'company',
+  'institution',
+  'organization',
+  'role',
+  'degree',
+  'issuing_organization',
+] as const;
+
+function getPrimaryLabel(node: Pick<OrbNode, '_labels'> | Record<string, unknown>): string {
+  const labels = (node._labels as string[] | undefined) ?? [];
+  return labels[0] ?? '';
+}
+
+function getLinkEndpointId(endpoint: unknown): string {
+  if (typeof endpoint === 'string') return endpoint;
+  if (endpoint && typeof endpoint === 'object') {
+    const maybeEndpoint = endpoint as { id?: unknown; uid?: unknown };
+    if (typeof maybeEndpoint.id === 'string') return maybeEndpoint.id;
+    if (typeof maybeEndpoint.uid === 'string') return maybeEndpoint.uid;
+  }
+  return '';
+}
+
+function getNodeDisplayName(node: Record<string, unknown>): string {
+  for (const field of DISPLAY_FIELDS) {
+    const raw = node[field];
+    if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  }
+
+  const label = getPrimaryLabel(node);
+  return label || 'Node';
+}
+
+function clampRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function hasValue(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'boolean') return true;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0;
+  return false;
+}
+
+function normalizeDate(raw: string): string | null {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || trimmed === 'present' || trimmed === 'current') return null;
+
+  if (/^\d{4}$/.test(trimmed)) return `${trimmed}-01`;
+  if (/^\d{4}-\d{2}$/.test(trimmed)) return trimmed;
+
+  const isoMatch = trimmed.match(/^(\d{4}-\d{2})-\d{2}/);
+  if (isoMatch) return isoMatch[1];
+
+  const mmYyyy = trimmed.match(/^(\d{1,2})\/(\d{4})$/);
+  if (mmYyyy) return `${mmYyyy[2]}-${mmYyyy[1].padStart(2, '0')}`;
+
+  const ddMmYyyy = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (ddMmYyyy) return `${ddMmYyyy[3]}-${ddMmYyyy[2].padStart(2, '0')}`;
+
+  return null;
+}
+
+function getNormalizedNodeDates(node: Record<string, unknown>): string[] {
+  const dates: string[] = [];
+  for (const field of DATE_FIELDS) {
+    const value = node[field];
+    if (typeof value !== 'string') continue;
+    const normalized = normalizeDate(value);
+    if (normalized) dates.push(normalized);
+  }
+  return dates;
+}
+
+function toMonthIndex(ym: string): number {
+  const [year, month] = ym.split('-').map(Number);
+  return year * 12 + (month - 1);
+}
+
+function formatMonthIndex(monthIndex: number): string {
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const year = Math.floor(monthIndex / 12);
+  const month = monthIndex % 12;
+  return `${months[month]} ${year}`;
+}
+
+function isNodeComplete(node: Record<string, unknown>): boolean {
+  const nodeType = getPrimaryLabel(node);
+  const required = REQUIRED_FIELDS_BY_TYPE[nodeType];
+  if (required?.length) {
+    return required.every((key) => hasValue(node[key]));
+  }
+  return DISPLAY_FIELDS.some((field) => hasValue(node[field]));
+}
+
+export function computeOrbisStatsSummary(
+  data: OrbData,
+  hiddenNodeTypes: Set<string> = new Set(),
+  filteredNodeIds: Set<string> = new Set(),
+  referenceDate: Date = new Date(),
+): OrbisStatsSummary {
+  const personId = ((data.person.user_id || data.person.orb_id) as string) || 'person';
+  const hiddenTypes = hiddenNodeTypes ?? new Set<string>();
+  const filteredIds = filteredNodeIds ?? new Set<string>();
+
+  const nodesById = new Map<string, Record<string, unknown>>();
+  nodesById.set(personId, { id: personId, ...data.person, _labels: [PERSON_LABEL] });
+
+  const visibleDomainNodes = data.nodes.filter((node) => {
+    const label = getPrimaryLabel(node);
+    if (hiddenTypes.has(label)) return false;
+    nodesById.set(node.uid, node);
+    return true;
+  });
+
+  const visibleIds = new Set<string>([personId, ...visibleDomainNodes.map((node) => node.uid)]);
+  const activeDomainNodes = visibleDomainNodes.filter((node) => !filteredIds.has(node.uid));
+  const activeIds = new Set<string>([personId, ...activeDomainNodes.map((node) => node.uid)]);
+
+  const visibleLinks = data.links.filter((link) => {
+    const source = getLinkEndpointId(link.source);
+    const target = getLinkEndpointId(link.target);
+    return source && target && visibleIds.has(source) && visibleIds.has(target);
+  });
+
+  const activeLinks = visibleLinks.filter((link) => {
+    const source = getLinkEndpointId(link.source);
+    const target = getLinkEndpointId(link.target);
+    return activeIds.has(source) && activeIds.has(target);
+  });
+
+  const degreeById = new Map<string, number>();
+  for (const id of activeIds) degreeById.set(id, 0);
+  for (const link of activeLinks) {
+    const source = getLinkEndpointId(link.source);
+    const target = getLinkEndpointId(link.target);
+    degreeById.set(source, (degreeById.get(source) ?? 0) + 1);
+    degreeById.set(target, (degreeById.get(target) ?? 0) + 1);
+  }
+
+  const connectedActiveNodes = activeDomainNodes.filter((node) => (degreeById.get(node.uid) ?? 0) > 0).length;
+  const typeDiversity = new Set(activeDomainNodes.map((node) => getPrimaryLabel(node)).filter(Boolean)).size;
+  const avgLinksPerNode = activeDomainNodes.length > 0 ? activeLinks.length / activeDomainNodes.length : 0;
+  const possibleEdges = activeIds.size > 1 ? (activeIds.size * (activeIds.size - 1)) / 2 : 0;
+  const density = possibleEdges > 0 ? activeLinks.length / possibleEdges : 0;
+
+  const skillCoverageCandidates = activeDomainNodes.filter((node) => getPrimaryLabel(node) !== SKILL_LABEL);
+  const linkedCandidateIds = new Set<string>();
+  const skillEdgeCountById = new Map<string, number>();
+  let usedSkillEdges = 0;
+
+  for (const link of activeLinks) {
+    if (link.type !== SKILL_LINK_TYPE) continue;
+    const source = getLinkEndpointId(link.source);
+    const target = getLinkEndpointId(link.target);
+    const sourceType = getPrimaryLabel(nodesById.get(source) ?? {});
+    const targetType = getPrimaryLabel(nodesById.get(target) ?? {});
+
+    if (sourceType === SKILL_LABEL && targetType !== SKILL_LABEL && targetType !== PERSON_LABEL) {
+      linkedCandidateIds.add(target);
+      usedSkillEdges += 1;
+      skillEdgeCountById.set(source, (skillEdgeCountById.get(source) ?? 0) + 1);
+    } else if (targetType === SKILL_LABEL && sourceType !== SKILL_LABEL && sourceType !== PERSON_LABEL) {
+      linkedCandidateIds.add(source);
+      usedSkillEdges += 1;
+      skillEdgeCountById.set(target, (skillEdgeCountById.get(target) ?? 0) + 1);
+    }
+  }
+
+  const topHub = [...activeDomainNodes]
+    .map((node) => ({ uid: node.uid, degree: degreeById.get(node.uid) ?? 0 }))
+    .filter((entry) => entry.degree > 0)
+    .sort((a, b) => b.degree - a.degree || a.uid.localeCompare(b.uid))[0];
+
+  const topHubNode = topHub ? nodesById.get(topHub.uid) : null;
+  const topHubName = topHubNode ? getNodeDisplayName(topHubNode) : 'No active links yet';
+  const topHubType = topHubNode ? getPrimaryLabel(topHubNode) || null : null;
+  const topHubDegree = topHub?.degree ?? 0;
+  const hubConcentration = clampRatio(activeLinks.length > 0 ? topHubDegree / activeLinks.length : 0);
+
+  const signatureSkill = [...skillEdgeCountById.entries()]
+    .map(([uid, links]) => {
+      const skillNode = nodesById.get(uid) ?? {};
+      return { uid, links, name: getNodeDisplayName(skillNode) };
+    })
+    .sort((a, b) => b.links - a.links || a.name.localeCompare(b.name))[0];
+
+  const signatureSkillName = signatureSkill?.name ?? 'No linked skill yet';
+  const signatureSkillLinks = signatureSkill?.links ?? 0;
+  const topSkillEntries = [...skillEdgeCountById.values()].sort((a, b) => b - a);
+  const focusTopSkillEdges = topSkillEntries.slice(0, 3).reduce((sum, count) => sum + count, 0);
+  const focusScore = clampRatio(usedSkillEdges > 0 ? focusTopSkillEdges / usedSkillEdges : 0);
+
+  const allDateMonths: number[] = [];
+  for (const node of activeDomainNodes) {
+    const dates = getNormalizedNodeDates(node);
+    for (const date of dates) allDateMonths.push(toMonthIndex(date));
+  }
+
+  const careerSpanHasData = allDateMonths.length > 0;
+  const minDateMonth = careerSpanHasData ? Math.min(...allDateMonths) : 0;
+  const maxDateMonth = careerSpanHasData ? Math.max(...allDateMonths) : 0;
+  const careerSpanMonths = careerSpanHasData ? Math.max(0, maxDateMonth - minDateMonth) : 0;
+  const careerSpanYears = careerSpanMonths / 12;
+  const careerSpanLabel = careerSpanHasData
+    ? `${formatMonthIndex(minDateMonth)} - ${formatMonthIndex(maxDateMonth)}`
+    : 'No dated nodes';
+
+  const currentMonth = referenceDate.getUTCFullYear() * 12 + referenceDate.getUTCMonth();
+  const recencyCutoffMonth = currentMonth - 23;
+  const recentActiveNodes = activeDomainNodes.filter((node) => {
+    const dates = getNormalizedNodeDates(node);
+    if (dates.length === 0) return false;
+    return dates.some((date) => toMonthIndex(date) >= recencyCutoffMonth);
+  }).length;
+  const recencyScore = clampRatio(activeDomainNodes.length > 0 ? recentActiveNodes / activeDomainNodes.length : 0);
+
+  const domainTypeCounts = new Map<string, number>();
+  for (const node of activeDomainNodes) {
+    const type = getPrimaryLabel(node);
+    if (!type) continue;
+    domainTypeCounts.set(type, (domainTypeCounts.get(type) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of domainTypeCounts.values()) {
+    const proportion = count / Math.max(1, activeDomainNodes.length);
+    entropy += -proportion * Math.log(proportion);
+  }
+  const maxEntropy = Math.log(DOMAIN_TYPE_UNIVERSE.length);
+  const domainBalanceScore = clampRatio(maxEntropy > 0 ? entropy / maxEntropy : 0);
+
+  const completeNodes = activeDomainNodes.filter((node) => isNodeComplete(node)).length;
+  const completenessRate = clampRatio(activeDomainNodes.length > 0 ? completeNodes / activeDomainNodes.length : 0);
+
+  const adjacency = new Map<string, Set<string>>();
+  for (const id of activeIds) adjacency.set(id, new Set<string>());
+  for (const link of activeLinks) {
+    const source = getLinkEndpointId(link.source);
+    const target = getLinkEndpointId(link.target);
+    adjacency.get(source)?.add(target);
+    adjacency.get(target)?.add(source);
+  }
+
+  let largestClusterNodes = 0;
+  const visited = new Set<string>();
+  for (const id of activeIds) {
+    if (visited.has(id)) continue;
+    const queue = [id];
+    visited.add(id);
+    let domainNodeCount = 0;
+
+    while (queue.length > 0) {
+      const current = queue.shift() as string;
+      if (current !== personId) domainNodeCount += 1;
+      const neighbors = adjacency.get(current);
+      if (!neighbors) continue;
+      for (const neighbor of neighbors) {
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+
+    if (domainNodeCount > largestClusterNodes) largestClusterNodes = domainNodeCount;
+  }
+  const largestClusterRate = clampRatio(
+    activeDomainNodes.length > 0 ? largestClusterNodes / activeDomainNodes.length : 0,
+  );
+
+  // Share readiness: weighted blend of profile quality signals.
+  const shareReadinessScore = clampRatio(
+    (0.4 * completenessRate) +
+    (0.25 * (skillCoverageCandidates.length > 0 ? linkedCandidateIds.size / skillCoverageCandidates.length : 0)) +
+    (0.2 * (activeDomainNodes.length > 0 ? connectedActiveNodes / activeDomainNodes.length : 0)) +
+    (0.15 * domainBalanceScore),
+  );
+
+  return {
+    visibleNodes: visibleDomainNodes.length,
+    activeNodes: activeDomainNodes.length,
+    visibleLinks: visibleLinks.length,
+    activeLinks: activeLinks.length,
+    hiddenNodes: data.nodes.length - visibleDomainNodes.length,
+    mutedNodes: visibleDomainNodes.length - activeDomainNodes.length,
+    typeDiversity,
+    avgLinksPerNode,
+    density: clampRatio(density),
+    connectivityRate: clampRatio(activeDomainNodes.length > 0 ? connectedActiveNodes / activeDomainNodes.length : 0),
+    skillCoverageRate: clampRatio(
+      skillCoverageCandidates.length > 0 ? linkedCandidateIds.size / skillCoverageCandidates.length : 0,
+    ),
+    skillLinkedNodes: linkedCandidateIds.size,
+    skillEligibleNodes: skillCoverageCandidates.length,
+    signatureSkillName,
+    signatureSkillLinks,
+    usedSkillEdges,
+    focusTopSkillEdges,
+    focusScore,
+    careerSpanMonths,
+    careerSpanYears,
+    careerSpanHasData,
+    careerSpanLabel,
+    recencyScore,
+    recentActiveNodes,
+    hubConcentration,
+    domainBalanceScore,
+    completenessRate,
+    completeNodes,
+    largestClusterRate,
+    largestClusterNodes,
+    shareReadinessScore,
+    topHubName,
+    topHubType,
+    topHubDegree,
+    filtersActive: filteredIds.size > 0 || hiddenTypes.size > 0,
+  };
+}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -12,6 +12,7 @@ import {
 } from '../api/orbs';
 import type { OrbVisibility } from '../api/orbs';
 import OrbGraph3D from '../components/graph/OrbGraph3D';
+import OrbisStatsOverlay from '../components/graph/OrbisStatsOverlay';
 import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import FloatingInput from '../components/editor/FloatingInput';
 import ChatBox from '../components/chat/ChatBox';
@@ -873,6 +874,13 @@ export default function OrbViewPage() {
           onCameraDistanceChange={handleCameraDistanceChange}
         />
       </div>
+      {!isPendingDeletion && (
+        <OrbisStatsOverlay
+          data={data}
+          filteredNodeIds={filteredNodeIds}
+          hiddenNodeTypes={hiddenNodeTypes}
+        />
+      )}
 
       {/* NodeTypeFilter moved to header bar */}
 


### PR DESCRIPTION
## Summary
- add a new Orbis Pulse overlay on the Orb view with live graph metrics
- compute meaningful personal graph statistics from the active/visible graph state (respecting node-type/date/keyword filters)
- add responsive behavior: compact toggle button on smaller/resized screens
- add metric info tooltips for Density, Skill Coverage, and Share Readiness
- add Share Readiness metric below Top Hub and remove the earlier vanity-metrics block
- polish overlay UX (pink title, icon spacing fixes, layering under header menus)

## Metrics included
- Active Nodes / Active Edges
- Density
- Skill Coverage
- Top Hub
- Share Readiness

## Validation
- npx eslint src/components/graph/orbisStats.ts src/components/graph/OrbisStatsOverlay.tsx src/components/graph/orbisStats.test.ts
- npx vitest run src/components/graph/orbisStats.test.ts

Closes #188