### PR TITLE
fix(ci): Artifact Registry permissions + Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,9 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# Opt into Node.js 24 for all GitHub Actions (avoids deprecation warnings)
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PROJECT_ID: open-orbis
   REGION: europe-west1
   BACKEND_SERVICE: orbis-api


### PR DESCRIPTION
## Summary

- Fix deploy failing with `PERMISSION_DENIED: artifactregistry.repositories.downloadArtifacts`
- Suppress Node.js 20 deprecation warnings

## Fixes

### Artifact Registry permissions (applied via gcloud, already active)
- Added `roles/artifactregistry.reader` to `github-deploy` SA (so `gcloud run deploy` can validate the image)
- Added `roles/artifactregistry.reader` to Cloud Run service agent (so Cloud Run can pull the image)

### Node.js 24
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as workflow env var

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)