### PR TITLE
feat(ui): add Privacy Policy link to account settings

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -500,6 +500,18 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
                 </svg>
                 Guided tour
               </button>
+              <button
+                onClick={() => {
+                  onClose();
+                  navigate('/privacy');
+                }}
+                className="flex items-center gap-2.5 text-left px-3 py-2.5 rounded-lg text-sm text-white/40 hover:text-white/70 hover:bg-white/5 transition-colors cursor-pointer w-full"
+              >
+                <svg className="w-4 h-4 text-purple-400/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+                </svg>
+                Privacy Policy
+              </button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Adds a "Privacy Policy" link to the Account Settings modal sidebar, below "Guided tour"
- Clicking it closes the modal and navigates to `/privacy`
- Styled consistently with the existing "Guided tour" link (shield icon, same text/hover colors)

Closes #350

## Test plan
- [ ] Open Account Settings modal → verify "Privacy Policy" link visible in sidebar
- [ ] Click "Privacy Policy" → verify modal closes and `/privacy` page loads
- [ ] Verify "Guided tour" link still works as before

## Documentation
No doc changes needed — single UI link addition.