### PR TITLE
feat: update guided tour for Orbis Pulse and visibility flow

### DIFF
--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -44,6 +44,12 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
+    target: '[data-tour="orbis-pulse"]',
+    title: 'Bottom-Right Metrics',
+    content: 'Orbis Pulse gives you live graph metrics (active nodes/edges, density, skill coverage, top hub, and share readiness) based on the current view and filters.',
+    placement: 'left',
+  },
+  {
     target: '[data-tour="undo-redo"]',
     title: 'Undo And Redo',
     content: 'Undo and redo your recent changes — adding or deleting nodes can be reversed.',
@@ -77,6 +83,12 @@ const STEPS: TourStep[] = [
     target: '[data-tour="chatbox"]',
     title: 'Search With Chat',
     content: 'Search your orbis by typing queries here. Matching nodes will be highlighted in the graph. You can also share your orbis from here.',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="visibility"]',
+    title: 'Set Visibility',
+    content: 'Use this Share button to open sharing controls and set your visibility mode (public, restricted, or private), then configure who can access your orbis.',
     placement: 'top',
   },
   {

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -44,12 +44,6 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
-    target: '[data-tour="orbis-pulse"]',
-    title: 'Bottom-Right Metrics',
-    content: 'Orbis Pulse gives you live graph metrics (active nodes/edges, density, skill coverage, top hub, and share readiness) based on the current view and filters.',
-    placement: 'left',
-  },
-  {
     target: '[data-tour="undo-redo"]',
     title: 'Undo And Redo',
     content: 'Undo and redo your recent changes — adding or deleting nodes can be reversed.',
@@ -57,8 +51,14 @@ const STEPS: TourStep[] = [
   },
   {
     target: '[data-tour="node-types"]',
-    title: 'Filter Node Types',
-    content: 'Filter which types of nodes are visible in the graph — education, skills, work experience, and more.',
+    title: 'View Node Types',
+    content: 'Open this to view your node categories (education, skills, work experience, and more).',
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour="keyword-filter"]',
+    title: 'Filter',
+    content: 'Use this button to filter the graph by keywords and focus on relevant parts of your orbis. These filters can also be configured for shared Orbis views to control what other users can see.',
     placement: 'bottom',
   },
   {
@@ -80,22 +80,40 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
-    target: '[data-tour="chatbox"]',
-    title: 'Search With Chat',
-    content: 'Search your orbis by typing queries here. Matching nodes will be highlighted in the graph. You can also share your orbis from here.',
-    placement: 'top',
-  },
-  {
-    target: '[data-tour="visibility"]',
-    title: 'Set Visibility',
-    content: 'Use this Share button to open sharing controls and set your visibility mode (public, restricted, or private), then configure who can access your orbis.',
-    placement: 'top',
+    target: '[data-tour="search-orbis-id"]',
+    title: 'Search Orbis ID',
+    content: 'Use this field to open any Orbis directly by ID. Type an ID and press Enter to navigate.',
+    placement: 'bottom',
   },
   {
     target: '[data-tour="user-menu"]',
     title: 'Account Settings',
     content: 'Access your account settings, uploaded CVs, and sign out from here. In Settings you can claim a custom Orbis ID, manage saved versions, or delete your account.',
     placement: 'bottom-end',
+  },
+  {
+    target: '[data-tour="orbis-pulse"]',
+    title: 'Orbis Pulse',
+    content: 'Orbis Pulse gives you live graph metrics (active nodes/edges, density, skill coverage, top hub, and share readiness) based on the current view and filters.',
+    placement: 'left',
+  },
+  {
+    target: '[data-tour="add-entry"]',
+    title: 'Add To Graph',
+    content: 'Use the + button to quickly add a new node to your orbis.',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="visibility"]',
+    title: 'Set Visibility',
+    content: 'Use this Share button to open sharing controls and set visibility to public or restricted. Default is restricted. You can then configure who can access your orbis.',
+    placement: 'top',
+  },
+  {
+    target: '[data-tour="chatbox"]',
+    title: 'Search With Chat',
+    content: 'Search your orbis by typing queries here. Matching nodes will be highlighted in the graph. You can also share your orbis from here.',
+    placement: 'top',
   },
 ];
 

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -475,6 +475,7 @@ export default function ChatBox({
           <div className="flex items-center gap-1.5 flex-shrink-0">
             {onShare && (
               <button
+                data-tour="visibility"
                 onClick={onShare}
                 className={`w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center border text-white/90 hover:text-white transition-all shadow-lg ${shareButtonClass}`}
                 title="Share"

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -487,6 +487,7 @@ export default function ChatBox({
             )}
             {onAdd && (
               <button
+                data-tour="add-entry"
                 onClick={onAdd}
                 className={`w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-purple-600 hover:bg-purple-500 text-white transition-all shadow-lg shadow-purple-600/30 hover:shadow-purple-500/40 ${highlightAdd ? 'animate-pulse ring-2 ring-purple-400 ring-offset-2 ring-offset-black' : ''}`}
                 title="Add Entry"

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -177,7 +177,11 @@ export default function OrbisStatsOverlay({
   }, [compactOpen, isCompact]);
 
   return (
-    <div ref={containerRef} className="pointer-events-none fixed right-4 bottom-24 z-20 sm:right-6 sm:bottom-8">
+    <div
+      ref={containerRef}
+      data-tour="orbis-pulse"
+      className="pointer-events-none fixed right-4 bottom-24 z-20 sm:right-6 sm:bottom-8"
+    >
       {isCompact ? (
         <div className="flex flex-col items-end gap-2">
           {compactOpen && (

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -733,7 +733,9 @@ export default function OrbViewPage() {
                       onSetVisible={handleSetVisibleNodeTypes}
                     />
                   </div>
-                  <KeywordFilterDropdown />
+                  <div data-tour="keyword-filter">
+                    <KeywordFilterDropdown />
+                  </div>
                   <button
                     data-tour="export"
                     onClick={() => window.open('/cv-export', '_blank')}
@@ -790,6 +792,7 @@ export default function OrbViewPage() {
               </div>
               <div className="w-px h-5 bg-white/10 mx-1 hidden sm:block" />
               <form
+                data-tour="search-orbis-id"
                 onSubmit={(e) => { e.preventDefault(); const v = orbSearchValue.trim(); if (v) { navigate(`/${v}`); setOrbSearchValue(''); } }}
                 className="hidden sm:flex items-center"
               >


### PR DESCRIPTION
## Summary
- refresh the guided tour order to match the latest UI flow
- add explicit walkthrough coverage for Search Orbis ID, Account Settings, Orbis Pulse, Add (+), Set Visibility, and Search/Query
- refine wording for node type viewing vs filtering responsibilities
- clarify that visibility options are public/restricted and default is restricted
- clarify that keyword filters can also be configured for shared Orbis views

## Tour anchor updates
- add `data-tour="keyword-filter"` around keyword filter control
- add `data-tour="add-entry"` on the + add button
- keep `data-tour="search-orbis-id"` and `data-tour="orbis-pulse"` coverage

## Validation
- `npx eslint src/components/GuidedTour.tsx src/components/chat/ChatBox.tsx src/pages/OrbViewPage.tsx`

Closes #318
