### PR TITLE
fix(ui): suppress node hover tooltip when menu/modal is open

### DIFF
--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -22,6 +22,8 @@ interface OrbGraph3DProps {
   focusNodeId?: string | null;
   focusNodeToken?: number;
   onCameraDistanceChange?: (distance: number) => void;
+  /** When false, node hover tooltips are suppressed (e.g. when a menu/modal is open) */
+  tooltipEnabled?: boolean;
 }
 
 
@@ -53,6 +55,7 @@ export default function OrbGraph3D({
   focusNodeId = null,
   focusNodeToken = 0,
   onCameraDistanceChange,
+  tooltipEnabled = true,
 }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
@@ -606,7 +609,7 @@ export default function OrbGraph3D({
         onNodeClick={handleNodeClick}
         onBackgroundClick={handleBackgroundClick}
       />
-      <NodeTooltip node={hoveredNode} position={tooltipPos} />
+      <NodeTooltip node={tooltipEnabled ? hoveredNode : null} position={tooltipPos} />
     </div>
   );
 }

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -944,6 +944,7 @@ export default function OrbViewPage() {
           focusNodeId={focusRequest?.nodeUid || null}
           focusNodeToken={focusRequest?.seq ?? 0}
           onCameraDistanceChange={handleCameraDistanceChange}
+          tooltipEnabled={!showToolsMenu && !showInput && !showShare && !showDiscoverUses && !showDrafts && !extractedImport && !showImportLimitWarning}
         />
       </div>
       {!isPendingDeletion && (


### PR DESCRIPTION
## Summary
- Adds a `tooltipEnabled` prop to `OrbGraph3D` (defaults to `true`)
- In `OrbViewPage`, sets `tooltipEnabled={false}` when any overlay is open: Tools menu, node editor, Share panel, Discover Uses, Drafts, CV import review, or import limit warning
- Other pages using `OrbGraph3D` (Landing, SharedOrb, CreateOrb) are unaffected — they use the default `true`

Closes #351

## Test plan
- [ ] Hover over a node with no menu open → tooltip appears normally
- [ ] Open Tools menu → hover over nodes → no tooltip
- [ ] Open Share panel → hover over nodes → no tooltip
- [ ] Open node editor (click a node) → hover over other nodes → no tooltip
- [ ] Close the overlay → tooltip resumes on hover
- [ ] SharedOrbPage: tooltip still works (no overlays suppress it)

## Documentation
No doc changes needed.