### PR TITLE
fix(ci): sequential Cloud Build to avoid rate limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
 
   build-mcp:
     name: Build MCP Image
+    needs: [build-backend]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Run `build-mcp` after `build-backend` instead of in parallel to stay under Cloud Build's 60 GetRequests/min project quota.

## Problem

Cloud Build polls build status ~1/sec. Two parallel builds = ~180 requests/min, exceeding the 60/min quota → rate limit error on both jobs.

## Fix

Add `needs: [build-backend]` to `build-mcp`. `build-frontend` still runs in parallel (uses npm, not Cloud Build).

```
build-backend ──→ build-mcp ──┐
build-frontend ────────────────┼──→ deploy
```

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)