### PR TITLE
fix(auth): suppress false session-expired toast + waitlist typo

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -34,8 +34,10 @@ client.interceptors.response.use(
     }
 
     // Never try to refresh from within /auth/* — infinite loop risk.
+    // /auth/me is also excluded: a 401 on the initial session probe simply
+    // means the user is not logged in, not that a session expired.
     const url = original.url || '';
-    if (url.startsWith('/auth/refresh') || url.startsWith('/auth/logout')) {
+    if (url.startsWith('/auth/refresh') || url.startsWith('/auth/logout') || url.startsWith('/auth/me')) {
       return Promise.reject(error);
     }
 

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -191,7 +191,7 @@ export default function ActivatePage() {
               disabled={deletingAccount}
               className="w-full mt-4 flex items-center justify-center rounded-xl border border-red-300/35 bg-gradient-to-r from-red-500/90 to-orange-500/90 hover:from-red-400 hover:to-orange-400 disabled:opacity-50 disabled:cursor-not-allowed text-red-50 text-sm font-semibold px-5 py-2.5 shadow-[0_10px_28px_-14px_rgba(248,113,113,0.9)] transition-all"
             >
-              {deletingAccount ? 'Removing and deleting...' : 'Remove from waitlist and delete my account'}
+              {deletingAccount ? 'Removing and deleting...' : 'Remove from waiting list and delete my account'}
             </button>
 
             {accountRemovalError && (


### PR DESCRIPTION
## Summary
- **Fix login loop in production**: the axios interceptor was treating the initial `/auth/me` 401 (user not logged in) as a session expiry, dispatching `orbis:session-expired` which called `logout()` + redirect to `/`. This caused a race condition where logging in via Google would succeed but immediately get overridden by the stale 401 handler, sending the user back to the landing page. Fix: exclude `/auth/me` from the refresh+toast interceptor logic.
- **Fix typo**: "Remove from waitlist" → "Remove from waiting list" in ActivatePage button text.

## Test plan
- [x] Open landing page without being logged in — no toast appears
- [ ] Log in via Google — should navigate to `/myorbis` or `/create` without looping back to landing
- [ ] Leave tab idle for 15+ min, then interact — refresh flow should still work and show toast only on genuine expiry

## Documentation
No doc changes needed