### PR TITLE
fix(ci): rename --startup-cpu-boost to --cpu-boost

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,7 +225,7 @@ jobs:
             --max-instances=10 \
             --timeout=300s \
             --allow-unauthenticated \
-            --startup-cpu-boost \
+            --cpu-boost \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest,RESEND_API_KEY=resend-api-key:latest,GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,LINKEDIN_CLIENT_ID=linkedin-client-id:latest,LINKEDIN_CLIENT_SECRET=linkedin-client-secret:latest" \
             --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,LLM_PROVIDER=vertex,LLM_FALLBACK_CHAIN=$FALLBACK_CHAIN,GEMINI_MODEL=gemini-2.5-pro,GCP_PROJECT_ID=$PROJECT_ID,VERTEX_REGION=$REGION,CV_STORAGE_BUCKET=$GCS_BUCKET,FRONTEND_URL=https://open-orbis.com,COOKIE_DOMAIN=.open-orbis.com,LINKEDIN_REDIRECT_URI=https://open-orbis.com/auth/linkedin/callback,CLOUD_TASKS_QUEUE=orbis-cv-queue,CLOUD_TASKS_LOCATION=$REGION,CLOUD_RUN_URL=$CLOUD_RUN_URL,CLOUD_RUN_SERVICE_ACCOUNT=$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com"
 


### PR DESCRIPTION
## Summary

Fix `gcloud run deploy` failing with `unrecognized arguments: --startup-cpu-boost (did you mean '--cpu-boost'?)`.

The correct flag name is `--cpu-boost`, not `--startup-cpu-boost`.

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)