### PR TITLE
fix(ci): add --suppress-logs to Cloud Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,8 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           gcloud builds submit backend/ \
             --tag "$IMAGE" \
-            --project="$PROJECT_ID"
+            --project="$PROJECT_ID" \
+            --suppress-logs
 
   build-mcp:
     name: Build MCP Image
@@ -82,7 +83,8 @@ jobs:
           gcloud builds submit backend/ \
             --config=backend/cloudbuild.mcp.yaml \
             --substitutions="_IMAGE=$MCP_IMAGE" \
-            --project="$PROJECT_ID"
+            --project="$PROJECT_ID" \
+            --suppress-logs
 
   build-frontend:
     name: Build Frontend


### PR DESCRIPTION
## Summary

- Fix backend and MCP image builds failing in CI due to Cloud Build log streaming permissions

## Problem

The CI service account cannot stream logs from Cloud Build's default logs bucket (requires Viewer/Owner role on the project). `gcloud builds submit` fails with exit code 1 even though the Docker build itself succeeds on Cloud Build.

## Fix

Add `--suppress-logs` flag to both `gcloud builds submit` calls. This skips log streaming while still waiting for the build to complete and returning the correct exit code.

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)