### PR TITLE
feat: auto-join waitlist on signup and add account removal on activate

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -494,7 +494,11 @@ async def delete_me(
     now = datetime.now(timezone.utc).isoformat()
     async with db.session() as session:
         await session.run(
-            "MATCH (p:Person {user_id: $user_id}) SET p.deletion_requested_at = $now",
+            "MATCH (p:Person {user_id: $user_id}) "
+            "SET p.deletion_requested_at = $now, "
+            "    p.waitlist_joined = false, "
+            "    p.waitlist_joined_at = null, "
+            "    p.updated_at = datetime()",
             user_id=current_user["user_id"],
             now=now,
         )

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -11,8 +11,8 @@ CREATE (p:Person {
     picture: $picture,
     provider: $provider,
     signup_code: $signup_code,
-    waitlist_joined: false,
-    waitlist_joined_at: null,
+    waitlist_joined: true,
+    waitlist_joined_at: datetime(),
     is_admin: false,
     headline: '',
     location: '',
@@ -303,7 +303,7 @@ RETURN
 """
 
 # Pending users: registered but not yet activated (no signup_code, not admin),
-# and explicitly opted into the waitlist via CTA.
+# and currently marked as joined to the waitlist.
 
 LIST_PENDING_PERSONS = """
 MATCH (p:Person)

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -259,6 +259,18 @@ def test_join_waitlist_returns_404_when_user_missing(client, mock_db):
     assert response.json()["detail"] == "User not found"
 
 
+def test_delete_me_also_clears_waitlist_flags(client, mock_db):
+    with patch("app.auth.router.revoke_all_for_user", AsyncMock(return_value=None)):
+        response = client.delete("/auth/me")
+
+    assert response.status_code == 200
+    run_mock = mock_db.session.return_value.__aenter__.return_value.run
+    called_query = run_mock.await_args.args[0]
+    assert "p.deletion_requested_at = $now" in called_query
+    assert "p.waitlist_joined = false" in called_query
+    assert "p.waitlist_joined_at = null" in called_query
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Admin endpoints
 # ─────────────────────────────────────────────────────────────────────────

--- a/backend/tests/unit/test_queries.py
+++ b/backend/tests/unit/test_queries.py
@@ -131,6 +131,10 @@ class TestQueryTemplates:
         assert "$name" in CREATE_PERSON
         assert "$orb_id" in CREATE_PERSON
 
+    def test_create_person_auto_joins_waitlist(self):
+        assert "waitlist_joined: true" in CREATE_PERSON
+        assert "waitlist_joined_at: datetime()" in CREATE_PERSON
+
     def test_get_person_by_user_id(self):
         assert "$user_id" in GET_PERSON_BY_USER_ID
 

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -159,7 +159,7 @@ export default function ActivatePage() {
               You&apos;ve been automatically added to the waiting list. We&apos;ll notify you when your account is activated.
             </p>
 
-            <div className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/35 bg-emerald-500/12 px-3.5 py-2.5">
+            <div className="w-full flex items-center justify-center gap-2 rounded-xl border border-emerald-400/35 bg-emerald-500/12 px-3.5 py-2.5">
               <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_10px_rgba(52,211,153,0.8)]" />
               <span className="text-emerald-100 text-sm font-medium">You&apos;re on the waiting list</span>
             </div>

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import axios from 'axios';
-import { activateAccount, getMe, joinWaitlist } from '../api/auth';
+import { activateAccount, deleteAccount, getMe } from '../api/auth';
 import { useAuthStore } from '../stores/authStore';
 import { hasOrbContent } from '../api/orbs';
 
@@ -18,14 +18,9 @@ export default function ActivatePage() {
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [joiningWaitlist, setJoiningWaitlist] = useState(false);
-  const [joinedWaitlist, setJoinedWaitlist] = useState<boolean>(Boolean(user?.waitlist_joined));
-  const [waitlistError, setWaitlistError] = useState<string | null>(null);
+  const [deletingAccount, setDeletingAccount] = useState(false);
+  const [accountRemovalError, setAccountRemovalError] = useState<string | null>(null);
   const navigatingRef = useRef(false);
-
-  useEffect(() => {
-    setJoinedWaitlist(Boolean(user?.waitlist_joined));
-  }, [user?.waitlist_joined]);
 
   const goToApp = useCallback(async () => {
     if (navigatingRef.current) return;
@@ -72,18 +67,17 @@ export default function ActivatePage() {
     navigate('/', { replace: true });
   };
 
-  const handleJoinWaitlist = async () => {
-    if (joinedWaitlist || joiningWaitlist) return;
-    setWaitlistError(null);
-    setJoiningWaitlist(true);
+  const handleRemoveWaitlistAndDelete = async () => {
+    if (deletingAccount) return;
+    setAccountRemovalError(null);
+    setDeletingAccount(true);
     try {
-      await joinWaitlist();
-      setJoinedWaitlist(true);
-      await fetchUser();
+      await deleteAccount();
+      await logout();
+      navigate('/', { replace: true });
     } catch {
-      setWaitlistError('Could not join the waiting list. Please try again.');
-    } finally {
-      setJoiningWaitlist(false);
+      setAccountRemovalError('Could not remove your account right now. Please try again.');
+      setDeletingAccount(false);
     }
   };
 
@@ -150,7 +144,7 @@ export default function ActivatePage() {
           </motion.div>
         )}
 
-        {/* Waitlist opt-in */}
+        {/* Waitlist status */}
         <div className="relative overflow-hidden rounded-2xl border border-white/[0.09] bg-gradient-to-br from-white/[0.06] via-white/[0.03] to-transparent px-5 py-5 mb-5 text-left backdrop-blur-sm">
           <div className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-emerald-400/10 blur-2xl" />
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.12),transparent_45%)]" />
@@ -162,27 +156,25 @@ export default function ActivatePage() {
             </div>
 
             <p className="text-white/70 text-sm leading-relaxed mb-4">
-              Don&apos;t have a code yet? Join the waiting list and we&apos;ll contact you as soon as access opens.
+              You&apos;ve been automatically added to the waiting list. We&apos;ll notify you when your account is activated.
             </p>
 
-            {joinedWaitlist ? (
-              <div className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/35 bg-emerald-500/12 px-3.5 py-2.5">
-                <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_10px_rgba(52,211,153,0.8)]" />
-                <span className="text-emerald-100 text-sm font-medium">You&apos;re on the waiting list</span>
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={handleJoinWaitlist}
-                disabled={joiningWaitlist}
-                className="w-full flex items-center justify-center rounded-xl border border-emerald-300/35 bg-gradient-to-r from-emerald-500 to-emerald-400 hover:from-emerald-400 hover:to-emerald-300 disabled:opacity-50 disabled:cursor-not-allowed text-emerald-950 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(16,185,129,0.9)] transition-all"
-              >
-                {joiningWaitlist ? 'Joining...' : 'Join waiting list'}
-              </button>
-            )}
+            <div className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/35 bg-emerald-500/12 px-3.5 py-2.5">
+              <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_10px_rgba(52,211,153,0.8)]" />
+              <span className="text-emerald-100 text-sm font-medium">You&apos;re on the waiting list</span>
+            </div>
 
-            {waitlistError && (
-              <p className="text-amber-300/90 text-xs mt-3">{waitlistError}</p>
+            <button
+              type="button"
+              onClick={handleRemoveWaitlistAndDelete}
+              disabled={deletingAccount}
+              className="w-full mt-4 flex items-center justify-center rounded-xl border border-red-300/35 bg-gradient-to-r from-red-500/90 to-orange-500/90 hover:from-red-400 hover:to-orange-400 disabled:opacity-50 disabled:cursor-not-allowed text-red-50 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(248,113,113,0.9)] transition-all"
+            >
+              {deletingAccount ? 'Removing and deleting...' : 'Remove from waitlist and delete my account'}
+            </button>
+
+            {accountRemovalError && (
+              <p className="text-amber-300/90 text-xs mt-3">{accountRemovalError}</p>
             )}
           </div>
         </div>

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -152,7 +152,7 @@ export default function ActivatePage() {
           <div className="relative z-10">
             <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 mb-3">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" />
-              <span className="text-[10px] font-semibold tracking-[0.14em] text-white/65">WAITLIST</span>
+              <span className="text-[10px] font-semibold tracking-[0.14em] text-white/65">Waiting List</span>
             </div>
 
             <p className="text-white/70 text-sm leading-relaxed mb-4">


### PR DESCRIPTION
## Summary
- auto-join new users to the waitlist at signup by setting waitlist_joined and waitlist_joined_at in CREATE_PERSON
- update /auth/me deletion flow to clear waitlist flags when scheduling account deletion
- replace Activate page waitlist opt-in CTA with an informational message and a new Remove from waitlist and delete my account action
- add backend tests for query defaults and delete behavior

## Validation
- /Users/alessandro/orb_project/backend/.venv/bin/pytest -q backend/tests/unit/test_invitation_system.py backend/tests/unit/test_queries.py
- npm -C frontend run lint -- src/pages/ActivatePage.tsx

Closes #327