### PR TITLE
docs: audit docs/ for consistency with recent codebase changes (#274)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,20 +16,23 @@
 ```
 backend/
   app/
-    auth/        # JWT auth, Google/LinkedIn OAuth, GDPR consent, account lifecycle, invite code activation
-    admin/       # Closed-beta admin: invite codes CRUD, beta config toggle, pending users, funnel metrics, insights
+    auth/        # JWT auth, Google/LinkedIn OAuth, GDPR consent, account lifecycle, invite code activation, MCP API keys, refresh tokens
+    admin/       # Closed-beta admin: invite codes CRUD, beta config toggle, pending users, funnel metrics, insights, user management
     email/       # Transactional email via Resend (activation notifications, invite codes)
     cv/          # CV PDF parsing (PyMuPDF), LLM classification (Ollama/Claude CLI), rule-based fallback
-    graph/       # Neo4j async driver, Cypher queries, Fernet encryption (MultiFernet + historic keys), node-property allowlist, embeddings (placeholder)
-    orbs/        # Orb (knowledge graph) CRUD, filter tokens for privacy-aware sharing
+    graph/       # Neo4j async driver, Cypher queries, Fernet encryption (MultiFernet + historic keys), node-property allowlist, LLM usage tracking, embeddings (placeholder)
+    orbs/        # Orb (knowledge graph) CRUD, share tokens, access grants, connection requests, visibility management
     notes/       # LLM-enhanced note-to-node conversion
     search/      # Semantic (vector index) and fuzzy text search
     export/      # Public orb export (JSON, JSON-LD, PDF)
+    drafts/      # Draft notes CRUD
+    ideas/       # Feature idea / feedback submission
+    snapshots/   # Orb version snapshots (save, restore, delete)
     main.py      # FastAPI app factory, middleware (CORS, SlowAPI), router registration
     config.py    # Pydantic Settings (env-based)
     rate_limit.py # SlowAPI limiter keyed on user_id (authenticated) / IP (public). Explicit caps on LLM endpoints: /cv/upload 3/min, /cv/import 3/min, /notes/enhance 10/min.
     dependencies.py # get_db, get_current_user (JWT bearer), require_admin
-  mcp_server/    # MCP server exposing orb graph to AI agents (6 tools)
+  mcp_server/    # MCP server exposing orb graph to AI agents (5 tools, API key auth via X-MCP-Key)
   tests/
     unit/        # pytest unit tests (mocked Neo4j, no external deps)
     integration/ # CV extraction quality tests (calls real Claude CLI)
@@ -38,9 +41,9 @@ backend/
 frontend/
   src/
     api/         # Axios client (baseURL /api, auth interceptor, 401 redirect)
-    components/  # React components by domain (graph/, editor/, chat/, cv/, drafts/, landing/, onboarding/)
-    pages/       # Page-level components (Landing, CreateOrb, OrbView, SharedOrb, CvExport, About, Privacy, Activate, Admin)
-    stores/      # Zustand stores (auth, orb, filter, dateFilter, toast)
+    components/  # React components by domain (graph/, editor/, chat/, cv/, drafts/, landing/, onboarding/, layout/, profile/, sharing/)
+    pages/       # Page-level components (Landing, AuthCallback, LinkedInCallback, CreateOrb, OrbView, SharedOrb, CvExport, Privacy, Activate, Admin)
+    stores/      # Zustand stores (auth, orb, filter, dateFilter, toast, undo)
 docs/            # Detailed documentation (see below)
 infra/           # Neo4j init script (constraints, indexes, vector indexes)
 ```
@@ -54,6 +57,7 @@ infra/           # Neo4j init script (constraints, indexes, vector indexes)
 - Tests: `cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=75`
 - All Person node PII fields (email, phone, address) are Fernet-encrypted at rest. `ENV` must be non-`development` in production — the backend refuses to start with placeholder `JWT_SECRET`, `ENCRYPTION_KEY`, or `NEO4J_PASSWORD` (see `backend/app/config.py`).
 - All node writes (`cv._persist_nodes`, `orbs.add_node`, `orbs.update_node`) must route properties through `sanitize_node_properties` from `app.graph.node_schema` before `encrypt_properties` — the allowlist is the single chokepoint against LLM-driven prompt injection poisoning the graph.
+- MCP server: all requests require `X-MCP-Key` header (resolved to `user_id` via `app.auth.mcp_keys`). Missing key returns 401.
 - Environment config: `.env` (both backend and root), see `.env.example` for template
 - No pre-commit hooks — linting enforced via CI only
 - Backend runs directly (not containerized): `cd backend && uv run uvicorn app.main:app --reload`
@@ -107,6 +111,8 @@ Detailed docs live in `docs/`. Key files:
 - `docs/deployment.md` — production setup, Docker, environment variables
 - `docs/cv-extraction-quality.md` — CV extraction quality metrics and CI
 - `docs/cross-browser-checklist.md` — manual cross-browser smoke test checklist
+- `docs/llm-provider-benchmark.md` — LLM provider evaluation for CV extraction
+- `docs/invitation-system.md` — invite code system and closed-beta flow
 - `docs/navigation-flow.md` — user-flow state diagrams (pages, modals, guards)
 - `docs/navigation-actions.yaml` — action catalog for every UI interaction
 - `docs/agent-navigation-guide.md` — agent traversal strategy for UX evaluation

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,12 @@ Admin endpoints additionally require `is_admin = true` on the Person node (retur
 | POST | `/auth/gdpr-consent` | JWT | Sets GDPR consent flag on Person node |
 | DELETE | `/auth/me` | JWT | Soft-deletes account (30-day grace period via `deletion_requested_at`) |
 | POST | `/auth/me/recover` | JWT | Cancel pending account deletion |
+| POST | `/auth/refresh` | JWT | Rotate refresh token (returns new access + refresh tokens) |
+| POST | `/auth/logout` | JWT | Revoke refresh token and clear session |
+| POST | `/auth/waitlist/join` | JWT | Opt in to waitlist (sets `waitlist_joined_at` on Person) |
+| POST | `/auth/api-keys` | JWT | Create MCP API key (returns raw key once; server stores SHA-256 hash). Keys use `orbk_` prefix. |
+| GET | `/auth/api-keys` | JWT | List user's API keys (metadata only — `key_id`, `label`, `created_at`, `last_used_at`) |
+| DELETE | `/auth/api-keys/{key_id}` | JWT | Revoke an API key |
 
 ## Admin (`/admin`)
 
@@ -42,7 +48,14 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | DELETE | `/admin/access-codes/{code}` | Admin | Delete unused code |
 | GET | `/admin/pending-users` | Admin | List users registered but not yet activated |
 | GET | `/admin/funnel` | Admin | Waitlist funnel metrics: daily signups/activations, conversion rate (`?days=30`) |
-| GET | `/admin/insights` | Admin | Provider breakdown, avg activation time, code attribution, engagement distribution |
+| GET | `/admin/insights` | Admin | Provider breakdown, avg activation time, code attribution, engagement distribution, LLM usage insights |
+| GET | `/admin/users` | Admin | List all users (paginated) |
+| GET | `/admin/users/{user_id}` | Admin | User detail including `llm_usage` list and `llm_usage_summary` |
+| POST | `/admin/users/{user_id}/activate` | Admin | Manually activate a single user |
+| POST | `/admin/users/activate-batch` | Admin | Batch activate multiple users |
+| POST | `/admin/users/{user_id}/promote` | Admin | Promote user to admin |
+| POST | `/admin/users/{user_id}/demote` | Admin | Remove admin role from user |
+| DELETE | `/admin/users/{user_id}` | Admin | Permanently delete a user |
 
 ## Orbs (`/orbs`)
 
@@ -58,11 +71,22 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | DELETE | `/orbs/me/nodes/{uid}` | JWT | — | Delete node |
 | POST | `/orbs/me/link-skill` | JWT | — | Add `USED_SKILL` relationship |
 | POST | `/orbs/me/unlink-skill` | JWT | — | Remove `USED_SKILL` relationship |
-| POST | `/orbs/me/filter-token` | JWT | — | Generate shareable filter token (JWT with keyword exclusions) |
-| PUT | `/orbs/me/visibility` | JWT | — | Set orb visibility: `private` \| `public` \| `restricted` |
+| DELETE | `/orbs/me/content` | JWT | — | Discard all orb nodes/links (preserves account, CVs, drafts, snapshots) |
+| PUT | `/orbs/me/visibility` | JWT | — | Set orb visibility: `public` \| `restricted` |
+| PUT | `/orbs/me/public-filters` | JWT | — | Save global public-view privacy filters (`keywords`, `hidden_node_types`) |
+| GET | `/orbs/me/public-filters` | JWT | — | Retrieve saved public-view filters |
+| POST | `/orbs/me/share-tokens` | JWT | — | Create share token with optional keyword/hidden-type filters, label, and expiry |
+| GET | `/orbs/me/share-tokens` | JWT | — | List all share tokens (active + revoked) |
+| DELETE | `/orbs/me/share-tokens/{token_id}` | JWT | — | Revoke a share token |
 | POST | `/orbs/me/access-grants` | JWT | — | Grant a specific email access to a `restricted` orb (sends notification email) |
 | GET | `/orbs/me/access-grants` | JWT | — | List active access grants on current user's orb |
 | DELETE | `/orbs/me/access-grants/{grant_id}` | JWT | — | Revoke an access grant |
+| PUT | `/orbs/me/access-grants/{grant_id}/filters` | JWT | — | Update keyword/hidden-type filters for a specific access grant |
+| POST | `/orbs/{orb_id}/connection-requests` | JWT | — | Request access to a restricted orb |
+| GET | `/orbs/{orb_id}/connection-requests/me` | JWT | — | Check if current user has a pending request for this orb |
+| GET | `/orbs/me/connection-requests` | JWT | — | List pending connection requests on the current user's orb |
+| POST | `/orbs/me/connection-requests/{request_id}/accept` | JWT | — | Accept a connection request (creates AccessGrant with optional filters) |
+| POST | `/orbs/me/connection-requests/{request_id}/reject` | JWT | — | Reject a connection request |
 | GET | `/orbs/{orb_id}` | JWT optional | 30/min | Public orb view. `private` → 403; `public` → requires `?token=` share token; `restricted` → requires auth and email on allowlist (owner bypass) |
 
 ## CV (`/cv`)
@@ -78,6 +102,7 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | GET | `/cv/download` | JWT | Download the latest uploaded CV (backward compat, delegates to documents endpoint). |
 | GET | `/cv/processing-count` | No | Count of PDFs currently being processed. |
 | GET | `/cv/progress` | JWT | Real-time progress for current user's CV processing. |
+| POST | `/cv/progress/discard` | JWT | Discard in-progress CV processing. |
 
 ### CV Upload/Import Response
 
@@ -173,3 +198,20 @@ Query params: `?format=json|jsonld|pdf`, `?filter_token=`, `?filter_keyword=`, `
 | POST | `/search/semantic` | JWT | Vector similarity search across 5 Neo4j indexes |
 | POST | `/search/text` | JWT | Fuzzy text search on own orb |
 | POST | `/search/text/public` | No | Fuzzy text search on any public orb (supports `?filter_token=`) |
+
+## Drafts (`/drafts`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/drafts` | JWT | List all draft notes for current user |
+| POST | `/drafts` | JWT | Create a new draft note |
+| PUT | `/drafts/{uid}` | JWT | Update a draft note |
+| DELETE | `/drafts/{uid}` | JWT | Delete a draft note |
+
+## Ideas (`/ideas`)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/ideas` | JWT | Submit a feature idea / feedback |
+| GET | `/admin/ideas` | Admin | List all submitted ideas |
+| DELETE | `/admin/ideas/{idea_id}` | Admin | Delete an idea |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,15 +40,18 @@ Middleware stack (outermost first):
 
 | Module | Responsibility |
 |--------|---------------|
-| `auth/` | JWT creation/validation, dev-login flow, GDPR consent, account deletion |
+| `auth/` | JWT creation/validation, OAuth (Google/LinkedIn), GDPR consent, account deletion, MCP API keys, refresh tokens |
 | `cv/` | PDF text extraction, LLM classification with fallback chain, graph persistence |
 | `graph/` | Neo4j driver singleton, all Cypher queries, Fernet encryption, embedding generation |
-| `orbs/` | Graph CRUD (nodes, relationships, profile), filter token generation |
+| `orbs/` | Graph CRUD (nodes, relationships, profile), share tokens, access grants, connection requests, visibility management |
 | `messages/` | Inbox (send, list, reply, read, delete), welcome message on registration |
 | `notes/` | Free-text note enhancement via LLM (classify to node type + properties) |
 | `search/` | Vector similarity search (5 indexes) + fuzzy text search (Cypher + Python fallback) |
 | `export/` | Public orb export as JSON, JSON-LD (Schema.org), or PDF (fpdf2) |
-| `mcp_server/` | MCP server exposing 6 tools for AI agent access to orb data |
+| `drafts/` | Draft notes CRUD (create, list, update, delete) |
+| `ideas/` | Feature idea / feedback submission and admin listing |
+| `snapshots/` | Orb version snapshots (save, restore, delete, auto-create on CV import) |
+| `mcp_server/` | MCP server exposing 5 tools for AI agent access to orb data (API key auth) |
 
 ### Dependency Injection
 
@@ -90,7 +93,7 @@ POST /auth/dev-login
     └─ Return JWT (HS256, 24h expiry) with {sub: user_id, email}
 ```
 
-JWT validation on protected endpoints via `HTTPBearer` scheme. Filter tokens are a separate JWT type with no expiry, encoding `{orb_id, filters[], type: "filter"}`.
+JWT validation on protected endpoints via `HTTPBearer` scheme. Refresh tokens support token rotation — each refresh revokes the old token and issues a new pair.
 
 ### Encryption
 
@@ -100,11 +103,12 @@ Fernet symmetric encryption for PII fields (`email`, `phone`, `address`). Key fr
 
 ### State Management
 
-Four Zustand stores:
+Five Zustand stores:
 - **authStore** — user session, token (localStorage-backed), login/logout
 - **orbStore** — graph data (person + nodes + links), CRUD actions with automatic re-fetch
 - **filterStore** — keyword-based node filtering (persisted to localStorage)
 - **dateFilterStore** — date range slider state for temporal filtering
+- **undoStore** — undo/redo stack for graph mutations
 
 ### API Layer
 
@@ -124,11 +128,33 @@ Performance optimizations: shared geometry (never recreated), node object cache 
 |------|------|------|
 | `/` | LandingPage | Public |
 | `/auth/callback` | AuthCallbackPage | Public |
+| `/auth/linkedin/callback` | LinkedInCallbackPage | Public |
 | `/create` | CreateOrbPage | Required |
 | `/myorbis` | OrbViewPage | Required |
 | `/cv-export` | CvExportPage | Required |
+| `/privacy` | PrivacyPolicyPage | Public |
+| `/activate` | ActivatePage | Required (not activated) |
+| `/admin` | AdminPage | Required + is_admin |
 | `/:orbId` | SharedOrbPage | Public |
 
 ## MCP Server
 
-Separate process (`python -m mcp_server.server`) exposing 6 tools via streamable-http transport. Connects to Neo4j independently (own driver instance). Tools: `orbis_get_summary`, `orbis_get_full_orb`, `orbis_get_nodes_by_type`, `orbis_get_connections`, `orbis_get_skills_for_experience`, `orbis_send_message`.
+Separate process (`python -m mcp_server.server`) exposing 5 tools via streamable-http transport. Connects to Neo4j independently (own driver instance).
+
+### Authentication
+
+All MCP requests require an `X-MCP-Key` header containing a user-scoped API key (prefix `orbk_`). The `APIKeyMiddleware` validates the key by looking up its SHA-256 hash in Neo4j and resolves it to a `user_id`. Missing or invalid key returns 401 before reaching any tool.
+
+### Access Control
+
+MCP tools support a two-tiered access model:
+- **Owner bypass:** If the API key owner is the orb owner, full unfiltered access (no share token needed)
+- **Share-token grant:** Non-owners must provide a valid `token` parameter; privacy filters from the token are applied to the response
+
+### Tools
+
+- `orbis_get_summary` — high-level orb overview (node counts by type)
+- `orbis_get_full_orb` — full graph data (person + nodes + links)
+- `orbis_get_nodes_by_type` — nodes filtered by label
+- `orbis_get_connections` — relationships for a specific node
+- `orbis_get_skills_for_experience` — skills linked to a work experience/project via `USED_SKILL`

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,7 +18,7 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 | `scholar_url` | string | |
 | `website_url` | string | |
 | `open_to_work` | boolean | |
-| `visibility` | string | `private` (default) \| `public` \| `restricted` — gates `GET /orbs/{orb_id}` |
+| `visibility` | string | `restricted` (default) \| `public` — gates `GET /orbs/{orb_id}` |
 | `profile_image` | string | Base64 data URI |
 | `gdpr_consent` | boolean | |
 | `gdpr_consent_at` | string | ISO datetime |
@@ -56,7 +56,19 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 
 ### Patent
 
-`title`, `patent_number`, `filing_date`, `grant_date`, `status`, `description`, `url`, `uid`
+`title`, `patent_number`, `filing_date`, `grant_date`, `description`, `url`, `uid`
+
+### Award
+
+`name`, `issuer`, `date`, `description`, `uid`
+
+### Outreach
+
+`title`, `venue`, `date`, `description`, `url`, `uid`
+
+### Training
+
+`title`, `provider`, `date`, `description`, `url`, `uid`
 
 ### AccessGrant (restricted-mode allowlist)
 
@@ -73,6 +85,67 @@ Created when a user grants a specific email permission to view their orb while `
 
 Linked via `(Person)-[:GRANTED_ACCESS]->(AccessGrant)`. Parallel to `ShareToken` — share tokens gate `public` orbs, access grants gate `restricted` orbs.
 
+### ConnectionRequest (restricted-mode access request)
+
+Created when a user requests access to a restricted orb. The orb owner reviews and accepts (creating an AccessGrant) or rejects.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `request_id` | string | UUID |
+| `requester_user_id` | string | Requesting user's ID |
+| `requester_email` | string | Lowercase |
+| `requester_name` | string | |
+| `status` | string | `pending` / `accepted` / `rejected` |
+| `created_at` | datetime | |
+| `resolved_at` | datetime | Nullable — set on accept/reject |
+
+Linked via `(Person)-[:HAS_CONNECTION_REQUEST]->(ConnectionRequest)`.
+
+### LLMUsage (per-call usage tracking)
+
+Records every LLM invocation (CV extraction, note enhancement) for cost and token tracking.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `usage_id` | string | UUID |
+| `endpoint` | string | e.g. `/cv/upload`, `/notes/enhance` |
+| `llm_provider` | string | `claude`, `ollama`, `rule_based` |
+| `llm_model` | string | e.g. `claude-opus-4-6`, `llama3.2:3b` |
+| `input_tokens` | integer | Nullable |
+| `output_tokens` | integer | Nullable |
+| `total_tokens` | integer | Nullable (input + output) |
+| `cost_usd` | float | Nullable |
+| `duration_ms` | integer | Nullable |
+| `created_at` | datetime | |
+
+Linked via `(Person)-[:HAS_LLM_USAGE]->(LLMUsage)`.
+
+### RefreshToken
+
+Tracks JWT refresh tokens for token rotation. Old tokens are revoked on refresh.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `token_id` | string | UUID |
+| `hash` | string | SHA-256 of token |
+| `issued_at` | datetime | |
+| `expires_at` | datetime | |
+| `revoked` | boolean | |
+| `replaced_by` | string | Nullable — token_id of replacement |
+
+Linked via `(Person)-[:HAS_REFRESH_TOKEN]->(RefreshToken)`.
+
+### MCPApiKey
+
+API keys for MCP server authentication. Raw key returned once at creation; only the hash is persisted.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `key_id` | string | UUID |
+| `hash` | string | SHA-256 of API key (prefix `orbk_`) |
+
+Linked via `(Person)-[:HAS_MCP_API_KEY]->(MCPApiKey)`.
+
 ## Relationships
 
 | Relationship | From | To | Purpose |
@@ -85,7 +158,14 @@ Linked via `(Person)-[:GRANTED_ACCESS]->(AccessGrant)`. Parallel to `ShareToken`
 | `HAS_PUBLICATION` | Person | Publication | |
 | `HAS_PROJECT` | Person | Project | |
 | `HAS_PATENT` | Person | Patent | |
+| `HAS_AWARD` | Person | Award | |
+| `HAS_OUTREACH` | Person | Outreach | |
+| `HAS_TRAINING` | Person | Training | |
 | `GRANTED_ACCESS` | Person | AccessGrant | Allowlist entry for `restricted` orbs |
+| `HAS_CONNECTION_REQUEST` | Person | ConnectionRequest | Access request for `restricted` orbs |
+| `HAS_LLM_USAGE` | Person | LLMUsage | Per-call LLM cost/token tracking |
+| `HAS_REFRESH_TOKEN` | Person | RefreshToken | JWT refresh token tracking |
+| `HAS_MCP_API_KEY` | Person | MCPApiKey | MCP API key tracking |
 | `USED_SKILL` | WorkExperience / Project / Education / Publication | Skill | Cross-entity skill link |
 
 The `USED_SKILL` relationship is the key graph feature — it connects experience nodes directly to Skill nodes, enabling queries like "which skills were used at company X?"
@@ -104,16 +184,20 @@ Used during `POST /cv/confirm` with Cypher `MERGE`:
 | Publication | `title` |
 | Project | `name` |
 | Patent | `title` |
+| Award | `name` |
+| Outreach | `title`, `venue` |
+| Training | `title`, `provider` |
 
 ## Vector Indexes
 
-Five vector indexes for semantic search (1536 dimensions, cosine similarity):
+Six vector indexes for semantic search (1536 dimensions, cosine similarity):
 
 - `education_embedding`
 - `work_experience_embedding`
 - `certification_embedding`
 - `publication_embedding`
 - `project_embedding`
+- `training_embedding`
 
 Embeddings are currently placeholder (deterministic SHA-512 hash). The infrastructure is in place for real embeddings (OpenAI ada-002 or sentence-transformers).
 
@@ -251,6 +335,14 @@ Defined in `infra/neo4j/init.cypher`:
 - Uniqueness constraint on `ShareToken.token_id`
 - Uniqueness constraint on `AccessGrant.grant_id`
 - Index on `AccessGrant.email` and on `Person.visibility`
+- Uniqueness constraint on `LLMUsage.usage_id`
+- Index on `LLMUsage.endpoint`
+- Uniqueness constraint on `ConnectionRequest.request_id`
+- Index on `ConnectionRequest.status` and `ConnectionRequest.requester_user_id`
+- Uniqueness constraint on `RefreshToken.token_id`
+- Index on `RefreshToken.hash` and `RefreshToken.expires_at`
+- Uniqueness constraint on `MCPApiKey.key_id`
+- Index on `MCPApiKey.hash`
 
 ## Query Patterns
 

--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -2,7 +2,7 @@
 # Each entry defines a user action with its trigger, preconditions, effect, and next state.
 # Used by autonomous agents for end-to-end UX evaluation.
 #
-# Last updated: 2026-04-09 | Issue: #193, #216
+# Last updated: 2026-04-14 | Issue: #193, #216, #274
 
 # ── Landing Page ──
 
@@ -31,15 +31,6 @@
   preconditions: [authenticated]
   expected_effect: Navigates to /myorbis
   next_state: ORB_VIEW
-  fallback_on_failure: null
-
-- id: LANDING_ABOUT
-  from_state: LANDING
-  action: Click About link
-  selector_or_control: "footer or header About link"
-  preconditions: []
-  expected_effect: Navigates to /about
-  next_state: ABOUT
   fallback_on_failure: null
 
 - id: LANDING_PRIVACY

--- a/docs/navigation-flow.md
+++ b/docs/navigation-flow.md
@@ -2,7 +2,7 @@
 
 > Navigable user-flow map for agent-based UX evaluation. Covers all pages, modals, interactions, guards, and error states.
 >
-> **Last updated:** 2026-04-09 | **Issue:** #193
+> **Last updated:** 2026-04-14 | **Issue:** #193, #274
 
 ## How to Update This Map
 
@@ -32,7 +32,6 @@ stateDiagram-v2
     state "Orb View (/myorbis)" as ORB_VIEW
     state "Shared Orb (/:orbId)" as SHARED_ORB
     state "CV Export (/cv-export)" as CV_EXPORT
-    state "About (/about)" as ABOUT
     state "Privacy (/privacy)" as PRIVACY
     state "Activate (/activate)" as ACTIVATION
     state "Admin Dashboard (/admin)" as ADMIN
@@ -76,7 +75,6 @@ stateDiagram-v2
     ORB_VIEW --> LANDING: Sign out
 
     %% ── Public pages ──
-    LANDING --> ABOUT: About link
     LANDING --> PRIVACY: Privacy link
     LANDING --> SHARED_ORB: Public orb link
     SHARED_ORB --> LANDING: "Create your own Orbis" CTA
@@ -199,7 +197,6 @@ flowchart TD
 | `CV_EXPORT` | `/cv-export` | Yes | PDF CV generation and preview |
 | `ACTIVATION` | `/activate` | Yes (not activated) | Invite code input page for closed beta. Blocks platform access until valid code entered. Admins bypass. |
 | `ADMIN` | `/admin` | Yes + is_admin | Admin dashboard: invite codes, pending users, beta config toggle |
-| `ABOUT` | `/about` | No | About page |
 | `PRIVACY` | `/privacy` | No | Privacy policy |
 | `CONSENT_GATE` | (overlay) | Yes | GDPR consent checkbox |
 | `FLOATING_INPUT` | (modal on ORB_VIEW) | Yes | Add/edit node form |


### PR DESCRIPTION
## Summary
Full audit of `docs/` against current codebase to close #274. Every doc file reviewed and updated where stale.

### docs/api.md
- Added 30+ missing endpoints: auth (refresh, logout, waitlist, API keys), orbs (connection requests, share tokens, public-filters, content discard, access-grant filters), CV (progress/discard), admin (user management), drafts CRUD, ideas
- Replaced stale `POST /orbs/me/filter-token` with new share-token endpoints
- Added LLM usage fields to admin insights note

### docs/database.md
- Added 7 missing node types: `LLMUsage`, `ConnectionRequest`, `RefreshToken`, `MCPApiKey`, `Award`, `Outreach`, `Training`
- Added corresponding relationships, deduplication keys, constraints/indexes
- Added `training_embedding` vector index (5 → 6 total)
- Fixed `Patent` properties (removed nonexistent `status`), fixed Person default visibility

### docs/architecture.md
- Updated MCP server: 6 → 5 tools, removed `orbis_send_message`, documented API key auth (`X-MCP-Key`), access control model (owner bypass + share-token grant)
- Added missing modules: `drafts/`, `ideas/`, `snapshots/`
- Updated orbs module description (share tokens, access grants, connection requests)
- Fixed Zustand stores count (4 → 5, added `undoStore`)
- Added missing routes (`/privacy`, `/activate`, `/admin`, LinkedIn callback)
- Removed stale filter-token JWT reference

### docs/navigation-flow.md & navigation-actions.yaml
- Removed deleted `/about` page (state, transitions, action entry)
- Updated timestamps

### CLAUDE.md
- Updated repo layout: new backend modules (`drafts/`, `ideas/`, `snapshots/`), updated `auth/`, `graph/`, `orbs/`, `mcp_server/` descriptions
- Updated pages list (removed About, added AuthCallback/LinkedInCallback)
- Updated stores list (added undo)
- Updated component dirs (added `layout/`, `profile/`, `sharing/`)
- Added MCP API key convention
- Added `llm-provider-benchmark.md` and `invitation-system.md` to docs index

## Test plan
- [x] Backend ruff check: all passed
- [x] Frontend ESLint: 0 errors
- [ ] Manual review of each doc for accuracy

## Documentation
This PR _is_ the documentation update for #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)