### PR TITLE
fix(backend): Neo4j pool liveness check fixes intermittent 500s after idle

### DIFF
--- a/backend/app/graph/neo4j_client.py
+++ b/backend/app/graph/neo4j_client.py
@@ -20,8 +20,12 @@ async def get_driver() -> AsyncDriver:
             auth=(settings.neo4j_user, settings.neo4j_password),
             max_connection_pool_size=50,
             connection_acquisition_timeout=10,
-            max_connection_lifetime=5
-            * 60,  # recycle before VPC connector drops idle TCP
+            # VPC connector / NAT can silently drop idle Bolt TCP sockets; the
+            # pool then hands out dead connections and the first request after
+            # idle fails with "TCPTransport closed". Recycle aggressively and
+            # liveness-check before reuse.
+            max_connection_lifetime=60,
+            liveness_check_timeout=30,
             keep_alive=True,
         )
     return _driver


### PR DESCRIPTION
## Summary

- Intermittent `POST /api/auth/google` and `/api/auth/refresh` 500s after the service had been idle were tracked down to stale Bolt sockets left in the Neo4j driver pool. The Cloud Run → VPC connector → Neo4j GCE VM path silently drops idle TCP, the pool doesn't notice, hands out a dead socket, and the request crashes with `RuntimeError: unable to perform operation on <TCPTransport closed=True>; the handler is closed`. The second attempt works because the pool has meanwhile discarded the dead connections — this matches the "works on the second try a minute later" symptom exactly.
- Fix in `backend/app/graph/neo4j_client.py`: add `liveness_check_timeout=30` so the driver NOOPs any connection idle >30s before reuse, and tighten `max_connection_lifetime` from 300s to 60s so pooled sockets are recycled well under any NAT idle timeout.
- Not a cold-start issue: startup probes consistently succeed on the first attempt within a few seconds. `min-instances` would hide the symptom but wouldn't fix this bug.

## Evidence

Repro in Cloud Logging (`orbis-api`, 2026-04-16 13:47): six `POST /api/auth/google` → 500 in 100–170 ms, each with the same Neo4j pool traceback ending in `_acquire_from_pool_checked` → `RuntimeError: ...TCPTransport closed=True`. Same failure mode on `/api/auth/refresh` at 13:06.

## Test plan

- [ ] Deploy to staging, let the service scale to zero, wait >5 min, hit `/api/auth/google` — should succeed on the first attempt.
- [ ] Watch Cloud Logging for `TCPTransport closed` errors over 24h — should be zero.
- [ ] Verify `/health/ready` still returns `{"neo4j": "connected"}` after the change.

## Documentation

No doc changes needed — internal driver-tuning fix, no API/architecture/convention change.