### PR TITLE
feat(ui): pending connections dropdown, closable Orbis Pulse, header cleanup

### DIFF
--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -38,12 +38,6 @@ const STEPS: TourStep[] = [
     disableBeacon: true,
   },
   {
-    target: '[data-tour="node-count"]',
-    title: 'Quick Stats',
-    content: 'Here you can see how many nodes and edges your orbis contains.',
-    placement: 'bottom',
-  },
-  {
     target: '[data-tour="undo-redo"]',
     title: 'Undo And Redo',
     content: 'Undo and redo your recent changes — adding or deleting nodes can be reversed.',

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -135,6 +135,7 @@ export default function OrbisStatsOverlay({
     return window.innerWidth < COMPACT_BREAKPOINT_PX;
   });
   const [compactOpen, setCompactOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   const stats = useMemo(
     () => computeOrbisStatsSummary(data, hiddenNodeTypes, filteredNodeIds),
@@ -182,10 +183,32 @@ export default function OrbisStatsOverlay({
       data-tour="orbis-pulse"
       className="pointer-events-none fixed right-4 bottom-32 z-20 sm:right-6 sm:bottom-8"
     >
-      {isCompact ? (
+      {dismissed ? (
+        /* Collapsed pill — click to re-open */
+        <button
+          type="button"
+          onClick={() => setDismissed(false)}
+          className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/65 backdrop-blur-md px-3 py-1.5 text-xs font-semibold text-white/90 shadow-lg shadow-black/40 hover:bg-black/75 transition-colors"
+        >
+          <span style={{ color: '#C43A82' }}>Orbis Pulse</span>
+          <svg className="h-3.5 w-3.5 text-white/70" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={2}>
+            <path d="M5 13l5-6 5 6" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      ) : isCompact ? (
         <div className="flex flex-col items-end gap-2">
           {compactOpen && (
-            <div className="pointer-events-auto">
+            <div className="pointer-events-auto relative">
+              <button
+                type="button"
+                onClick={() => { setCompactOpen(false); setDismissed(true); }}
+                className="absolute top-2 right-2 w-6 h-6 rounded-md text-white/40 hover:text-white hover:bg-white/10 flex items-center justify-center transition-colors z-10"
+                aria-label="Close Orbis Pulse"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
               <OrbisPulsePanel stats={stats} />
             </div>
           )}
@@ -208,7 +231,17 @@ export default function OrbisStatsOverlay({
           </button>
         </div>
       ) : (
-        <div className="pointer-events-auto">
+        <div className="pointer-events-auto relative">
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="absolute top-2 right-2 w-6 h-6 rounded-md text-white/40 hover:text-white hover:bg-white/10 flex items-center justify-center transition-colors z-10"
+            aria-label="Close Orbis Pulse"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
           <OrbisPulsePanel stats={stats} />
         </div>
       )}

--- a/frontend/src/components/graph/PendingConnectionsDropdown.tsx
+++ b/frontend/src/components/graph/PendingConnectionsDropdown.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  listConnectionRequests,
+  acceptConnectionRequest,
+  rejectConnectionRequest,
+} from '../../api/orbs';
+import type { ConnectionRequest } from '../../api/orbs';
+import { useToastStore } from '../../stores/toastStore';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export default function PendingConnectionsDropdown() {
+  const [open, setOpen] = useState(false);
+  const [requests, setRequests] = useState<ConnectionRequest[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+  const [acceptKeywords, setAcceptKeywords] = useState('');
+  const [acceptHiddenTypes, setAcceptHiddenTypes] = useState('');
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const fetchRequests = useCallback(() => {
+    setLoading(true);
+    listConnectionRequests()
+      .then(setRequests)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Fetch on mount and when dropdown opens
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  useEffect(() => {
+    if (open) fetchRequests();
+  }, [open, fetchRequests]);
+
+  // Close on outside click or ESC
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  const handleAccept = async (requestId: string) => {
+    const kw = acceptKeywords.split(',').map(k => k.trim()).filter(Boolean);
+    const ht = acceptHiddenTypes.split(',').map(t => t.trim()).filter(Boolean);
+    try {
+      await acceptConnectionRequest(requestId, { keywords: kw, hidden_node_types: ht });
+      setRequests(prev => prev.filter(r => r.request_id !== requestId));
+      setAcceptingId(null);
+      setAcceptKeywords('');
+      setAcceptHiddenTypes('');
+      addToast('Access granted', 'success');
+    } catch {
+      addToast('Failed to accept request', 'error');
+    }
+  };
+
+  const handleReject = async (requestId: string) => {
+    setRejectingId(requestId);
+    try {
+      await rejectConnectionRequest(requestId);
+      setRequests(prev => prev.filter(r => r.request_id !== requestId));
+      addToast('Request rejected', 'success');
+    } catch {
+      addToast('Failed to reject request', 'error');
+    } finally {
+      setRejectingId(null);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className={`h-8 leading-none flex items-center gap-1.5 text-xs font-medium py-1.5 px-2.5 rounded-lg transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 ${
+          open
+            ? 'bg-emerald-500/15 border border-emerald-400/30 text-white'
+            : 'border border-transparent text-white/55 hover:text-white hover:bg-white/8'
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+        </svg>
+        <span className="hidden sm:inline">Connections</span>
+        {requests.length > 0 && (
+          <span className="bg-emerald-500 text-white text-[10px] font-bold leading-none w-4 h-4 rounded-full flex items-center justify-center">
+            {requests.length}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute left-0 sm:right-0 sm:left-auto top-full mt-2 w-80 sm:w-96 bg-neutral-950/95 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl z-50 overflow-hidden">
+          <div className="px-4 py-3 border-b border-white/10">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs text-emerald-300 uppercase tracking-[0.12em] font-semibold">Pending Connections</h3>
+              <span className="text-[11px] text-white/40">{requests.length} pending</span>
+            </div>
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {loading && requests.length === 0 && (
+              <p className="text-[11px] text-gray-500 text-center py-6">Loading requests...</p>
+            )}
+            {!loading && requests.length === 0 && (
+              <p className="text-[11px] text-gray-500 text-center py-6">No pending requests</p>
+            )}
+            <div className="p-2 space-y-2">
+              {requests.map((req) => (
+                <div key={req.request_id} className="border border-white/8 rounded-lg px-3 py-2.5 bg-white/[0.03] space-y-2">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm text-white truncate">{req.requester_name || req.requester_email}</p>
+                      <p className="text-[11px] text-gray-400 mt-0.5">{req.requester_email}</p>
+                      <p className="text-[10px] text-gray-500 mt-0.5">{formatDate(req.created_at)}</p>
+                    </div>
+                    <div className="flex gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setAcceptingId(acceptingId === req.request_id ? null : req.request_id);
+                          setAcceptKeywords('');
+                          setAcceptHiddenTypes('');
+                        }}
+                        className="h-7 px-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-[11px] font-medium transition-colors"
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleReject(req.request_id)}
+                        disabled={rejectingId === req.request_id}
+                        className="h-7 px-2.5 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-50 text-[11px] font-medium transition-colors"
+                      >
+                        {rejectingId === req.request_id ? '...' : 'Reject'}
+                      </button>
+                    </div>
+                  </div>
+
+                  {acceptingId === req.request_id && (
+                    <div className="rounded-lg border border-white/8 bg-black/30 p-2.5 space-y-2">
+                      <div>
+                        <label className="text-[10px] text-gray-500 uppercase tracking-wide">Filtered Keywords (comma separated)</label>
+                        <input
+                          type="text"
+                          value={acceptKeywords}
+                          onChange={(e) => setAcceptKeywords(e.target.value)}
+                          placeholder="python, machine learning"
+                          className="mt-1 w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-white text-xs placeholder-gray-600 focus:outline-none focus:border-emerald-500/50"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-[10px] text-gray-500 uppercase tracking-wide">Hidden Node Types (comma separated)</label>
+                        <input
+                          type="text"
+                          value={acceptHiddenTypes}
+                          onChange={(e) => setAcceptHiddenTypes(e.target.value)}
+                          placeholder="Skill, Project"
+                          className="mt-1 w-full bg-white/[0.04] border border-white/10 rounded-lg px-2.5 py-1.5 text-white text-xs placeholder-gray-600 focus:outline-none focus:border-emerald-500/50"
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleAccept(req.request_id)}
+                          className="h-7 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-[11px] font-medium transition-colors"
+                        >
+                          Confirm &amp; Grant
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setAcceptingId(null)}
+                          className="h-7 px-3 rounded-lg border border-white/15 text-white/60 hover:bg-white/10 text-[11px] font-medium transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/graph/SharePanel.tsx
+++ b/frontend/src/components/graph/SharePanel.tsx
@@ -7,16 +7,13 @@ import {
   createShareToken,
   getPublicFilters,
   listAccessGrants,
-  listConnectionRequests,
   listShareTokens,
-  acceptConnectionRequest,
-  rejectConnectionRequest,
   revokeAccessGrant,
   revokeShareToken,
   updateAccessGrantFilters,
   updatePublicFilters,
 } from '../../api/orbs';
-import type { AccessGrant, ConnectionRequest, OrbVisibility, ShareToken } from '../../api/orbs';
+import type { AccessGrant, OrbVisibility, ShareToken } from '../../api/orbs';
 
 const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach', 'Training'];
 
@@ -56,12 +53,6 @@ export default function SharePanel({
   const [editingGrantKeywords, setEditingGrantKeywords] = useState('');
   const [editingGrantHiddenTypes, setEditingGrantHiddenTypes] = useState('');
   const [updatingGrantFiltersId, setUpdatingGrantFiltersId] = useState<string | null>(null);
-  const [pendingRequests, setPendingRequests] = useState<ConnectionRequest[]>([]);
-  const [pendingLoading, setPendingLoading] = useState(false);
-  const [acceptingRequestId, setAcceptingRequestId] = useState<string | null>(null);
-  const [acceptKeywords, setAcceptKeywords] = useState('');
-  const [acceptHiddenTypes, setAcceptHiddenTypes] = useState('');
-  const [rejectingRequestId, setRejectingRequestId] = useState<string | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
   const addToast = useToastStore((s) => s.addToast);
   const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword, deactivateAll } = useFilterStore();
@@ -143,14 +134,6 @@ export default function SharePanel({
     };
   }, [isRestricted]);
 
-  useEffect(() => {
-    if (!isRestricted) return;
-    setPendingLoading(true);
-    listConnectionRequests()
-      .then(setPendingRequests)
-      .catch(() => {})
-      .finally(() => setPendingLoading(false));
-  }, [isRestricted]);
 
   useEffect(() => {
     const panel = modalRef.current;
@@ -337,35 +320,6 @@ export default function SharePanel({
     await saveGrantFilters(grant.grant_id, '', '');
   };
 
-  const handleAcceptRequest = async (requestId: string) => {
-    const keywords = acceptKeywords.split(',').map(k => k.trim()).filter(Boolean);
-    const hiddenTypes = acceptHiddenTypes.split(',').map(t => t.trim()).filter(Boolean);
-    try {
-      await acceptConnectionRequest(requestId, { keywords, hidden_node_types: hiddenTypes });
-      setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
-      setAcceptingRequestId(null);
-      setAcceptKeywords('');
-      setAcceptHiddenTypes('');
-      // Refresh grants list
-      listAccessGrants().then(g => setGrants(g.grants));
-      addToast('Access granted', 'success');
-    } catch {
-      addToast('Failed to accept request', 'error');
-    }
-  };
-
-  const handleRejectRequest = async (requestId: string) => {
-    setRejectingRequestId(requestId);
-    try {
-      await rejectConnectionRequest(requestId);
-      setPendingRequests(prev => prev.filter(r => r.request_id !== requestId));
-      addToast('Request rejected', 'success');
-    } catch {
-      addToast('Failed to reject request', 'error');
-    } finally {
-      setRejectingRequestId(null);
-    }
-  };
 
   const [pendingVisibility, setPendingVisibility] = useState<OrbVisibility | null>(null);
 
@@ -745,91 +699,6 @@ export default function SharePanel({
 
             {isRestricted && (
               <>
-                {(pendingLoading || pendingRequests.length > 0) && (
-                  <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
-                    <div className="flex items-center justify-between gap-2 mb-3">
-                      <label className="text-xs text-amber-200/80 uppercase tracking-wide font-medium">Pending Requests</label>
-                      <span className="text-[11px] text-amber-200/60">{pendingRequests.length}</span>
-                    </div>
-                    {pendingLoading && <p className="text-[11px] text-gray-500">Loading requests...</p>}
-                    <div className="space-y-2 max-h-64 overflow-y-auto">
-                      {pendingRequests.map((req) => (
-                        <div key={req.request_id} className="border border-gray-700 rounded-lg px-3 py-2.5 bg-gray-900/60 space-y-2">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <p className="text-sm text-white truncate">{req.requester_name || req.requester_email}</p>
-                              <p className="text-[11px] text-gray-400 mt-0.5">{req.requester_email}</p>
-                              <p className="text-[10px] text-gray-500 mt-0.5">{formatDate(req.created_at)}</p>
-                            </div>
-                            <div className="flex gap-2">
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setAcceptingRequestId(acceptingRequestId === req.request_id ? null : req.request_id);
-                                  setAcceptKeywords('');
-                                  setAcceptHiddenTypes('');
-                                }}
-                                className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
-                              >
-                                Accept
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => handleRejectRequest(req.request_id)}
-                                disabled={rejectingRequestId === req.request_id}
-                                className="h-8 px-3 rounded-lg border border-red-500/40 text-red-300 hover:bg-red-500/10 disabled:opacity-50 text-xs font-medium transition-colors"
-                              >
-                                {rejectingRequestId === req.request_id ? 'Rejecting...' : 'Reject'}
-                              </button>
-                            </div>
-                          </div>
-
-                          {acceptingRequestId === req.request_id && (
-                            <div className="rounded-lg border border-gray-700/70 bg-gray-900/60 p-2.5 space-y-2">
-                              <div>
-                                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Filtered Keywords (comma separated)</label>
-                                <input
-                                  type="text"
-                                  value={acceptKeywords}
-                                  onChange={(e) => setAcceptKeywords(e.target.value)}
-                                  placeholder="python, machine learning"
-                                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
-                                />
-                              </div>
-                              <div>
-                                <label className="text-[10px] text-gray-500 uppercase tracking-wide">Hidden Node Types (comma separated)</label>
-                                <input
-                                  type="text"
-                                  value={acceptHiddenTypes}
-                                  onChange={(e) => setAcceptHiddenTypes(e.target.value)}
-                                  placeholder="Skill, Project"
-                                  className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-lg px-2.5 py-2 text-white text-xs placeholder-gray-500"
-                                />
-                              </div>
-                              <div className="flex gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() => handleAcceptRequest(req.request_id)}
-                                  className="h-8 px-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-colors"
-                                >
-                                  Confirm &amp; Grant Access
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => setAcceptingRequestId(null)}
-                                  className="h-8 px-3 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium transition-colors"
-                                >
-                                  Cancel
-                                </button>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
                 <div className="rounded-xl border border-gray-700 bg-gray-800/40 p-4">
                   <label className="text-xs text-gray-500 uppercase tracking-wide font-medium">Invite By Email</label>
                   <p className="text-[11px] text-gray-500 mt-0.5 mb-2">Invite people who can view this orbis after signing in according to the filters selected.</p>

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -35,6 +35,7 @@ import type { DocumentMetadata } from '../api/cv';
 const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach', 'Training'];
 
 import SharePanel from '../components/graph/SharePanel';
+import PendingConnectionsDropdown from '../components/graph/PendingConnectionsDropdown';
 
 
 // ── Icon components ──
@@ -650,9 +651,6 @@ export default function OrbViewPage() {
                 </div>
                 <span className="text-white font-bold text-sm tracking-tight hidden sm:inline">OpenOrbis</span>
               </div>
-              <div className="hidden sm:block w-px h-5 bg-white/10" />
-              <span data-tour="node-count" className="text-white text-xs hidden sm:inline">{data.nodes.length} nodes &middot; {data.links.length} edges</span>
-
               {/* Tools hamburger — visible below lg */}
               {!isPendingDeletion && (
                 <div className="relative lg:hidden" ref={toolsMenuRef}>
@@ -743,19 +741,24 @@ export default function OrbViewPage() {
                           onChange={handleImportInputChange}
                         />
                       </label>
-                      {/* Notes */}
-                      <button
-                        onClick={() => { setShowDrafts(true); setShowToolsMenu(false); }}
-                        className="w-full flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border border-white/10 text-white/70 hover:text-purple-300 hover:border-purple-400/30 hover:bg-purple-500/10 transition-all"
-                      >
-                        <IconNotes />
-                        Notes
-                        {draftNotes.length > 0 && (
-                          <span className="bg-purple-500 text-white text-[10px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
-                            {draftNotes.length}
-                          </span>
-                        )}
-                      </button>
+                      {/* Connections + Notes */}
+                      <div className="flex gap-2">
+                        <div className="flex-1">
+                          <PendingConnectionsDropdown />
+                        </div>
+                        <button
+                          onClick={() => { setShowDrafts(true); setShowToolsMenu(false); }}
+                          className="flex-1 flex items-center justify-center gap-1.5 text-xs font-medium py-2 rounded-lg border border-white/10 text-white/70 hover:text-purple-300 hover:border-purple-400/30 hover:bg-purple-500/10 transition-all"
+                        >
+                          <IconNotes />
+                          Notes
+                          {draftNotes.length > 0 && (
+                            <span className="bg-purple-500 text-white text-[10px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
+                              {draftNotes.length}
+                            </span>
+                          )}
+                        </button>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -763,37 +766,6 @@ export default function OrbViewPage() {
 
               {!isPendingDeletion && (
                 <div className="hidden lg:flex items-center gap-1.5 ml-2">
-                  {/* Undo / Redo */}
-                  <div data-tour="undo-redo" className="flex items-center">
-                    <button
-                      onClick={handleUndo}
-                      disabled={undoStack.length === 0}
-                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
-                        undoStack.length === 0
-                          ? 'text-teal-500/20 cursor-default'
-                          : 'text-teal-400 hover:text-teal-300 hover:bg-teal-500/10'
-                      }`}
-                      title="Undo"
-                    >
-                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
-                      </svg>
-                    </button>
-                    <button
-                      onClick={handleRedo}
-                      disabled={redoStack.length === 0}
-                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
-                        redoStack.length === 0
-                          ? 'text-sky-500/20 cursor-default'
-                          : 'text-sky-400 hover:text-sky-300 hover:bg-sky-500/10'
-                      }`}
-                      title="Redo"
-                    >
-                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 10H11a5 5 0 00-5 5v2M21 10l-4-4M21 10l-4 4" />
-                      </svg>
-                    </button>
-                  </div>
                   <div data-tour="node-types">
                     <NodeTypeFilter
                       hiddenTypes={hiddenNodeTypes}
@@ -841,12 +813,47 @@ export default function OrbViewPage() {
                       onChange={handleImportInputChange}
                     />
                   </label>
+                  {/* Undo / Redo */}
+                  <div data-tour="undo-redo" className="flex items-center">
+                    <button
+                      onClick={handleUndo}
+                      disabled={undoStack.length === 0}
+                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
+                        undoStack.length === 0
+                          ? 'text-teal-500/20 cursor-default'
+                          : 'text-teal-400 hover:text-teal-300 hover:bg-teal-500/10'
+                      }`}
+                      title="Undo"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+                      </svg>
+                    </button>
+                    <button
+                      onClick={handleRedo}
+                      disabled={redoStack.length === 0}
+                      className={`h-8 w-8 flex items-center justify-center rounded-lg transition-all cursor-pointer ${
+                        redoStack.length === 0
+                          ? 'text-sky-500/20 cursor-default'
+                          : 'text-sky-400 hover:text-sky-300 hover:bg-sky-500/10'
+                      }`}
+                      title="Redo"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 10H11a5 5 0 00-5 5v2M21 10l-4-4M21 10l-4 4" />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
 
             <div className="h-8 flex items-center gap-1">
               <ProcessingCounter />
+
+              <div className="hidden lg:block">
+                <PendingConnectionsDropdown />
+              </div>
 
               <div data-tour="notes" className="hidden lg:block">
                 <HeaderBtn onClick={() => setShowDrafts(true)} variant="outline">


### PR DESCRIPTION
## Summary
- **Pending Connections dropdown** — new header button (left of Notes) with emerald green badge showing pending request count; each request has accept/reject with keyword + hidden node type filters
- **Removed pending requests from SharePanel** — all state, handlers, and UI moved to the new dropdown
- **Removed node/edge count** from header bar (duplicate of Orbis Pulse active nodes/edges)
- **Orbis Pulse closable** — X button dismisses the panel to a small re-open pill (works on both desktop and compact/mobile)
- **Moved undo/redo** buttons to the right of "Import new document" in the desktop header
- **Removed orphaned guided tour step** for deleted node-count element

Closes #354

## Test plan
- [ ] Desktop: verify Connections button visible in header with correct icon
- [ ] Desktop: click Connections → dropdown opens showing pending count and request list (or "No pending requests")
- [ ] Desktop: accept a request with filters → toast shown, request removed from list
- [ ] Desktop: reject a request → toast shown, request removed
- [ ] Desktop: Orbis Pulse X button → panel collapses to pill; click pill → panel re-opens
- [ ] Desktop: verify undo/redo arrows appear after "Import new document"
- [ ] Desktop: verify node/edge count no longer in header
- [ ] Desktop: open Share panel → verify no "Pending Requests" section
- [ ] Mobile: Tools menu shows Connections icon + Notes side by side
- [ ] Mobile: Connections dropdown opens correctly from Tools menu

## Documentation
No doc changes needed — UI-only changes.