### PR TITLE
fix(mcp): bind to 0.0.0.0:PORT for Cloud Run

### DIFF
--- a/backend/Dockerfile.mcp
+++ b/backend/Dockerfile.mcp
@@ -11,9 +11,8 @@ COPY app/ app/
 COPY mcp_server/ mcp_server/
 ENV PATH="/app/.venv/bin:$PATH"
 # Cloud Run sends traffic to PORT (default 8080).
-# FastMCP reads host/port from FASTMCP_HOST / FASTMCP_PORT.
+# server.py reads HOST/PORT env vars directly for uvicorn.
+ENV HOST=0.0.0.0
 ENV PORT=8080
-ENV FASTMCP_HOST=0.0.0.0
-ENV FASTMCP_PORT=8080
 EXPOSE 8080
 CMD ["python", "-m", "mcp_server.server"]

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -92,10 +92,12 @@ if __name__ == "__main__":
     # Serve the middleware-wrapped app directly via uvicorn so the auth
     # layer runs on every request. mcp.run(transport="streamable-http")
     # would bypass our add_middleware() call.
+    import os
+
     import uvicorn
 
     uvicorn.run(
         _build_starlette_app(),
-        host=mcp.settings.host,
-        port=mcp.settings.port,
+        host=os.environ.get("HOST", "0.0.0.0"),
+        port=int(os.environ.get("PORT", "8080")),
     )


### PR DESCRIPTION
## Summary

Fix MCP server container failing to start on Cloud Run — was listening on `127.0.0.1:8000` instead of `0.0.0.0:8080`.

## Problem

Cloud Run logs showed:
```
Uvicorn running on http://127.0.0.1:8000
Default STARTUP TCP probe failed for container on port 8080
```

`FASTMCP_HOST`/`FASTMCP_PORT` env vars in Dockerfile were not being picked up by FastMCP's pydantic-settings due to conflicts with the app's own settings.

## Fix

Read `HOST` and `PORT` env vars directly in `server.py` and pass them to uvicorn, bypassing FastMCP settings. Dockerfile sets `HOST=0.0.0.0` and `PORT=8080`.

## Documentation

No doc changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)