### PR TITLE
fix(ci): force traffic routing after Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,6 +231,23 @@ jobs:
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest,RESEND_API_KEY=resend-api-key:latest,GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,LINKEDIN_CLIENT_ID=linkedin-client-id:latest,LINKEDIN_CLIENT_SECRET=linkedin-client-secret:latest" \
             --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,LLM_PROVIDER=vertex,LLM_FALLBACK_CHAIN=$FALLBACK_CHAIN,GEMINI_MODEL=gemini-2.5-pro,GCP_PROJECT_ID=$PROJECT_ID,VERTEX_REGION=$REGION,CV_STORAGE_BUCKET=$GCS_BUCKET,FRONTEND_URL=https://open-orbis.com,COOKIE_DOMAIN=.open-orbis.com,LINKEDIN_REDIRECT_URI=https://open-orbis.com/auth/linkedin/callback,CLOUD_TASKS_QUEUE=orbis-cv-queue,CLOUD_TASKS_LOCATION=$REGION,CLOUD_RUN_URL=$CLOUD_RUN_URL,CLOUD_RUN_SERVICE_ACCOUNT=$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com"
 
+      - name: Ensure backend traffic routes to new revision
+        run: |
+          NEW_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.latestCreatedRevisionName)")
+          SERVING_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.traffic[0].revisionName)")
+          if [ "$NEW_REV" != "$SERVING_REV" ]; then
+            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV"
+            gcloud run services update-traffic "$BACKEND_SERVICE" \
+              --region="$REGION" --project="$PROJECT_ID" \
+              --to-revisions="$NEW_REV=100"
+          else
+            echo "Traffic correctly routing to $NEW_REV"
+          fi
+
       - name: Mark backend deployed
         id: backend-done
         run: echo "done=true" >> "$GITHUB_OUTPUT"
@@ -255,6 +272,23 @@ jobs:
             --no-allow-unauthenticated \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest" \
             --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID"
+
+      - name: Ensure MCP traffic routes to new revision
+        run: |
+          NEW_REV=$(gcloud run services describe "$MCP_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.latestCreatedRevisionName)")
+          SERVING_REV=$(gcloud run services describe "$MCP_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.traffic[0].revisionName)")
+          if [ "$NEW_REV" != "$SERVING_REV" ]; then
+            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV"
+            gcloud run services update-traffic "$MCP_SERVICE" \
+              --region="$REGION" --project="$PROJECT_ID" \
+              --to-revisions="$NEW_REV=100"
+          else
+            echo "Traffic correctly routing to $NEW_REV"
+          fi
 
       - name: Mark MCP deployed
         id: mcp-done


### PR DESCRIPTION
## Summary
- `gcloud run deploy` can create a new revision successfully (exit 0) but silently fail to route traffic to it. This caused the alpha.1 and alpha.2 deploys to leave traffic on an old revision.
- Adds explicit traffic verification after each Cloud Run deploy (backend + MCP). If the serving revision doesn't match the latest created revision, force-routes with `update-traffic`.

## Test plan
- [ ] Merge and create a release to trigger deploy
- [ ] Verify in CI logs that the traffic check step runs
- [ ] Confirm the new revision is actually serving after deploy

## Documentation
No doc changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)