### PR TITLE
fix(ui): mobile layout for landing features and orb chatbox

### DIFF
--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -259,7 +259,7 @@ export default function ChatBox({
     <div
       data-tour="chatbox"
       ref={containerRef}
-      className="fixed bottom-0 left-1/2 -translate-x-1/2 z-40 w-full max-w-[90vw] sm:max-w-xl px-2 sm:px-4 pb-6 sm:pb-10"
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 z-40 w-full px-3 sm:px-4 sm:max-w-xl pb-4 sm:pb-10"
       onClick={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
@@ -413,8 +413,8 @@ export default function ChatBox({
         </div>
       )}
 
-      {/* Feedback button above chatbox */}
-      <div className="flex justify-center mb-1.5">
+      {/* Feedback button above chatbox — hidden on mobile to avoid overlap with Orbis Pulse */}
+      <div className="hidden sm:flex justify-center mb-1.5">
         <button
           type="button"
           onClick={() => { if (!feedbackSent) setShowFeedback(true); }}
@@ -429,12 +429,12 @@ export default function ChatBox({
       </div>
 
       {/* Bottom bar — discover + recenter + chat input + action buttons */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5 sm:gap-2">
         {onDiscover && (
           <button
             type="button"
             onClick={onDiscover}
-            className="w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 hover:border-yellow-400/50 text-yellow-400 hover:text-yellow-300 transition-all backdrop-blur-sm flex-shrink-0 shadow-lg shadow-yellow-600/10"
+            className="w-8 h-8 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-yellow-500/20 hover:bg-yellow-500/30 border border-yellow-500/30 hover:border-yellow-400/50 text-yellow-400 hover:text-yellow-300 transition-all backdrop-blur-sm flex-shrink-0 shadow-lg shadow-yellow-600/10"
             title="Discover uses"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -446,7 +446,7 @@ export default function ChatBox({
           <button
             type="button"
             onClick={onRecenter}
-            className="w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-white/10 hover:bg-white/20 border border-white/15 hover:border-white/25 text-white/50 hover:text-white transition-all backdrop-blur-sm flex-shrink-0"
+            className="w-8 h-8 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-white/10 hover:bg-white/20 border border-white/15 hover:border-white/25 text-white/50 hover:text-white transition-all backdrop-blur-sm flex-shrink-0"
             title="Recenter graph"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -457,7 +457,7 @@ export default function ChatBox({
         {/* Chat input */}
         <form onSubmit={handleSubmit} className="flex-1">
           <div
-            className="flex items-center gap-2 sm:gap-3 rounded-full px-3 sm:px-5 py-2.5 sm:py-3 backdrop-blur-md shadow-lg"
+            className="flex items-center gap-2 sm:gap-3 rounded-full px-2.5 sm:px-5 py-2 sm:py-3 backdrop-blur-md shadow-lg"
             style={{
               backgroundColor: 'rgba(255,255,255,0.12)',
               border: '1px solid rgba(255,255,255,0.15)',
@@ -497,7 +497,7 @@ export default function ChatBox({
               <button
                 data-tour="visibility"
                 onClick={onShare}
-                className={`w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center border text-white/90 hover:text-white transition-all shadow-lg ${shareButtonClass}`}
+                className={`w-8 h-8 sm:w-11 sm:h-11 rounded-full flex items-center justify-center border text-white/90 hover:text-white transition-all shadow-lg ${shareButtonClass}`}
                 title="Share"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -509,7 +509,7 @@ export default function ChatBox({
               <button
                 data-tour="add-entry"
                 onClick={onAdd}
-                className={`w-9 h-9 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-purple-600 hover:bg-purple-500 text-white transition-all shadow-lg shadow-purple-600/30 hover:shadow-purple-500/40 ${highlightAdd ? 'animate-pulse ring-2 ring-purple-400 ring-offset-2 ring-offset-black' : ''}`}
+                className={`w-8 h-8 sm:w-11 sm:h-11 rounded-full flex items-center justify-center bg-purple-600 hover:bg-purple-500 text-white transition-all shadow-lg shadow-purple-600/30 hover:shadow-purple-500/40 ${highlightAdd ? 'animate-pulse ring-2 ring-purple-400 ring-offset-2 ring-offset-black' : ''}`}
                 title="Add Entry"
               >
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -520,7 +520,7 @@ export default function ChatBox({
           </div>
         )}
       </div>
-      <p className="mt-2 text-center text-[11px] text-white/35">
+      <p className="mt-2 text-center text-[11px] text-white/35 hidden sm:block">
         {interactionHint}
       </p>
 

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -180,7 +180,7 @@ export default function OrbisStatsOverlay({
     <div
       ref={containerRef}
       data-tour="orbis-pulse"
-      className="pointer-events-none fixed right-4 bottom-24 z-20 sm:right-6 sm:bottom-8"
+      className="pointer-events-none fixed right-4 bottom-32 z-20 sm:right-6 sm:bottom-8"
     >
       {isCompact ? (
         <div className="flex flex-col items-end gap-2">

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -58,37 +58,46 @@ function FeatureRow({ side, color, colorName, icon, title, description }: {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-40px' });
 
-  const iconEl = (
+  const iconBlock = (
     <div className="flex items-center justify-center">
       <div
-        className="w-20 h-20 sm:w-36 sm:h-36 rounded-2xl sm:rounded-3xl flex items-center justify-center relative"
+        className="w-24 h-24 sm:w-36 sm:h-36 rounded-2xl sm:rounded-3xl flex items-center justify-center relative"
         style={{ background: `linear-gradient(135deg, ${color}20, ${color}08)`, border: `1px solid ${color}25` }}
       >
         <div className="absolute inset-0 rounded-3xl blur-[40px] opacity-30" style={{ backgroundColor: color }} />
-        <svg className={`w-8 h-8 sm:w-16 sm:h-16 text-${colorName}-400 relative z-10`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className={`w-10 h-10 sm:w-16 sm:h-16 text-${colorName}-400 relative z-10`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
           {icon}
         </svg>
       </div>
     </div>
   );
 
-  const textEl = (
+  const textBlock = (
     <div className={`flex flex-col justify-center text-center sm:text-left ${side === 'left' ? 'sm:pl-8' : 'sm:pr-8 sm:text-right'}`}>
       <h3 className="text-white text-xl sm:text-2xl font-bold mb-3">{title}</h3>
       <p className="text-white/40 text-sm sm:text-base leading-relaxed max-w-md mx-auto sm:mx-0">{description}</p>
     </div>
   );
 
-  // Single container: column on mobile, 2-col grid on desktop
+  // Mobile: icon + title + description grouped as one unit
+  // Desktop: 2-col grid with alternating icon/text sides
   return (
     <motion.div
       ref={ref}
       initial={{ opacity: 0, y: 30 }}
       animate={isInView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.7, ease: 'easeOut' }}
-      className={`flex flex-col items-center gap-4 sm:grid sm:grid-cols-2 sm:gap-16 sm:items-center ${side === 'right' ? 'sm:direction-rtl' : ''}`}
     >
-      {side === 'left' ? <>{iconEl}{textEl}</> : <>{textEl}{iconEl}</>}
+      {/* Mobile layout */}
+      <div className="flex flex-col items-center gap-2 sm:hidden">
+        {iconBlock}
+        <h3 className="text-white text-xl font-bold">{title}</h3>
+        <p className="text-white/40 text-sm leading-relaxed max-w-md text-center">{description}</p>
+      </div>
+      {/* Desktop layout */}
+      <div className={`hidden sm:grid sm:grid-cols-2 sm:gap-16 sm:items-center ${side === 'right' ? 'sm:direction-rtl' : ''}`}>
+        {side === 'left' ? <>{iconBlock}{textBlock}</> : <>{textBlock}{iconBlock}</>}
+      </div>
     </motion.div>
   );
 }
@@ -381,7 +390,7 @@ export default function LandingPage() {
             </h2>
           </FadeIn>
 
-          <div className="space-y-16 sm:space-y-32">
+          <div className="space-y-10 sm:space-y-32">
             {/* 1 — Left */}
             <FeatureRow side="left" color="#f59e0b" colorName="amber"
               icon={<><circle cx="12" cy="12" r="2.5" strokeWidth={1.5} /><circle cx="4" cy="6" r="1.5" strokeWidth={1.5} /><circle cx="20" cy="6" r="1.5" strokeWidth={1.5} /><circle cx="4" cy="18" r="1.5" strokeWidth={1.5} /><circle cx="20" cy="18" r="1.5" strokeWidth={1.5} /><circle cx="12" cy="2.5" r="1.5" strokeWidth={1.5} /><line x1="10" y1="10.5" x2="5.2" y2="7" strokeWidth={1.5} strokeLinecap="round" /><line x1="14" y1="10.5" x2="18.8" y2="7" strokeWidth={1.5} strokeLinecap="round" /><line x1="10" y1="13.5" x2="5.2" y2="17" strokeWidth={1.5} strokeLinecap="round" /><line x1="14" y1="13.5" x2="18.8" y2="17" strokeWidth={1.5} strokeLinecap="round" /><line x1="12" y1="9.5" x2="12" y2="4" strokeWidth={1.5} strokeLinecap="round" /></>}


### PR DESCRIPTION
## Summary
- **Landing page features (#348):** on mobile, each feature now renders as a cohesive icon → title → description unit with larger icons (96px) and tighter spacing between items
- **Chatbox bottom bar:** shrink action buttons (36px → 32px) and remove `max-w-[90vw]` so the "+" add button no longer clips off-screen on mobile
- **Orbis Pulse:** repositioned higher on mobile (`bottom-32`) to avoid overlapping the chatbox
- **Declutter mobile:** hide "Send Feedback" and mouse/drag interaction hint (irrelevant for touch)

Desktop layout is unchanged across all components.

Closes #348

## Test plan
- [ ] Mobile (390px): verify all 4 landing page features show icon → title → description vertically
- [ ] Mobile (390px): verify all chatbox buttons (discover, recenter, search, share, +) are fully visible
- [ ] Mobile (390px): verify Orbis Pulse button does not overlap the chatbox
- [ ] Desktop (1280px): verify landing page features still use 2-column alternating layout
- [ ] Desktop (1280px): verify chatbox shows Send Feedback, interaction hint, and full-size buttons

## Documentation
No doc changes needed — purely cosmetic mobile layout fixes.