### PR TITLE
feat(ui): revamp Orbis Pulse metrics with interactive insights

### DIFF
--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -134,28 +134,29 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
           <p className={`mt-1 text-lg leading-none font-semibold ${freshnessColor(stats.freshnessScore)}`}>{formatPercent(stats.freshnessScore)}</p>
           <p className="mt-1 text-[10px] text-white/45">recent entries</p>
         </div>
+      </div>
 
-        <div className={`relative ${METRIC_CARD_LG}`}>
-          <MetricInfo
-            label="Orphan Nodes"
-            description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
-          />
-          <button
-            type="button"
-            onClick={() => stats.orphanNodes > 0 && setOrphansExpanded((v) => !v)}
-            className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
-          >
-            <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>
-            <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.orphanNodes}</p>
-            <p className="mt-1 text-[10px] text-white/45">
-              {formatPercent(stats.orphanRate)} of active
-              {stats.orphanNodes > 0 && (
-                <span className="ml-1 text-purple-400/70">{orphansExpanded ? '▲' : '▼'}</span>
-              )}
-            </p>
-          </button>
-          {orphansExpanded && <NodeDetailList nodes={stats.orphanNodeDetails} />}
-        </div>
+      {/* Orphan Nodes — full width below the grid */}
+      <div className={`relative mt-2 ${METRIC_CARD_LG}`}>
+        <MetricInfo
+          label="Orphan Nodes"
+          description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
+        />
+        <button
+          type="button"
+          onClick={() => stats.orphanNodes > 0 && setOrphansExpanded((v) => !v)}
+          className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+        >
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.orphanNodes}</p>
+          <p className="mt-1 text-[10px] text-white/45">
+            {formatPercent(stats.orphanRate)} of active
+            {stats.orphanNodes > 0 && (
+              <span className="ml-1 text-purple-400/70">{orphansExpanded ? '▲' : '▼'}</span>
+            )}
+          </p>
+        </button>
+        {orphansExpanded && <NodeDetailList nodes={stats.orphanNodeDetails} />}
       </div>
 
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -66,20 +66,31 @@ function NodeDetailList({ nodes, max = 8 }: { nodes: NodeDetail[]; max?: number 
 }
 
 function ClusterDetailList({ clusters }: { clusters: ClusterDetail[] }) {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
   return (
-    <div className="mt-2 space-y-2 max-h-40 overflow-y-auto">
+    <div className="mt-2 space-y-1.5 max-h-48 overflow-y-auto">
       {clusters.map((cluster, i) => (
-        <div key={i}>
-          <p className="text-[10px] text-white/50 font-medium">Cluster {i + 1} — {cluster.nodes.length} nodes</p>
-          <div className="mt-0.5 space-y-0.5">
-            {cluster.nodes.slice(0, 5).map((n) => (
-              <div key={n.uid} className="flex items-center gap-2 text-[11px] pl-2">
-                <span className="text-white/70 truncate flex-1">{n.name}</span>
-                <span className="text-white/30 flex-shrink-0">{n.type}</span>
-              </div>
-            ))}
-            {cluster.nodes.length > 5 && <p className="text-[10px] text-white/30 pl-2">+{cluster.nodes.length - 5} more</p>}
-          </div>
+        <div key={i} className="rounded-md border border-white/6 bg-white/[0.02] px-2.5 py-1.5">
+          <button
+            type="button"
+            onClick={() => setExpandedIdx(expandedIdx === i ? null : i)}
+            className="w-full flex items-center gap-2 text-left cursor-pointer"
+          >
+            <span className="text-[11px] text-white/80 font-medium truncate flex-1">{cluster.hub.name}</span>
+            <span className="text-[10px] text-white/30 flex-shrink-0">{cluster.size} nodes</span>
+            <span className="text-[10px] text-purple-400/70">{expandedIdx === i ? '▲' : '▼'}</span>
+          </button>
+          {expandedIdx === i && (
+            <div className="mt-1.5 space-y-0.5 border-t border-white/5 pt-1.5">
+              {cluster.nodes.slice(0, 8).map((n) => (
+                <div key={n.uid} className="flex items-center gap-2 text-[10px] pl-1">
+                  <span className="text-white/60 truncate flex-1">{n.name}</span>
+                  <span className="text-white/25 flex-shrink-0">{n.type}</span>
+                </div>
+              ))}
+              {cluster.nodes.length > 8 && <p className="text-[10px] text-white/25 pl-1">+{cluster.nodes.length - 8} more</p>}
+            </div>
+          )}
         </div>
       ))}
     </div>
@@ -196,15 +207,20 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
           <NodeDetailList nodes={stats.orphanNodeDetails} />
         </ExpandableMetric>
 
-        <ExpandableMetric
-          label="Skill Clusters"
-          description="Groups of interconnected nodes. More clusters indicate diverse, distinct areas of expertise."
-          value={stats.skillClusters}
-          hint="connected groups"
-          count={stats.skillClusters}
-        >
-          <ClusterDetailList clusters={stats.clusterDetails} />
-        </ExpandableMetric>
+        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+          <MetricInfo
+            label="Background Areas"
+            description="Clusters of interconnected nodes, each identified by its most connected hub. They summarize the key areas of expertise."
+          />
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Background Areas</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.skillClusters}</p>
+          {stats.clusterDetails.length > 0 && (
+            <p className="mt-1 text-[10px] text-white/55 truncate">
+              {stats.clusterDetails.map((c) => c.hub.name).join(', ')}
+            </p>
+          )}
+          {stats.skillClusters > 0 && <ClusterDetailList clusters={stats.clusterDetails} />}
+        </div>
 
         <ExpandableMetric
           label="Bridge Nodes"

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -88,11 +88,19 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
       <div
         className={`mt-3 ${METRIC_CARD_LG}`}
         onMouseEnter={() => stats.topHubNeighbors.length > 0 && onHighlight?.(new Set(stats.topHubNeighbors.map((n) => n.uid)))}
-        onMouseLeave={() => onHighlight?.(new Set())}
+        onMouseLeave={() => !hubExpanded && onHighlight?.(new Set())}
       >
         <button
           type="button"
-          onClick={() => stats.topHubDegree > 0 && setHubExpanded((v) => !v)}
+          onClick={() => {
+            if (stats.topHubDegree === 0) return;
+            setHubExpanded((v) => {
+              const next = !v;
+              if (next) onHighlight?.(new Set(stats.topHubNeighbors.map((n) => n.uid)));
+              else onHighlight?.(new Set());
+              return next;
+            });
+          }}
           className={`w-full text-left ${stats.topHubDegree > 0 ? 'cursor-pointer' : 'cursor-default'}`}
         >
           <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
@@ -157,7 +165,7 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
       <div
         className={`relative mt-2 ${METRIC_CARD_LG}`}
         onMouseEnter={() => stats.orphanNodes > 0 && onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)))}
-        onMouseLeave={() => onHighlight?.(new Set())}
+        onMouseLeave={() => !orphansExpanded && onHighlight?.(new Set())}
       >
         <MetricInfo
           label="Orphan Nodes"
@@ -165,7 +173,15 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
         />
         <button
           type="button"
-          onClick={() => stats.orphanNodes > 0 && setOrphansExpanded((v) => !v)}
+          onClick={() => {
+            if (stats.orphanNodes === 0) return;
+            setOrphansExpanded((v) => {
+              const next = !v;
+              if (next) onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)));
+              else onHighlight?.(new Set());
+              return next;
+            });
+          }}
           className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
         >
           <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -203,10 +203,10 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
           onClick={() => setShowSuggest(true)}
           className={`${METRIC_CARD_LG} flex flex-col items-center justify-center gap-1.5 cursor-pointer text-center`}
         >
-          <svg className="w-4 h-4 text-purple-400/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
           </svg>
-          <p className="text-[10px] text-white/35 leading-tight">
+          <p className="text-[10px] text-purple-300 font-medium leading-tight">
             {suggestSent ? 'Thanks!' : 'Suggest a metric'}
           </p>
         </button>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -255,7 +255,7 @@ export default function OrbisStatsOverlay({
     <div
       ref={containerRef}
       data-tour="orbis-pulse"
-      className="pointer-events-none fixed right-4 bottom-32 z-20 sm:right-6 sm:bottom-8"
+      className="pointer-events-none fixed right-4 bottom-32 z-[45] sm:right-6 sm:bottom-8"
     >
       {dismissed ? (
         /* Collapsed pill — click to re-open */

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { OrbData } from '../../api/orbs';
-import { computeOrbisStatsSummary } from './orbisStats';
+import { computeOrbisStatsSummary, formatTypeLabel } from './orbisStats';
+import type { NodeDetail, ClusterDetail } from './orbisStats';
 
 interface OrbisStatsOverlayProps {
   data: OrbData;
@@ -37,21 +38,83 @@ function formatPercent(value: number, digits = 0): string {
   return `${(value * 100).toFixed(digits)}%`;
 }
 
-function formatTypeLabel(type: string | null): string {
-  if (!type) return 'Node';
-  return type.replace(/([a-z])([A-Z])/g, '$1 $2');
-}
-
 function metricHint(active: number, total: number): string {
   if (active === total) return 'All visible';
   return `${active} of ${total}`;
 }
 
-function shareReadinessLabel(score: number): string {
-  if (score >= 0.8) return 'Excellent';
-  if (score >= 0.65) return 'Strong';
-  if (score >= 0.5) return 'Improving';
-  return 'Needs work';
+function freshnessColor(score: number): string {
+  if (score >= 0.7) return 'text-emerald-400';
+  if (score >= 0.4) return 'text-amber-400';
+  return 'text-red-400';
+}
+
+function NodeDetailList({ nodes, max = 8 }: { nodes: NodeDetail[]; max?: number }) {
+  const shown = nodes.slice(0, max);
+  const more = nodes.length - shown.length;
+  return (
+    <div className="mt-2 space-y-1 max-h-32 overflow-y-auto">
+      {shown.map((n) => (
+        <div key={n.uid} className="flex items-center gap-2 text-[11px]">
+          <span className="text-white/70 truncate flex-1">{n.name}</span>
+          <span className="text-white/30 flex-shrink-0">{n.type}</span>
+        </div>
+      ))}
+      {more > 0 && <p className="text-[10px] text-white/30">+{more} more</p>}
+    </div>
+  );
+}
+
+function ClusterDetailList({ clusters }: { clusters: ClusterDetail[] }) {
+  return (
+    <div className="mt-2 space-y-2 max-h-40 overflow-y-auto">
+      {clusters.map((cluster, i) => (
+        <div key={i}>
+          <p className="text-[10px] text-white/50 font-medium">Cluster {i + 1} — {cluster.nodes.length} nodes</p>
+          <div className="mt-0.5 space-y-0.5">
+            {cluster.nodes.slice(0, 5).map((n) => (
+              <div key={n.uid} className="flex items-center gap-2 text-[11px] pl-2">
+                <span className="text-white/70 truncate flex-1">{n.name}</span>
+                <span className="text-white/30 flex-shrink-0">{n.type}</span>
+              </div>
+            ))}
+            {cluster.nodes.length > 5 && <p className="text-[10px] text-white/30 pl-2">+{cluster.nodes.length - 5} more</p>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ExpandableMetric({ label, description, value, hint, children, count }: {
+  label: string;
+  description: string;
+  value: React.ReactNode;
+  hint: string;
+  children: React.ReactNode;
+  count: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+      <MetricInfo label={label} description={description} />
+      <button
+        type="button"
+        onClick={() => count > 0 && setExpanded((v) => !v)}
+        className={`w-full text-left ${count > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+      >
+        <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">{label}</p>
+        <p className="mt-1 text-lg leading-none font-semibold text-white">{value}</p>
+        <p className="mt-1 text-[10px] text-white/45">
+          {hint}
+          {count > 0 && (
+            <span className="ml-1 text-purple-400/70">{expanded ? '▲' : '▼'}</span>
+          )}
+        </p>
+      </button>
+      {expanded && children}
+    </div>
+  );
 }
 
 function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
@@ -66,7 +129,16 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         </div>
       </div>
 
-      <div className="mt-3 grid grid-cols-2 gap-2">
+      {/* Top Hub — prominent at the top */}
+      <div className="mt-3 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
+        <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
+        <p className="mt-1 text-[10px] text-white/45">
+          {formatTypeLabel(stats.topHubType)} {stats.topHubDegree > 0 && `\u00b7 ${stats.topHubDegree} active links`}
+        </p>
+      </div>
+
+      <div className="mt-2 grid grid-cols-2 gap-2">
         <div className="rounded-lg border border-white/8 bg-white/[0.03] p-2">
           <p className="text-[10px] uppercase tracking-wide text-white/40">Active Nodes</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.activeNodes}</p>
@@ -82,7 +154,7 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
           <MetricInfo
             label="Density"
-            description="Active links divided by the maximum possible links among active nodes in the current view."
+            description="Ratio of actual links to the maximum possible links among active nodes."
           />
           <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Density</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.density, 1)}</p>
@@ -92,7 +164,7 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
           <MetricInfo
             label="Skill Coverage"
-            description="Share of active non-skill nodes connected to at least one skill through a USED_SKILL link."
+            description="Percentage of non-skill nodes linked to at least one skill."
           />
           <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Skill Coverage</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.skillCoverageRate)}</p>
@@ -100,24 +172,49 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
             {stats.skillLinkedNodes}/{stats.skillEligibleNodes} linked
           </p>
         </div>
+
+        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+          <MetricInfo
+            label="Freshness"
+            description="Percentage of dated nodes with at least one date in the last 24 months. Higher means your orbis reflects recent activity."
+          />
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Freshness</p>
+          <p className={`mt-1 text-lg leading-none font-semibold ${freshnessColor(stats.freshnessScore)}`}>{formatPercent(stats.freshnessScore)}</p>
+          <p className="mt-1 text-[10px] text-white/45">recent entries</p>
+        </div>
       </div>
 
-      <div className="mt-2.5 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
-        <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
-        <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
-        <p className="mt-1 text-[10px] text-white/45">
-          {formatTypeLabel(stats.topHubType)} • {stats.topHubDegree} active links
-        </p>
-      </div>
+      {/* Expandable metrics */}
+      <div className="mt-2 space-y-2">
+        <ExpandableMetric
+          label="Orphan Nodes"
+          description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
+          value={stats.orphanNodes}
+          hint={`${formatPercent(stats.orphanRate)} of active`}
+          count={stats.orphanNodes}
+        >
+          <NodeDetailList nodes={stats.orphanNodeDetails} />
+        </ExpandableMetric>
 
-      <div className="relative mt-2.5 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
-        <MetricInfo
-          label="Share Readiness"
-          description="Weighted score: 40% completeness, 25% skill coverage, 20% connectivity, 15% domain balance."
-        />
-        <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Share Readiness</p>
-        <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.shareReadinessScore)}</p>
-        <p className="mt-1 text-[10px] text-white/45">{shareReadinessLabel(stats.shareReadinessScore)}</p>
+        <ExpandableMetric
+          label="Skill Clusters"
+          description="Groups of interconnected nodes. More clusters indicate diverse, distinct areas of expertise."
+          value={stats.skillClusters}
+          hint="connected groups"
+          count={stats.skillClusters}
+        >
+          <ClusterDetailList clusters={stats.clusterDetails} />
+        </ExpandableMetric>
+
+        <ExpandableMetric
+          label="Bridge Nodes"
+          description="Nodes that connect otherwise separate parts of your graph. They tie your career story together."
+          value={stats.bridgeNodes}
+          hint="key connectors"
+          count={stats.bridgeNodes}
+        >
+          <NodeDetailList nodes={stats.bridgeNodeDetails} />
+        </ExpandableMetric>
       </div>
 
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -162,12 +162,12 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
 
         <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
-            label="Density"
-            description="Ratio of actual edges to the maximum possible edges among active nodes."
+            label="Avg Edges/Node"
+            description="Average number of edges per node. Higher means your nodes are well connected to each other."
           />
-          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Density</p>
-          <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.density, 1)}</p>
-          <p className="mt-1 text-[10px] text-white/45">{stats.avgLinksPerNode.toFixed(1)} edges/node</p>
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Avg Edges/Node</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.avgLinksPerNode.toFixed(1)}</p>
+          <p className="mt-1 text-[10px] text-white/45">{stats.activeLinks} total edges</p>
         </div>
 
         <div className={`relative ${METRIC_CARD_LG}`}>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -27,7 +27,7 @@ function MetricInfo({ description, label }: { description: string; label: string
         >
           i
         </button>
-        <div className="pointer-events-none absolute right-0 top-6 z-10 w-56 rounded-lg border border-white/15 bg-black/90 px-2 py-1.5 text-[10px] leading-snug text-white/80 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        <div className="pointer-events-none absolute right-0 top-6 z-50 w-56 rounded-lg border border-white/15 bg-black/90 px-2 py-1.5 text-[10px] leading-snug text-white/80 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
           {description}
         </div>
       </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -259,7 +259,7 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
                   try {
                     await submitIdea(`[Metric Suggestion] ${suggestText.trim()}`, 'idea');
                     setSuggestSent(true);
-                    setTimeout(() => setSuggestSent(false), 8000);
+                    setTimeout(() => setSuggestSent(false), 4000);
                   } catch { /* best effort */ }
                   finally {
                     setSuggestSending(false);

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { OrbData } from '../../api/orbs';
 import { computeOrbisStatsSummary, formatTypeLabel } from './orbisStats';
-import type { NodeDetail, ClusterDetail } from './orbisStats';
+import type { ClusterDetail } from './orbisStats';
 
 interface OrbisStatsOverlayProps {
   data: OrbData;
@@ -210,27 +210,17 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
           <MetricInfo
             label="Background Areas"
-            description="Clusters of interconnected nodes, each identified by its most connected hub. They summarize the key areas of expertise."
+            description="Key areas of your background, each identified by the skill most connected to your experiences, certifications, and projects."
           />
           <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Background Areas</p>
-          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.skillClusters}</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.backgroundAreas}</p>
           {stats.clusterDetails.length > 0 && (
             <p className="mt-1 text-[10px] text-white/55 truncate">
               {stats.clusterDetails.map((c) => c.hub.name).join(', ')}
             </p>
           )}
-          {stats.skillClusters > 0 && <ClusterDetailList clusters={stats.clusterDetails} />}
+          {stats.backgroundAreas > 0 && <ClusterDetailList clusters={stats.clusterDetails} />}
         </div>
-
-        <ExpandableMetric
-          label="Bridge Nodes"
-          description="Nodes that connect otherwise separate parts of your graph. They tie your career story together."
-          value={stats.bridgeNodes}
-          hint="key connectors"
-          count={stats.bridgeNodes}
-        >
-          <NodeDetailList nodes={stats.bridgeNodeDetails} />
-        </ExpandableMetric>
       </div>
 
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { OrbData } from '../../api/orbs';
 import { computeOrbisStatsSummary, formatTypeLabel } from './orbisStats';
-import type { ClusterDetail } from './orbisStats';
 
 interface OrbisStatsOverlayProps {
   data: OrbData;
@@ -65,74 +64,12 @@ function NodeDetailList({ nodes, max = 8 }: { nodes: NodeDetail[]; max?: number 
   );
 }
 
-function ClusterDetailList({ clusters }: { clusters: ClusterDetail[] }) {
-  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
-  return (
-    <div className="mt-2 space-y-1.5 max-h-48 overflow-y-auto">
-      {clusters.map((cluster, i) => (
-        <div key={i} className="rounded-md border border-white/6 bg-white/[0.02] px-2.5 py-1.5">
-          <button
-            type="button"
-            onClick={() => setExpandedIdx(expandedIdx === i ? null : i)}
-            className="w-full flex items-center gap-2 text-left cursor-pointer"
-          >
-            <span className="text-[11px] text-white/80 font-medium truncate flex-1">{cluster.hub.name}</span>
-            <span className="text-[10px] text-white/30 flex-shrink-0">{cluster.size} nodes</span>
-            <span className="text-[10px] text-purple-400/70">{expandedIdx === i ? '▲' : '▼'}</span>
-          </button>
-          {expandedIdx === i && (
-            <div className="mt-1.5 space-y-0.5 border-t border-white/5 pt-1.5">
-              {cluster.nodes.slice(0, 8).map((n) => (
-                <div key={n.uid} className="flex items-center gap-2 text-[10px] pl-1">
-                  <span className="text-white/60 truncate flex-1">{n.name}</span>
-                  <span className="text-white/25 flex-shrink-0">{n.type}</span>
-                </div>
-              ))}
-              {cluster.nodes.length > 8 && <p className="text-[10px] text-white/25 pl-1">+{cluster.nodes.length - 8} more</p>}
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
 const METRIC_CARD = 'rounded-lg border border-white/8 bg-white/[0.03] p-2 transition-all duration-200 hover:border-white/20 hover:bg-white/[0.06] hover:shadow-[0_0_12px_rgba(255,255,255,0.04)]';
 const METRIC_CARD_LG = 'rounded-lg border border-white/8 bg-white/[0.03] p-2.5 transition-all duration-200 hover:border-white/20 hover:bg-white/[0.06] hover:shadow-[0_0_12px_rgba(255,255,255,0.04)]';
 
-function ExpandableMetric({ label, description, value, hint, children, count }: {
-  label: string;
-  description: string;
-  value: React.ReactNode;
-  hint: string;
-  children: React.ReactNode;
-  count: number;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div className={`relative ${METRIC_CARD_LG}`}>
-      <MetricInfo label={label} description={description} />
-      <button
-        type="button"
-        onClick={() => count > 0 && setExpanded((v) => !v)}
-        className={`w-full text-left ${count > 0 ? 'cursor-pointer' : 'cursor-default'}`}
-      >
-        <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">{label}</p>
-        <p className="mt-1 text-lg leading-none font-semibold text-white">{value}</p>
-        <p className="mt-1 text-[10px] text-white/45">
-          {hint}
-          {count > 0 && (
-            <span className="ml-1 text-purple-400/70">{expanded ? '▲' : '▼'}</span>
-          )}
-        </p>
-      </button>
-      {expanded && children}
-    </div>
-  );
-}
 
 function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
-  const [areasExpanded, setAreasExpanded] = useState(false);
+  const [orphansExpanded, setOrphansExpanded] = useState(false);
   return (
     <div className="w-[min(336px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md shadow-[0_20px_60px_rgba(0,0,0,0.45)] p-3.5">
       <div className="flex items-start justify-between gap-2">
@@ -197,42 +134,27 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
           <p className={`mt-1 text-lg leading-none font-semibold ${freshnessColor(stats.freshnessScore)}`}>{formatPercent(stats.freshnessScore)}</p>
           <p className="mt-1 text-[10px] text-white/45">recent entries</p>
         </div>
-      </div>
-
-      {/* Expandable metrics */}
-      <div className="mt-2 space-y-2">
-        <ExpandableMetric
-          label="Orphan Nodes"
-          description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
-          value={stats.orphanNodes}
-          hint={`${formatPercent(stats.orphanRate)} of active`}
-          count={stats.orphanNodes}
-        >
-          <NodeDetailList nodes={stats.orphanNodeDetails} />
-        </ExpandableMetric>
 
         <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
-            label="Background Areas"
-            description="Key areas of your background, each identified by the skill most connected to your experiences, certifications, and projects."
+            label="Orphan Nodes"
+            description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
           />
           <button
             type="button"
-            onClick={() => stats.backgroundAreas > 0 && setAreasExpanded((v) => !v)}
-            className={`w-full text-left ${stats.backgroundAreas > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+            onClick={() => stats.orphanNodes > 0 && setOrphansExpanded((v) => !v)}
+            className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
           >
-            <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Background Areas</p>
-            <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.backgroundAreas}</p>
-            {stats.clusterDetails.length > 0 && (
-              <p className="mt-1 text-[10px] text-white/55 truncate">
-                {stats.clusterDetails.map((c) => c.hub.name).join(', ')}
-                {stats.backgroundAreas > 0 && (
-                  <span className="ml-1 text-purple-400/70">{areasExpanded ? '▲' : '▼'}</span>
-                )}
-              </p>
-            )}
+            <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>
+            <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.orphanNodes}</p>
+            <p className="mt-1 text-[10px] text-white/45">
+              {formatPercent(stats.orphanRate)} of active
+              {stats.orphanNodes > 0 && (
+                <span className="ml-1 text-purple-400/70">{orphansExpanded ? '▲' : '▼'}</span>
+              )}
+            </p>
           </button>
-          {areasExpanded && <ClusterDetailList clusters={stats.clusterDetails} />}
+          {orphansExpanded && <NodeDetailList nodes={stats.orphanNodeDetails} />}
         </div>
       </div>
 

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -97,6 +97,9 @@ function ClusterDetailList({ clusters }: { clusters: ClusterDetail[] }) {
   );
 }
 
+const METRIC_CARD = 'rounded-lg border border-white/8 bg-white/[0.03] p-2 transition-all duration-200 hover:border-white/20 hover:bg-white/[0.06] hover:shadow-[0_0_12px_rgba(255,255,255,0.04)]';
+const METRIC_CARD_LG = 'rounded-lg border border-white/8 bg-white/[0.03] p-2.5 transition-all duration-200 hover:border-white/20 hover:bg-white/[0.06] hover:shadow-[0_0_12px_rgba(255,255,255,0.04)]';
+
 function ExpandableMetric({ label, description, value, hint, children, count }: {
   label: string;
   description: string;
@@ -107,7 +110,7 @@ function ExpandableMetric({ label, description, value, hint, children, count }: 
 }) {
   const [expanded, setExpanded] = useState(false);
   return (
-    <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+    <div className={`relative ${METRIC_CARD_LG}`}>
       <MetricInfo label={label} description={description} />
       <button
         type="button"
@@ -129,6 +132,7 @@ function ExpandableMetric({ label, description, value, hint, children, count }: 
 }
 
 function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
+  const [areasExpanded, setAreasExpanded] = useState(false);
   return (
     <div className="w-[min(336px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md shadow-[0_20px_60px_rgba(0,0,0,0.45)] p-3.5">
       <div className="flex items-start justify-between gap-2">
@@ -141,38 +145,38 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
       </div>
 
       {/* Top Hub — prominent at the top */}
-      <div className="mt-3 rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+      <div className={`mt-3 ${METRIC_CARD_LG}`}>
         <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
         <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
         <p className="mt-1 text-[10px] text-white/45">
-          {formatTypeLabel(stats.topHubType)} {stats.topHubDegree > 0 && `\u00b7 ${stats.topHubDegree} active links`}
+          {formatTypeLabel(stats.topHubType)} {stats.topHubDegree > 0 && `\u00b7 ${stats.topHubDegree} active edges`}
         </p>
       </div>
 
       <div className="mt-2 grid grid-cols-2 gap-2">
-        <div className="rounded-lg border border-white/8 bg-white/[0.03] p-2">
+        <div className={METRIC_CARD}>
           <p className="text-[10px] uppercase tracking-wide text-white/40">Active Nodes</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.activeNodes}</p>
           <p className="mt-1 text-[10px] text-white/45">{stats.visibleNodes} visible</p>
         </div>
 
-        <div className="rounded-lg border border-white/8 bg-white/[0.03] p-2">
+        <div className={METRIC_CARD}>
           <p className="text-[10px] uppercase tracking-wide text-white/40">Active Edges</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.activeLinks}</p>
           <p className="mt-1 text-[10px] text-white/45">{stats.visibleLinks} visible</p>
         </div>
 
-        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
             label="Density"
-            description="Ratio of actual links to the maximum possible links among active nodes."
+            description="Ratio of actual edges to the maximum possible edges among active nodes."
           />
           <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Density</p>
           <p className="mt-1 text-lg leading-none font-semibold text-white">{formatPercent(stats.density, 1)}</p>
-          <p className="mt-1 text-[10px] text-white/45">{stats.avgLinksPerNode.toFixed(1)} links/node</p>
+          <p className="mt-1 text-[10px] text-white/45">{stats.avgLinksPerNode.toFixed(1)} edges/node</p>
         </div>
 
-        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
             label="Skill Coverage"
             description="Percentage of non-skill nodes linked to at least one skill."
@@ -184,7 +188,7 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
           </p>
         </div>
 
-        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
             label="Freshness"
             description="Percentage of dated nodes with at least one date in the last 24 months. Higher means your orbis reflects recent activity."
@@ -207,19 +211,28 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
           <NodeDetailList nodes={stats.orphanNodeDetails} />
         </ExpandableMetric>
 
-        <div className="relative rounded-lg border border-white/8 bg-white/[0.03] p-2.5">
+        <div className={`relative ${METRIC_CARD_LG}`}>
           <MetricInfo
             label="Background Areas"
             description="Key areas of your background, each identified by the skill most connected to your experiences, certifications, and projects."
           />
-          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Background Areas</p>
-          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.backgroundAreas}</p>
-          {stats.clusterDetails.length > 0 && (
-            <p className="mt-1 text-[10px] text-white/55 truncate">
-              {stats.clusterDetails.map((c) => c.hub.name).join(', ')}
-            </p>
-          )}
-          {stats.backgroundAreas > 0 && <ClusterDetailList clusters={stats.clusterDetails} />}
+          <button
+            type="button"
+            onClick={() => stats.backgroundAreas > 0 && setAreasExpanded((v) => !v)}
+            className={`w-full text-left ${stats.backgroundAreas > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+          >
+            <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Background Areas</p>
+            <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.backgroundAreas}</p>
+            {stats.clusterDetails.length > 0 && (
+              <p className="mt-1 text-[10px] text-white/55 truncate">
+                {stats.clusterDetails.map((c) => c.hub.name).join(', ')}
+                {stats.backgroundAreas > 0 && (
+                  <span className="ml-1 text-purple-400/70">{areasExpanded ? '▲' : '▼'}</span>
+                )}
+              </p>
+            )}
+          </button>
+          {areasExpanded && <ClusterDetailList clusters={stats.clusterDetails} />}
         </div>
       </div>
 

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -50,18 +50,15 @@ function freshnessColor(score: number): string {
   return 'text-red-400';
 }
 
-function NodeDetailList({ nodes, max = 8 }: { nodes: NodeDetail[]; max?: number }) {
-  const shown = nodes.slice(0, max);
-  const more = nodes.length - shown.length;
+function NodeDetailList({ nodes }: { nodes: NodeDetail[] }) {
   return (
-    <div className="mt-2 space-y-1 max-h-32 overflow-y-auto">
-      {shown.map((n) => (
+    <div className="mt-2 space-y-1 max-h-40 overflow-y-auto">
+      {nodes.map((n) => (
         <div key={n.uid} className="flex items-center gap-2 text-[11px]">
           <span className="text-white/70 truncate flex-1">{n.name}</span>
           <span className="text-white/30 flex-shrink-0">{n.type}</span>
         </div>
       ))}
-      {more > 0 && <p className="text-[10px] text-white/30">+{more} more</p>}
     </div>
   );
 }

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -115,6 +115,41 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
         {hubExpanded && <NodeDetailList nodes={stats.topHubNeighbors} />}
       </div>
 
+      {/* Orphan Nodes — full width below top hub, highlights on hover */}
+      <div
+        className={`relative mt-2 ${METRIC_CARD_LG}`}
+        onMouseEnter={() => stats.orphanNodes > 0 && onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)))}
+        onMouseLeave={() => !orphansExpanded && onHighlight?.(new Set())}
+      >
+        <MetricInfo
+          label="Orphan Nodes"
+          description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
+        />
+        <button
+          type="button"
+          onClick={() => {
+            if (stats.orphanNodes === 0) return;
+            setOrphansExpanded((v) => {
+              const next = !v;
+              if (next) onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)));
+              else onHighlight?.(new Set());
+              return next;
+            });
+          }}
+          className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+        >
+          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>
+          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.orphanNodes}</p>
+          <p className="mt-1 text-[10px] text-white/45">
+            {formatPercent(stats.orphanRate)} of active
+            {stats.orphanNodes > 0 && (
+              <span className="ml-1 text-purple-400/70">{orphansExpanded ? '▲' : '▼'}</span>
+            )}
+          </p>
+        </button>
+        {orphansExpanded && <NodeDetailList nodes={stats.orphanNodeDetails} />}
+      </div>
+
       <div className="mt-2 grid grid-cols-2 gap-2">
         <div className={METRIC_CARD}>
           <p className="text-[10px] uppercase tracking-wide text-white/40">Active Nodes</p>
@@ -159,41 +194,6 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
           <p className={`mt-1 text-lg leading-none font-semibold ${freshnessColor(stats.freshnessScore)}`}>{formatPercent(stats.freshnessScore)}</p>
           <p className="mt-1 text-[10px] text-white/45">recent entries</p>
         </div>
-      </div>
-
-      {/* Orphan Nodes — full width below the grid, highlights on hover */}
-      <div
-        className={`relative mt-2 ${METRIC_CARD_LG}`}
-        onMouseEnter={() => stats.orphanNodes > 0 && onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)))}
-        onMouseLeave={() => !orphansExpanded && onHighlight?.(new Set())}
-      >
-        <MetricInfo
-          label="Orphan Nodes"
-          description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
-        />
-        <button
-          type="button"
-          onClick={() => {
-            if (stats.orphanNodes === 0) return;
-            setOrphansExpanded((v) => {
-              const next = !v;
-              if (next) onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)));
-              else onHighlight?.(new Set());
-              return next;
-            });
-          }}
-          className={`w-full text-left ${stats.orphanNodes > 0 ? 'cursor-pointer' : 'cursor-default'}`}
-        >
-          <p className="pr-7 text-[10px] uppercase tracking-wide text-white/40">Orphan Nodes</p>
-          <p className="mt-1 text-lg leading-none font-semibold text-white">{stats.orphanNodes}</p>
-          <p className="mt-1 text-[10px] text-white/45">
-            {formatPercent(stats.orphanRate)} of active
-            {stats.orphanNodes > 0 && (
-              <span className="ml-1 text-purple-400/70">{orphansExpanded ? '▲' : '▼'}</span>
-            )}
-          </p>
-        </button>
-        {orphansExpanded && <NodeDetailList nodes={stats.orphanNodeDetails} />}
       </div>
 
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { OrbData } from '../../api/orbs';
+import { submitIdea } from '../../api/orbs';
 import { computeOrbisStatsSummary, formatTypeLabel } from './orbisStats';
 
 interface OrbisStatsOverlayProps {
@@ -70,6 +72,10 @@ const METRIC_CARD_LG = 'rounded-lg border border-white/8 bg-white/[0.03] p-2.5 t
 function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
   const [orphansExpanded, setOrphansExpanded] = useState(false);
   const [hubExpanded, setHubExpanded] = useState(false);
+  const [showSuggest, setShowSuggest] = useState(false);
+  const [suggestText, setSuggestText] = useState('');
+  const [suggestSending, setSuggestSending] = useState(false);
+  const [suggestSent, setSuggestSent] = useState(false);
   return (
     <div className="w-[min(336px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md shadow-[0_20px_60px_rgba(0,0,0,0.45)] p-3.5">
       <div className="flex items-start justify-between gap-2">
@@ -191,7 +197,76 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
           <p className={`mt-1 text-lg leading-none font-semibold ${freshnessColor(stats.freshnessScore)}`}>{formatPercent(stats.freshnessScore)}</p>
           <p className="mt-1 text-[10px] text-white/45">recent entries</p>
         </div>
+
+        <button
+          type="button"
+          onClick={() => setShowSuggest(true)}
+          className={`${METRIC_CARD_LG} flex flex-col items-center justify-center gap-1.5 cursor-pointer text-center`}
+        >
+          <svg className="w-4 h-4 text-purple-400/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+          </svg>
+          <p className="text-[10px] text-white/35 leading-tight">
+            {suggestSent ? 'Thanks!' : 'Suggest a metric'}
+          </p>
+        </button>
       </div>
+
+      {showSuggest && createPortal(
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/60" onClick={() => setShowSuggest(false)} />
+          <div className="relative bg-gray-900 border border-gray-700 rounded-2xl p-5 max-w-md w-full mx-4 shadow-2xl">
+            <button
+              type="button"
+              onClick={() => setShowSuggest(false)}
+              className="absolute right-3 top-3 h-8 w-8 rounded-lg border border-gray-700 text-gray-400 hover:bg-gray-800 transition-colors flex items-center justify-center"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+            <h3 className="text-white text-base font-semibold mb-1">Suggest a Metric</h3>
+            <p className="text-gray-400 text-sm mb-4">What metric would you find useful in Orbis Pulse?</p>
+            <textarea
+              autoFocus
+              value={suggestText}
+              onChange={(e) => setSuggestText(e.target.value)}
+              placeholder="Describe the metric you'd like to see..."
+              className="w-full bg-gray-800 border border-gray-700 rounded-xl px-3 py-2.5 text-white text-sm placeholder-gray-500 resize-none h-28 focus:outline-none focus:border-purple-500/50"
+            />
+            <div className="flex items-center justify-end gap-2 mt-4">
+              <button
+                type="button"
+                onClick={() => setShowSuggest(false)}
+                className="h-9 px-4 rounded-lg border border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm font-medium transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={!suggestText.trim() || suggestSending}
+                onClick={async () => {
+                  setSuggestSending(true);
+                  try {
+                    await submitIdea(`[Metric Suggestion] ${suggestText.trim()}`, 'idea');
+                    setSuggestSent(true);
+                    setTimeout(() => setSuggestSent(false), 5000);
+                  } catch { /* best effort */ }
+                  finally {
+                    setSuggestSending(false);
+                    setSuggestText('');
+                    setShowSuggest(false);
+                  }
+                }}
+                className="h-9 px-4 rounded-lg bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white text-sm font-medium transition-colors"
+              >
+                {suggestSending ? 'Sending...' : 'Submit'}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
 
     </div>
   );

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -70,6 +70,7 @@ const METRIC_CARD_LG = 'rounded-lg border border-white/8 bg-white/[0.03] p-2.5 t
 
 function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
   const [orphansExpanded, setOrphansExpanded] = useState(false);
+  const [hubExpanded, setHubExpanded] = useState(false);
   return (
     <div className="w-[min(336px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md shadow-[0_20px_60px_rgba(0,0,0,0.45)] p-3.5">
       <div className="flex items-start justify-between gap-2">
@@ -81,13 +82,23 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         </div>
       </div>
 
-      {/* Top Hub — prominent at the top */}
+      {/* Top Hub — prominent at the top, clickable to show neighbors */}
       <div className={`mt-3 ${METRIC_CARD_LG}`}>
-        <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
-        <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
-        <p className="mt-1 text-[10px] text-white/45">
-          {formatTypeLabel(stats.topHubType)} {stats.topHubDegree > 0 && `\u00b7 ${stats.topHubDegree} active edges`}
-        </p>
+        <button
+          type="button"
+          onClick={() => stats.topHubDegree > 0 && setHubExpanded((v) => !v)}
+          className={`w-full text-left ${stats.topHubDegree > 0 ? 'cursor-pointer' : 'cursor-default'}`}
+        >
+          <p className="text-[10px] uppercase tracking-wide text-white/40">Top Hub</p>
+          <p className="mt-1 text-sm leading-tight text-white/90 truncate">{stats.topHubName}</p>
+          <p className="mt-1 text-[10px] text-white/45">
+            {formatTypeLabel(stats.topHubType)} {stats.topHubDegree > 0 && `\u00b7 ${stats.topHubNeighbors.length} neighbors`}
+            {stats.topHubDegree > 0 && (
+              <span className="ml-1 text-purple-400/70">{hubExpanded ? '▲' : '▼'}</span>
+            )}
+          </p>
+        </button>
+        {hubExpanded && <NodeDetailList nodes={stats.topHubNeighbors} />}
       </div>
 
       <div className="mt-2 grid grid-cols-2 gap-2">

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -6,10 +6,12 @@ interface OrbisStatsOverlayProps {
   data: OrbData;
   filteredNodeIds?: Set<string>;
   hiddenNodeTypes?: Set<string>;
+  onHighlight?: (nodeIds: Set<string>) => void;
 }
 
 interface OrbisPulsePanelProps {
   stats: ReturnType<typeof computeOrbisStatsSummary>;
+  onHighlight?: (nodeIds: Set<string>) => void;
 }
 
 const COMPACT_BREAKPOINT_PX = 1280;
@@ -68,7 +70,7 @@ const METRIC_CARD = 'rounded-lg border border-white/8 bg-white/[0.03] p-2 transi
 const METRIC_CARD_LG = 'rounded-lg border border-white/8 bg-white/[0.03] p-2.5 transition-all duration-200 hover:border-white/20 hover:bg-white/[0.06] hover:shadow-[0_0_12px_rgba(255,255,255,0.04)]';
 
 
-function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
+function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
   const [orphansExpanded, setOrphansExpanded] = useState(false);
   const [hubExpanded, setHubExpanded] = useState(false);
   return (
@@ -82,8 +84,12 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         </div>
       </div>
 
-      {/* Top Hub — prominent at the top, clickable to show neighbors */}
-      <div className={`mt-3 ${METRIC_CARD_LG}`}>
+      {/* Top Hub — prominent at the top, clickable to show neighbors, hover highlights */}
+      <div
+        className={`mt-3 ${METRIC_CARD_LG}`}
+        onMouseEnter={() => stats.topHubNeighbors.length > 0 && onHighlight?.(new Set(stats.topHubNeighbors.map((n) => n.uid)))}
+        onMouseLeave={() => onHighlight?.(new Set())}
+      >
         <button
           type="button"
           onClick={() => stats.topHubDegree > 0 && setHubExpanded((v) => !v)}
@@ -147,8 +153,12 @@ function OrbisPulsePanel({ stats }: OrbisPulsePanelProps) {
         </div>
       </div>
 
-      {/* Orphan Nodes — full width below the grid */}
-      <div className={`relative mt-2 ${METRIC_CARD_LG}`}>
+      {/* Orphan Nodes — full width below the grid, highlights on hover */}
+      <div
+        className={`relative mt-2 ${METRIC_CARD_LG}`}
+        onMouseEnter={() => stats.orphanNodes > 0 && onHighlight?.(new Set(stats.orphanNodeDetails.map((n) => n.uid)))}
+        onMouseLeave={() => onHighlight?.(new Set())}
+      >
         <MetricInfo
           label="Orphan Nodes"
           description="Nodes with no connections to other nodes. Consider linking them to skills or experiences."
@@ -178,6 +188,7 @@ export default function OrbisStatsOverlay({
   data,
   filteredNodeIds = new Set(),
   hiddenNodeTypes = new Set(),
+  onHighlight,
 }: OrbisStatsOverlayProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isCompact, setIsCompact] = useState<boolean>(() => {
@@ -259,7 +270,7 @@ export default function OrbisStatsOverlay({
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
-              <OrbisPulsePanel stats={stats} />
+              <OrbisPulsePanel stats={stats} onHighlight={onHighlight} />
             </div>
           )}
           <button
@@ -292,7 +303,7 @@ export default function OrbisStatsOverlay({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
-          <OrbisPulsePanel stats={stats} />
+          <OrbisPulsePanel stats={stats} onHighlight={onHighlight} />
         </div>
       )}
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -200,15 +200,24 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
 
         <button
           type="button"
-          onClick={() => setShowSuggest(true)}
-          className={`${METRIC_CARD_LG} flex flex-col items-center justify-center gap-1.5 cursor-pointer text-center`}
+          onClick={() => !suggestSent && setShowSuggest(true)}
+          className={`${METRIC_CARD_LG} flex flex-col items-center justify-center gap-1.5 cursor-pointer text-center ${suggestSent ? 'border-emerald-500/30 bg-emerald-500/10' : ''}`}
         >
-          <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-          </svg>
-          <p className="text-[10px] text-purple-300 font-medium leading-tight">
-            {suggestSent ? 'Thanks!' : 'Suggest a metric'}
-          </p>
+          {suggestSent ? (
+            <>
+              <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              <p className="text-[10px] text-emerald-300 font-bold leading-tight">Thanks!</p>
+            </>
+          ) : (
+            <>
+              <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+              <p className="text-[10px] text-purple-300 font-medium leading-tight">Suggest a metric</p>
+            </>
+          )}
         </button>
       </div>
 
@@ -250,7 +259,7 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
                   try {
                     await submitIdea(`[Metric Suggestion] ${suggestText.trim()}`, 'idea');
                     setSuggestSent(true);
-                    setTimeout(() => setSuggestSent(false), 5000);
+                    setTimeout(() => setSuggestSent(false), 8000);
                   } catch { /* best effort */ }
                   finally {
                     setSuggestSending(false);

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -216,14 +216,14 @@ export function computeOrbisStatsSummary(
   const topHubType = topHubNode ? getPrimaryLabel(topHubNode) || null : null;
   const topHubDegree = topHub?.degree ?? 0;
 
-  // 1-hop neighbors of top hub
+  // 1-hop neighbors of top hub, sorted by their edge count (most connected first)
   const topHubNeighbors: NodeDetail[] = topHub
     ? [...(adj.get(topHub.uid) ?? [])]
         .map((uid) => {
           const node = nodesById.get(uid) ?? {};
-          return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
+          return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)), degree: degreeById.get(uid) ?? 0 };
         })
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => b.degree - a.degree || a.name.localeCompare(b.name))
     : [];
 
   // ── Orphan node details ──

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -39,10 +39,8 @@ export interface OrbisStatsSummary {
   orphanRate: number;
   orphanNodeDetails: NodeDetail[];
   freshnessScore: number;
-  skillClusters: number;
+  backgroundAreas: number;
   clusterDetails: ClusterDetail[];
-  bridgeNodes: number;
-  bridgeNodeDetails: NodeDetail[];
   filtersActive: boolean;
 }
 
@@ -230,100 +228,87 @@ export function computeOrbisStatsSummary(
   );
   const freshnessScore = datedNodes.length > 0 ? clampRatio(recentNodes.length / datedNodes.length) : 0;
 
-  // ── Skill clusters & bridge nodes ──
-  // Build adjacency among domain nodes only (Person excluded)
-  const adj = new Map<string, Set<string>>();
-  for (const id of activeDomainIds) adj.set(id, new Set());
+  // ── Background Areas ──
+  // Group non-skill nodes around the skill they're most connected to via USED_SKILL.
+  // Each top skill with linked domain nodes defines a "background area".
+  const skillToMembers = new Map<string, Set<string>>();
   for (const link of activeLinks) {
+    if (link.type !== SKILL_LINK_TYPE) continue;
     const s = getLinkEndpointId(link.source);
     const t = getLinkEndpointId(link.target);
-    adj.get(s)?.add(t);
-    adj.get(t)?.add(s);
+    const sType = getPrimaryLabel(nodesById.get(s) ?? {});
+    const tType = getPrimaryLabel(nodesById.get(t) ?? {});
+
+    let skillUid: string | null = null;
+    let domainUid: string | null = null;
+    if (sType === SKILL_LABEL && tType !== SKILL_LABEL && tType !== PERSON_LABEL) {
+      skillUid = s; domainUid = t;
+    } else if (tType === SKILL_LABEL && sType !== SKILL_LABEL && sType !== PERSON_LABEL) {
+      skillUid = t; domainUid = s;
+    }
+    if (skillUid && domainUid) {
+      if (!skillToMembers.has(skillUid)) skillToMembers.set(skillUid, new Set());
+      skillToMembers.get(skillUid)!.add(domainUid);
+    }
   }
 
-  // Find connected components (BFS) and collect node details per cluster
-  const componentOf = new Map<string, number>();
-  let componentCount = 0;
-  const componentNodeIds: string[][] = [];
-  for (const id of activeDomainIds) {
-    if (componentOf.has(id)) continue;
-    const cid = componentCount++;
-    const queue = [id];
-    componentOf.set(id, cid);
-    const members: string[] = [];
-    while (queue.length > 0) {
-      const cur = queue.shift() as string;
-      members.push(cur);
-      for (const nb of adj.get(cur) ?? []) {
-        if (componentOf.has(nb)) continue;
-        componentOf.set(nb, cid);
-        queue.push(nb);
-      }
+  // Assign each domain node to the skill with the most connections to it.
+  // Track how many USED_SKILL links each node has to each skill.
+  const nodeToSkillLinks = new Map<string, Map<string, number>>();
+  for (const link of activeLinks) {
+    if (link.type !== SKILL_LINK_TYPE) continue;
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    const sType = getPrimaryLabel(nodesById.get(s) ?? {});
+    const tType = getPrimaryLabel(nodesById.get(t) ?? {});
+
+    let skillUid: string | null = null;
+    let domainUid: string | null = null;
+    if (sType === SKILL_LABEL && tType !== SKILL_LABEL && tType !== PERSON_LABEL) {
+      skillUid = s; domainUid = t;
+    } else if (tType === SKILL_LABEL && sType !== SKILL_LABEL && sType !== PERSON_LABEL) {
+      skillUid = t; domainUid = s;
     }
-    componentNodeIds.push(members);
+    if (skillUid && domainUid) {
+      if (!nodeToSkillLinks.has(domainUid)) nodeToSkillLinks.set(domainUid, new Map());
+      const m = nodeToSkillLinks.get(domainUid)!;
+      m.set(skillUid, (m.get(skillUid) ?? 0) + 1);
+    }
   }
-  // Clusters = components with at least 2 nodes, each identified by its most connected node (hub)
-  const clusterDetails: ClusterDetail[] = componentNodeIds
-    .filter((m) => m.length >= 2)
-    .sort((a, b) => b.length - a.length)
-    .map((members) => {
-      // Find the hub: the member with the highest degree in this cluster
-      let hubUid = members[0];
-      let hubDeg = degreeById.get(hubUid) ?? 0;
-      for (const uid of members) {
-        const d = degreeById.get(uid) ?? 0;
-        if (d > hubDeg) { hubUid = uid; hubDeg = d; }
-      }
-      const hubNode = nodesById.get(hubUid) ?? {};
-      const hub: NodeDetail = { uid: hubUid, name: getNodeDisplayName(hubNode), type: formatTypeLabel(getPrimaryLabel(hubNode)) };
+
+  // Each domain node belongs to the skill cluster where it has the most links
+  const clusterMembers = new Map<string, string[]>(); // skillUid -> domainUid[]
+  for (const [domainUid, skillMap] of nodeToSkillLinks) {
+    let bestSkill = '';
+    let bestCount = 0;
+    for (const [skillUid, count] of skillMap) {
+      if (count > bestCount) { bestSkill = skillUid; bestCount = count; }
+    }
+    if (bestSkill) {
+      if (!clusterMembers.has(bestSkill)) clusterMembers.set(bestSkill, []);
+      clusterMembers.get(bestSkill)!.push(domainUid);
+    }
+  }
+
+  // Build cluster details: only clusters with at least 1 member, sorted by size
+  const clusterDetails: ClusterDetail[] = [...clusterMembers.entries()]
+    .filter(([, members]) => members.length >= 1)
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([skillUid, members]) => {
+      const skillNode = nodesById.get(skillUid) ?? {};
+      const hub: NodeDetail = { uid: skillUid, name: getNodeDisplayName(skillNode), type: formatTypeLabel(getPrimaryLabel(skillNode)) };
       const nodes = members.map((uid) => {
         const node = nodesById.get(uid) ?? {};
         return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
       });
       return { hub, size: members.length, nodes };
     });
-  const skillClusters = clusterDetails.length;
 
-  // Bridge nodes: articulation points whose removal increases component count.
-  const apSet = new Set<string>();
-  if (activeDomainIds.size > 0) {
-    const ids = [...activeDomainIds];
-    const disc = new Map<string, number>();
-    const low = new Map<string, number>();
-    const parentMap = new Map<string, string | null>();
-    let timer = 0;
-
-    const dfs = (u: string) => {
-      disc.set(u, timer);
-      low.set(u, timer);
-      timer++;
-      let children = 0;
-      for (const v of adj.get(u) ?? []) {
-        if (!disc.has(v)) {
-          children++;
-          parentMap.set(v, u);
-          dfs(v);
-          low.set(u, Math.min(low.get(u)!, low.get(v)!));
-          if (parentMap.get(u) === null && children > 1) apSet.add(u);
-          if (parentMap.get(u) !== null && low.get(v)! >= disc.get(u)!) apSet.add(u);
-        } else if (v !== parentMap.get(u)) {
-          low.set(u, Math.min(low.get(u)!, disc.get(v)!));
-        }
-      }
-    };
-
-    for (const id of ids) {
-      if (!disc.has(id)) {
-        parentMap.set(id, null);
-        dfs(id);
-      }
-    }
-  }
-  const bridgeNodes = apSet.size;
-  const bridgeNodeDetails: NodeDetail[] = [...apSet].map((uid) => {
-    const node = nodesById.get(uid) ?? {};
-    return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
-  });
+  // Only show top clusters (skip very small ones with just 1 node unless there are few clusters)
+  const meaningfulClusters = clusterDetails.length <= 5
+    ? clusterDetails
+    : clusterDetails.filter((c) => c.size >= 2);
+  const backgroundAreas = meaningfulClusters.length;
 
   return {
     activeNodes: activeDomainNodes.length,
@@ -344,10 +329,8 @@ export function computeOrbisStatsSummary(
     orphanRate,
     orphanNodeDetails,
     freshnessScore,
-    skillClusters,
-    clusterDetails,
-    bridgeNodes,
-    bridgeNodeDetails,
+    backgroundAreas,
+    clusterDetails: meaningfulClusters,
     filtersActive: filteredIds.size > 0 || hiddenTypes.size > 0,
   };
 }

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -29,6 +29,7 @@ export interface OrbisStatsSummary {
   topHubName: string;
   topHubType: string | null;
   topHubDegree: number;
+  topHubNeighbors: NodeDetail[];
   orphanNodes: number;
   orphanRate: number;
   orphanNodeDetails: NodeDetail[];
@@ -194,6 +195,16 @@ export function computeOrbisStatsSummary(
     }
   }
 
+  // ── Adjacency for neighbor lookups ──
+  const adj = new Map<string, Set<string>>();
+  for (const id of activeDomainIds) adj.set(id, new Set());
+  for (const link of activeLinks) {
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    adj.get(s)?.add(t);
+    adj.get(t)?.add(s);
+  }
+
   // ── Top Hub ──
   const topHub = [...activeDomainNodes]
     .map((node) => ({ uid: node.uid, degree: degreeById.get(node.uid) ?? 0 }))
@@ -204,6 +215,16 @@ export function computeOrbisStatsSummary(
   const topHubName = topHubNode ? getNodeDisplayName(topHubNode) : 'No active edges yet';
   const topHubType = topHubNode ? getPrimaryLabel(topHubNode) || null : null;
   const topHubDegree = topHub?.degree ?? 0;
+
+  // 1-hop neighbors of top hub
+  const topHubNeighbors: NodeDetail[] = topHub
+    ? [...(adj.get(topHub.uid) ?? [])]
+        .map((uid) => {
+          const node = nodesById.get(uid) ?? {};
+          return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name))
+    : [];
 
   // ── Orphan node details ──
   const orphanNodeDetails: NodeDetail[] = activeDomainNodes
@@ -235,6 +256,7 @@ export function computeOrbisStatsSummary(
     topHubName,
     topHubType,
     topHubDegree,
+    topHubNeighbors,
     orphanNodes,
     orphanRate,
     orphanNodeDetails,

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -16,12 +16,6 @@ export interface NodeDetail {
   type: string;
 }
 
-export interface ClusterDetail {
-  hub: NodeDetail;
-  size: number;
-  nodes: NodeDetail[];
-}
-
 export interface OrbisStatsSummary {
   activeNodes: number;
   visibleNodes: number;
@@ -39,8 +33,6 @@ export interface OrbisStatsSummary {
   orphanRate: number;
   orphanNodeDetails: NodeDetail[];
   freshnessScore: number;
-  backgroundAreas: number;
-  clusterDetails: ClusterDetail[];
   filtersActive: boolean;
 }
 
@@ -228,46 +220,6 @@ export function computeOrbisStatsSummary(
   );
   const freshnessScore = datedNodes.length > 0 ? clampRatio(recentNodes.length / datedNodes.length) : 0;
 
-  // ── Background Areas ──
-  // Each skill defines a background area. Its size = all domain nodes connected to it
-  // via USED_SKILL edges (the actual neighborhood visible in the graph).
-  const skillNeighbors = new Map<string, Set<string>>();
-  for (const link of activeLinks) {
-    if (link.type !== SKILL_LINK_TYPE) continue;
-    const s = getLinkEndpointId(link.source);
-    const t = getLinkEndpointId(link.target);
-    const sType = getPrimaryLabel(nodesById.get(s) ?? {});
-    const tType = getPrimaryLabel(nodesById.get(t) ?? {});
-
-    let skillUid: string | null = null;
-    let domainUid: string | null = null;
-    if (sType === SKILL_LABEL && tType !== SKILL_LABEL && tType !== PERSON_LABEL) {
-      skillUid = s; domainUid = t;
-    } else if (tType === SKILL_LABEL && sType !== SKILL_LABEL && sType !== PERSON_LABEL) {
-      skillUid = t; domainUid = s;
-    }
-    if (skillUid && domainUid) {
-      if (!skillNeighbors.has(skillUid)) skillNeighbors.set(skillUid, new Set());
-      skillNeighbors.get(skillUid)!.add(domainUid);
-    }
-  }
-
-  // Build cluster details sorted by neighbor count, filter to skills with 2+ neighbors
-  const clusterDetails: ClusterDetail[] = [...skillNeighbors.entries()]
-    .filter(([, members]) => members.size >= 2)
-    .sort((a, b) => b[1].size - a[1].size)
-    .map(([skillUid, memberSet]) => {
-      const skillNode = nodesById.get(skillUid) ?? {};
-      const hub: NodeDetail = { uid: skillUid, name: getNodeDisplayName(skillNode), type: formatTypeLabel(getPrimaryLabel(skillNode)) };
-      const nodes = [...memberSet].map((uid) => {
-        const node = nodesById.get(uid) ?? {};
-        return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
-      });
-      return { hub, size: memberSet.size, nodes };
-    });
-  const meaningfulClusters = clusterDetails;
-  const backgroundAreas = meaningfulClusters.length;
-
   return {
     activeNodes: activeDomainNodes.length,
     visibleNodes: visibleDomainNodes.length,
@@ -287,8 +239,6 @@ export function computeOrbisStatsSummary(
     orphanRate,
     orphanNodeDetails,
     freshnessScore,
-    backgroundAreas,
-    clusterDetails: meaningfulClusters,
     filtersActive: filteredIds.size > 0 || hiddenTypes.size > 0,
   };
 }

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -209,7 +209,7 @@ export function computeOrbisStatsSummary(
     .sort((a, b) => b.degree - a.degree || a.uid.localeCompare(b.uid))[0];
 
   const topHubNode = topHub ? nodesById.get(topHub.uid) : null;
-  const topHubName = topHubNode ? getNodeDisplayName(topHubNode) : 'No active links yet';
+  const topHubName = topHubNode ? getNodeDisplayName(topHubNode) : 'No active edges yet';
   const topHubType = topHubNode ? getPrimaryLabel(topHubNode) || null : null;
   const topHubDegree = topHub?.degree ?? 0;
 
@@ -229,9 +229,9 @@ export function computeOrbisStatsSummary(
   const freshnessScore = datedNodes.length > 0 ? clampRatio(recentNodes.length / datedNodes.length) : 0;
 
   // ── Background Areas ──
-  // Group non-skill nodes around the skill they're most connected to via USED_SKILL.
-  // Each top skill with linked domain nodes defines a "background area".
-  const skillToMembers = new Map<string, Set<string>>();
+  // Each skill defines a background area. Its size = all domain nodes connected to it
+  // via USED_SKILL edges (the actual neighborhood visible in the graph).
+  const skillNeighbors = new Map<string, Set<string>>();
   for (const link of activeLinks) {
     if (link.type !== SKILL_LINK_TYPE) continue;
     const s = getLinkEndpointId(link.source);
@@ -247,67 +247,25 @@ export function computeOrbisStatsSummary(
       skillUid = t; domainUid = s;
     }
     if (skillUid && domainUid) {
-      if (!skillToMembers.has(skillUid)) skillToMembers.set(skillUid, new Set());
-      skillToMembers.get(skillUid)!.add(domainUid);
+      if (!skillNeighbors.has(skillUid)) skillNeighbors.set(skillUid, new Set());
+      skillNeighbors.get(skillUid)!.add(domainUid);
     }
   }
 
-  // Assign each domain node to the skill with the most connections to it.
-  // Track how many USED_SKILL links each node has to each skill.
-  const nodeToSkillLinks = new Map<string, Map<string, number>>();
-  for (const link of activeLinks) {
-    if (link.type !== SKILL_LINK_TYPE) continue;
-    const s = getLinkEndpointId(link.source);
-    const t = getLinkEndpointId(link.target);
-    const sType = getPrimaryLabel(nodesById.get(s) ?? {});
-    const tType = getPrimaryLabel(nodesById.get(t) ?? {});
-
-    let skillUid: string | null = null;
-    let domainUid: string | null = null;
-    if (sType === SKILL_LABEL && tType !== SKILL_LABEL && tType !== PERSON_LABEL) {
-      skillUid = s; domainUid = t;
-    } else if (tType === SKILL_LABEL && sType !== SKILL_LABEL && sType !== PERSON_LABEL) {
-      skillUid = t; domainUid = s;
-    }
-    if (skillUid && domainUid) {
-      if (!nodeToSkillLinks.has(domainUid)) nodeToSkillLinks.set(domainUid, new Map());
-      const m = nodeToSkillLinks.get(domainUid)!;
-      m.set(skillUid, (m.get(skillUid) ?? 0) + 1);
-    }
-  }
-
-  // Each domain node belongs to the skill cluster where it has the most links
-  const clusterMembers = new Map<string, string[]>(); // skillUid -> domainUid[]
-  for (const [domainUid, skillMap] of nodeToSkillLinks) {
-    let bestSkill = '';
-    let bestCount = 0;
-    for (const [skillUid, count] of skillMap) {
-      if (count > bestCount) { bestSkill = skillUid; bestCount = count; }
-    }
-    if (bestSkill) {
-      if (!clusterMembers.has(bestSkill)) clusterMembers.set(bestSkill, []);
-      clusterMembers.get(bestSkill)!.push(domainUid);
-    }
-  }
-
-  // Build cluster details: only clusters with at least 1 member, sorted by size
-  const clusterDetails: ClusterDetail[] = [...clusterMembers.entries()]
-    .filter(([, members]) => members.length >= 1)
-    .sort((a, b) => b[1].length - a[1].length)
-    .map(([skillUid, members]) => {
+  // Build cluster details sorted by neighbor count, filter to skills with 2+ neighbors
+  const clusterDetails: ClusterDetail[] = [...skillNeighbors.entries()]
+    .filter(([, members]) => members.size >= 2)
+    .sort((a, b) => b[1].size - a[1].size)
+    .map(([skillUid, memberSet]) => {
       const skillNode = nodesById.get(skillUid) ?? {};
       const hub: NodeDetail = { uid: skillUid, name: getNodeDisplayName(skillNode), type: formatTypeLabel(getPrimaryLabel(skillNode)) };
-      const nodes = members.map((uid) => {
+      const nodes = [...memberSet].map((uid) => {
         const node = nodesById.get(uid) ?? {};
         return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
       });
-      return { hub, size: members.length, nodes };
+      return { hub, size: memberSet.size, nodes };
     });
-
-  // Only show top clusters (skip very small ones with just 1 node unless there are few clusters)
-  const meaningfulClusters = clusterDetails.length <= 5
-    ? clusterDetails
-    : clusterDetails.filter((c) => c.size >= 2);
+  const meaningfulClusters = clusterDetails;
   const backgroundAreas = meaningfulClusters.length;
 
   return {

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -3,19 +3,6 @@ import type { OrbData, OrbNode } from '../../api/orbs';
 const SKILL_LABEL = 'Skill';
 const PERSON_LABEL = 'Person';
 const SKILL_LINK_TYPE = 'USED_SKILL';
-const DOMAIN_TYPE_UNIVERSE = [
-  'Education',
-  'WorkExperience',
-  'Certification',
-  'Language',
-  'Publication',
-  'Project',
-  'Skill',
-  'Patent',
-  'Award',
-  'Outreach',
-  'Training',
-] as const;
 
 const DATE_FIELDS = [
   'start_date', 'end_date', 'date',
@@ -23,67 +10,43 @@ const DATE_FIELDS = [
   'filing_date', 'grant_date',
 ] as const;
 
-const REQUIRED_FIELDS_BY_TYPE: Record<string, string[]> = {
-  Education: ['institution', 'degree', 'start_date'],
-  WorkExperience: ['title', 'company', 'start_date'],
-  Certification: ['name', 'issuing_organization'],
-  Language: ['name', 'proficiency'],
-  Publication: ['title'],
-  Project: ['title', 'description'],
-  Skill: ['name'],
-  Patent: ['title'],
-  Award: ['title'],
-  Outreach: ['title'],
-  Training: ['title'],
-};
+export interface NodeDetail {
+  uid: string;
+  name: string;
+  type: string;
+}
+
+export interface ClusterDetail {
+  nodes: NodeDetail[];
+}
 
 export interface OrbisStatsSummary {
-  visibleNodes: number;
   activeNodes: number;
-  visibleLinks: number;
+  visibleNodes: number;
   activeLinks: number;
-  hiddenNodes: number;
-  mutedNodes: number;
-  typeDiversity: number;
-  avgLinksPerNode: number;
+  visibleLinks: number;
   density: number;
-  connectivityRate: number;
+  avgLinksPerNode: number;
   skillCoverageRate: number;
   skillLinkedNodes: number;
   skillEligibleNodes: number;
   topHubName: string;
   topHubType: string | null;
   topHubDegree: number;
-  signatureSkillName: string;
-  signatureSkillLinks: number;
-  usedSkillEdges: number;
-  focusTopSkillEdges: number;
-  focusScore: number;
-  careerSpanMonths: number;
-  careerSpanYears: number;
-  careerSpanHasData: boolean;
-  careerSpanLabel: string;
-  recencyScore: number;
-  recentActiveNodes: number;
-  hubConcentration: number;
-  domainBalanceScore: number;
-  completenessRate: number;
-  completeNodes: number;
-  largestClusterRate: number;
-  largestClusterNodes: number;
-  shareReadinessScore: number;
+  orphanNodes: number;
+  orphanRate: number;
+  orphanNodeDetails: NodeDetail[];
+  freshnessScore: number;
+  skillClusters: number;
+  clusterDetails: ClusterDetail[];
+  bridgeNodes: number;
+  bridgeNodeDetails: NodeDetail[];
   filtersActive: boolean;
 }
 
 const DISPLAY_FIELDS = [
-  'name',
-  'title',
-  'company',
-  'institution',
-  'organization',
-  'role',
-  'degree',
-  'issuing_organization',
+  'name', 'title', 'company', 'institution', 'organization',
+  'role', 'degree', 'issuing_organization',
 ] as const;
 
 function getPrimaryLabel(node: Pick<OrbNode, '_labels'> | Record<string, unknown>): string {
@@ -106,7 +69,6 @@ function getNodeDisplayName(node: Record<string, unknown>): string {
     const raw = node[field];
     if (typeof raw === 'string' && raw.trim()) return raw.trim();
   }
-
   const label = getPrimaryLabel(node);
   return label || 'Node';
 }
@@ -114,16 +76,6 @@ function getNodeDisplayName(node: Record<string, unknown>): string {
 function clampRatio(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(1, value));
-}
-
-function hasValue(value: unknown): boolean {
-  if (value == null) return false;
-  if (typeof value === 'string') return value.trim().length > 0;
-  if (typeof value === 'number') return Number.isFinite(value);
-  if (typeof value === 'boolean') return true;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0;
-  return false;
 }
 
 function normalizeDate(raw: string): string | null {
@@ -161,21 +113,12 @@ function toMonthIndex(ym: string): number {
   return year * 12 + (month - 1);
 }
 
-function formatMonthIndex(monthIndex: number): string {
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  const year = Math.floor(monthIndex / 12);
-  const month = monthIndex % 12;
-  return `${months[month]} ${year}`;
+function formatTypeLabel(type: string | null): string {
+  if (!type) return 'Node';
+  return type.replace(/([a-z])([A-Z])/g, '$1 $2');
 }
 
-function isNodeComplete(node: Record<string, unknown>): boolean {
-  const nodeType = getPrimaryLabel(node);
-  const required = REQUIRED_FIELDS_BY_TYPE[nodeType];
-  if (required?.length) {
-    return required.every((key) => hasValue(node[key]));
-  }
-  return DISPLAY_FIELDS.some((field) => hasValue(node[field]));
-}
+export { formatTypeLabel };
 
 export function computeOrbisStatsSummary(
   data: OrbData,
@@ -197,205 +140,202 @@ export function computeOrbisStatsSummary(
     return true;
   });
 
-  const visibleIds = new Set<string>([personId, ...visibleDomainNodes.map((node) => node.uid)]);
+  const visibleDomainIds = new Set(visibleDomainNodes.map((n) => n.uid));
   const activeDomainNodes = visibleDomainNodes.filter((node) => !filteredIds.has(node.uid));
-  const activeIds = new Set<string>([personId, ...activeDomainNodes.map((node) => node.uid)]);
+  const activeDomainIds = new Set(activeDomainNodes.map((n) => n.uid));
+
+  // ── Filter links: exclude Person node edges ──
+  const isPersonEdge = (link: { source: unknown; target: unknown }) => {
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    return s === personId || t === personId;
+  };
 
   const visibleLinks = data.links.filter((link) => {
-    const source = getLinkEndpointId(link.source);
-    const target = getLinkEndpointId(link.target);
-    return source && target && visibleIds.has(source) && visibleIds.has(target);
+    if (isPersonEdge(link)) return false;
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    return s && t && visibleDomainIds.has(s) && visibleDomainIds.has(t);
   });
 
   const activeLinks = visibleLinks.filter((link) => {
-    const source = getLinkEndpointId(link.source);
-    const target = getLinkEndpointId(link.target);
-    return activeIds.has(source) && activeIds.has(target);
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    return activeDomainIds.has(s) && activeDomainIds.has(t);
   });
 
+  // ── Degree counts (Person edges excluded) ──
   const degreeById = new Map<string, number>();
-  for (const id of activeIds) degreeById.set(id, 0);
+  for (const id of activeDomainIds) degreeById.set(id, 0);
   for (const link of activeLinks) {
-    const source = getLinkEndpointId(link.source);
-    const target = getLinkEndpointId(link.target);
-    degreeById.set(source, (degreeById.get(source) ?? 0) + 1);
-    degreeById.set(target, (degreeById.get(target) ?? 0) + 1);
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    degreeById.set(s, (degreeById.get(s) ?? 0) + 1);
+    degreeById.set(t, (degreeById.get(t) ?? 0) + 1);
   }
 
-  const connectedActiveNodes = activeDomainNodes.filter((node) => (degreeById.get(node.uid) ?? 0) > 0).length;
-  const typeDiversity = new Set(activeDomainNodes.map((node) => getPrimaryLabel(node)).filter(Boolean)).size;
-  const avgLinksPerNode = activeDomainNodes.length > 0 ? activeLinks.length / activeDomainNodes.length : 0;
-  const possibleEdges = activeIds.size > 1 ? (activeIds.size * (activeIds.size - 1)) / 2 : 0;
+  // ── Density ──
+  const n = activeDomainIds.size;
+  const avgLinksPerNode = n > 0 ? activeLinks.length / n : 0;
+  const possibleEdges = n > 1 ? (n * (n - 1)) / 2 : 0;
   const density = possibleEdges > 0 ? activeLinks.length / possibleEdges : 0;
 
+  // ── Orphan nodes (0 edges after excluding Person edges) ──
+  const orphanNodes = activeDomainNodes.filter((node) => (degreeById.get(node.uid) ?? 0) === 0).length;
+  const orphanRate = clampRatio(n > 0 ? orphanNodes / n : 0);
+
+  // ── Skill coverage ──
   const skillCoverageCandidates = activeDomainNodes.filter((node) => getPrimaryLabel(node) !== SKILL_LABEL);
   const linkedCandidateIds = new Set<string>();
-  const skillEdgeCountById = new Map<string, number>();
-  let usedSkillEdges = 0;
 
   for (const link of activeLinks) {
     if (link.type !== SKILL_LINK_TYPE) continue;
-    const source = getLinkEndpointId(link.source);
-    const target = getLinkEndpointId(link.target);
-    const sourceType = getPrimaryLabel(nodesById.get(source) ?? {});
-    const targetType = getPrimaryLabel(nodesById.get(target) ?? {});
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    const sType = getPrimaryLabel(nodesById.get(s) ?? {});
+    const tType = getPrimaryLabel(nodesById.get(t) ?? {});
 
-    if (sourceType === SKILL_LABEL && targetType !== SKILL_LABEL && targetType !== PERSON_LABEL) {
-      linkedCandidateIds.add(target);
-      usedSkillEdges += 1;
-      skillEdgeCountById.set(source, (skillEdgeCountById.get(source) ?? 0) + 1);
-    } else if (targetType === SKILL_LABEL && sourceType !== SKILL_LABEL && sourceType !== PERSON_LABEL) {
-      linkedCandidateIds.add(source);
-      usedSkillEdges += 1;
-      skillEdgeCountById.set(target, (skillEdgeCountById.get(target) ?? 0) + 1);
+    if (sType === SKILL_LABEL && tType !== SKILL_LABEL && tType !== PERSON_LABEL) {
+      linkedCandidateIds.add(t);
+    } else if (tType === SKILL_LABEL && sType !== SKILL_LABEL && sType !== PERSON_LABEL) {
+      linkedCandidateIds.add(s);
     }
   }
 
+  // ── Top Hub ──
   const topHub = [...activeDomainNodes]
     .map((node) => ({ uid: node.uid, degree: degreeById.get(node.uid) ?? 0 }))
-    .filter((entry) => entry.degree > 0)
+    .filter((e) => e.degree > 0)
     .sort((a, b) => b.degree - a.degree || a.uid.localeCompare(b.uid))[0];
 
   const topHubNode = topHub ? nodesById.get(topHub.uid) : null;
   const topHubName = topHubNode ? getNodeDisplayName(topHubNode) : 'No active links yet';
   const topHubType = topHubNode ? getPrimaryLabel(topHubNode) || null : null;
   const topHubDegree = topHub?.degree ?? 0;
-  const hubConcentration = clampRatio(activeLinks.length > 0 ? topHubDegree / activeLinks.length : 0);
 
-  const signatureSkill = [...skillEdgeCountById.entries()]
-    .map(([uid, links]) => {
-      const skillNode = nodesById.get(uid) ?? {};
-      return { uid, links, name: getNodeDisplayName(skillNode) };
-    })
-    .sort((a, b) => b.links - a.links || a.name.localeCompare(b.name))[0];
+  // ── Orphan node details ──
+  const orphanNodeDetails: NodeDetail[] = activeDomainNodes
+    .filter((node) => (degreeById.get(node.uid) ?? 0) === 0)
+    .map((node) => ({ uid: node.uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) }));
 
-  const signatureSkillName = signatureSkill?.name ?? 'No linked skill yet';
-  const signatureSkillLinks = signatureSkill?.links ?? 0;
-  const topSkillEntries = [...skillEdgeCountById.values()].sort((a, b) => b - a);
-  const focusTopSkillEdges = topSkillEntries.slice(0, 3).reduce((sum, count) => sum + count, 0);
-  const focusScore = clampRatio(usedSkillEdges > 0 ? focusTopSkillEdges / usedSkillEdges : 0);
-
-  const allDateMonths: number[] = [];
-  for (const node of activeDomainNodes) {
-    const dates = getNormalizedNodeDates(node);
-    for (const date of dates) allDateMonths.push(toMonthIndex(date));
-  }
-
-  const careerSpanHasData = allDateMonths.length > 0;
-  const minDateMonth = careerSpanHasData ? Math.min(...allDateMonths) : 0;
-  const maxDateMonth = careerSpanHasData ? Math.max(...allDateMonths) : 0;
-  const careerSpanMonths = careerSpanHasData ? Math.max(0, maxDateMonth - minDateMonth) : 0;
-  const careerSpanYears = careerSpanMonths / 12;
-  const careerSpanLabel = careerSpanHasData
-    ? `${formatMonthIndex(minDateMonth)} - ${formatMonthIndex(maxDateMonth)}`
-    : 'No dated nodes';
-
+  // ── Freshness score ──
+  // Score based on % of nodes with a date in the last 24 months.
   const currentMonth = referenceDate.getUTCFullYear() * 12 + referenceDate.getUTCMonth();
-  const recencyCutoffMonth = currentMonth - 23;
-  const recentActiveNodes = activeDomainNodes.filter((node) => {
-    const dates = getNormalizedNodeDates(node);
-    if (dates.length === 0) return false;
-    return dates.some((date) => toMonthIndex(date) >= recencyCutoffMonth);
-  }).length;
-  const recencyScore = clampRatio(activeDomainNodes.length > 0 ? recentActiveNodes / activeDomainNodes.length : 0);
+  const recencyCutoff = currentMonth - 23;
+  const datedNodes = activeDomainNodes.filter((node) => getNormalizedNodeDates(node).length > 0);
+  const recentNodes = datedNodes.filter((node) =>
+    getNormalizedNodeDates(node).some((d) => toMonthIndex(d) >= recencyCutoff),
+  );
+  const freshnessScore = datedNodes.length > 0 ? clampRatio(recentNodes.length / datedNodes.length) : 0;
 
-  const domainTypeCounts = new Map<string, number>();
-  for (const node of activeDomainNodes) {
-    const type = getPrimaryLabel(node);
-    if (!type) continue;
-    domainTypeCounts.set(type, (domainTypeCounts.get(type) ?? 0) + 1);
-  }
-  let entropy = 0;
-  for (const count of domainTypeCounts.values()) {
-    const proportion = count / Math.max(1, activeDomainNodes.length);
-    entropy += -proportion * Math.log(proportion);
-  }
-  const maxEntropy = Math.log(DOMAIN_TYPE_UNIVERSE.length);
-  const domainBalanceScore = clampRatio(maxEntropy > 0 ? entropy / maxEntropy : 0);
-
-  const completeNodes = activeDomainNodes.filter((node) => isNodeComplete(node)).length;
-  const completenessRate = clampRatio(activeDomainNodes.length > 0 ? completeNodes / activeDomainNodes.length : 0);
-
-  const adjacency = new Map<string, Set<string>>();
-  for (const id of activeIds) adjacency.set(id, new Set<string>());
+  // ── Skill clusters & bridge nodes ──
+  // Build adjacency among domain nodes only (Person excluded)
+  const adj = new Map<string, Set<string>>();
+  for (const id of activeDomainIds) adj.set(id, new Set());
   for (const link of activeLinks) {
-    const source = getLinkEndpointId(link.source);
-    const target = getLinkEndpointId(link.target);
-    adjacency.get(source)?.add(target);
-    adjacency.get(target)?.add(source);
+    const s = getLinkEndpointId(link.source);
+    const t = getLinkEndpointId(link.target);
+    adj.get(s)?.add(t);
+    adj.get(t)?.add(s);
   }
 
-  let largestClusterNodes = 0;
-  const visited = new Set<string>();
-  for (const id of activeIds) {
-    if (visited.has(id)) continue;
+  // Find connected components (BFS) and collect node details per cluster
+  const componentOf = new Map<string, number>();
+  let componentCount = 0;
+  const componentNodeIds: string[][] = [];
+  for (const id of activeDomainIds) {
+    if (componentOf.has(id)) continue;
+    const cid = componentCount++;
     const queue = [id];
-    visited.add(id);
-    let domainNodeCount = 0;
-
+    componentOf.set(id, cid);
+    const members: string[] = [];
     while (queue.length > 0) {
-      const current = queue.shift() as string;
-      if (current !== personId) domainNodeCount += 1;
-      const neighbors = adjacency.get(current);
-      if (!neighbors) continue;
-      for (const neighbor of neighbors) {
-        if (visited.has(neighbor)) continue;
-        visited.add(neighbor);
-        queue.push(neighbor);
+      const cur = queue.shift() as string;
+      members.push(cur);
+      for (const nb of adj.get(cur) ?? []) {
+        if (componentOf.has(nb)) continue;
+        componentOf.set(nb, cid);
+        queue.push(nb);
       }
     }
-
-    if (domainNodeCount > largestClusterNodes) largestClusterNodes = domainNodeCount;
+    componentNodeIds.push(members);
   }
-  const largestClusterRate = clampRatio(
-    activeDomainNodes.length > 0 ? largestClusterNodes / activeDomainNodes.length : 0,
-  );
+  // Skill clusters = components with at least 2 nodes (meaningful clusters)
+  const clusterDetails: ClusterDetail[] = componentNodeIds
+    .filter((m) => m.length >= 2)
+    .sort((a, b) => b.length - a.length)
+    .map((members) => ({
+      nodes: members.map((uid) => {
+        const node = nodesById.get(uid) ?? {};
+        return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
+      }),
+    }));
+  const skillClusters = clusterDetails.length;
 
-  // Share readiness: weighted blend of profile quality signals.
-  const shareReadinessScore = clampRatio(
-    (0.4 * completenessRate) +
-    (0.25 * (skillCoverageCandidates.length > 0 ? linkedCandidateIds.size / skillCoverageCandidates.length : 0)) +
-    (0.2 * (activeDomainNodes.length > 0 ? connectedActiveNodes / activeDomainNodes.length : 0)) +
-    (0.15 * domainBalanceScore),
-  );
+  // Bridge nodes: articulation points whose removal increases component count.
+  const apSet = new Set<string>();
+  if (activeDomainIds.size > 0) {
+    const ids = [...activeDomainIds];
+    const disc = new Map<string, number>();
+    const low = new Map<string, number>();
+    const parentMap = new Map<string, string | null>();
+    let timer = 0;
+
+    const dfs = (u: string) => {
+      disc.set(u, timer);
+      low.set(u, timer);
+      timer++;
+      let children = 0;
+      for (const v of adj.get(u) ?? []) {
+        if (!disc.has(v)) {
+          children++;
+          parentMap.set(v, u);
+          dfs(v);
+          low.set(u, Math.min(low.get(u)!, low.get(v)!));
+          if (parentMap.get(u) === null && children > 1) apSet.add(u);
+          if (parentMap.get(u) !== null && low.get(v)! >= disc.get(u)!) apSet.add(u);
+        } else if (v !== parentMap.get(u)) {
+          low.set(u, Math.min(low.get(u)!, disc.get(v)!));
+        }
+      }
+    };
+
+    for (const id of ids) {
+      if (!disc.has(id)) {
+        parentMap.set(id, null);
+        dfs(id);
+      }
+    }
+  }
+  const bridgeNodes = apSet.size;
+  const bridgeNodeDetails: NodeDetail[] = [...apSet].map((uid) => {
+    const node = nodesById.get(uid) ?? {};
+    return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
+  });
 
   return {
-    visibleNodes: visibleDomainNodes.length,
     activeNodes: activeDomainNodes.length,
-    visibleLinks: visibleLinks.length,
+    visibleNodes: visibleDomainNodes.length,
     activeLinks: activeLinks.length,
-    hiddenNodes: data.nodes.length - visibleDomainNodes.length,
-    mutedNodes: visibleDomainNodes.length - activeDomainNodes.length,
-    typeDiversity,
-    avgLinksPerNode,
+    visibleLinks: visibleLinks.length,
     density: clampRatio(density),
-    connectivityRate: clampRatio(activeDomainNodes.length > 0 ? connectedActiveNodes / activeDomainNodes.length : 0),
+    avgLinksPerNode,
     skillCoverageRate: clampRatio(
       skillCoverageCandidates.length > 0 ? linkedCandidateIds.size / skillCoverageCandidates.length : 0,
     ),
     skillLinkedNodes: linkedCandidateIds.size,
     skillEligibleNodes: skillCoverageCandidates.length,
-    signatureSkillName,
-    signatureSkillLinks,
-    usedSkillEdges,
-    focusTopSkillEdges,
-    focusScore,
-    careerSpanMonths,
-    careerSpanYears,
-    careerSpanHasData,
-    careerSpanLabel,
-    recencyScore,
-    recentActiveNodes,
-    hubConcentration,
-    domainBalanceScore,
-    completenessRate,
-    completeNodes,
-    largestClusterRate,
-    largestClusterNodes,
-    shareReadinessScore,
     topHubName,
     topHubType,
     topHubDegree,
+    orphanNodes,
+    orphanRate,
+    orphanNodeDetails,
+    freshnessScore,
+    skillClusters,
+    clusterDetails,
+    bridgeNodes,
+    bridgeNodeDetails,
     filtersActive: filteredIds.size > 0 || hiddenTypes.size > 0,
   };
 }

--- a/frontend/src/components/graph/orbisStats.ts
+++ b/frontend/src/components/graph/orbisStats.ts
@@ -17,6 +17,8 @@ export interface NodeDetail {
 }
 
 export interface ClusterDetail {
+  hub: NodeDetail;
+  size: number;
   nodes: NodeDetail[];
 }
 
@@ -260,16 +262,26 @@ export function computeOrbisStatsSummary(
     }
     componentNodeIds.push(members);
   }
-  // Skill clusters = components with at least 2 nodes (meaningful clusters)
+  // Clusters = components with at least 2 nodes, each identified by its most connected node (hub)
   const clusterDetails: ClusterDetail[] = componentNodeIds
     .filter((m) => m.length >= 2)
     .sort((a, b) => b.length - a.length)
-    .map((members) => ({
-      nodes: members.map((uid) => {
+    .map((members) => {
+      // Find the hub: the member with the highest degree in this cluster
+      let hubUid = members[0];
+      let hubDeg = degreeById.get(hubUid) ?? 0;
+      for (const uid of members) {
+        const d = degreeById.get(uid) ?? 0;
+        if (d > hubDeg) { hubUid = uid; hubDeg = d; }
+      }
+      const hubNode = nodesById.get(hubUid) ?? {};
+      const hub: NodeDetail = { uid: hubUid, name: getNodeDisplayName(hubNode), type: formatTypeLabel(getPrimaryLabel(hubNode)) };
+      const nodes = members.map((uid) => {
         const node = nodesById.get(uid) ?? {};
         return { uid, name: getNodeDisplayName(node), type: formatTypeLabel(getPrimaryLabel(node)) };
-      }),
-    }));
+      });
+      return { hub, size: members.length, nodes };
+    });
   const skillClusters = clusterDetails.length;
 
   // Bridge nodes: articulation points whose removal increases component count.

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -959,6 +959,7 @@ export default function OrbViewPage() {
           data={data}
           filteredNodeIds={filteredNodeIds}
           hiddenNodeTypes={hiddenNodeTypes}
+          onHighlight={setHighlightedNodeIds}
         />
       )}
 

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -331,6 +331,7 @@ export default function SharedOrbPage() {
         data={data}
         filteredNodeIds={dateFilteredNodeIds}
         hiddenNodeTypes={hiddenNodeTypes}
+        onHighlight={setHighlightedNodeIds}
       />
 
       {/* ── Chat Box (no Add / Share buttons) ── */}

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -8,6 +8,7 @@ import NodeTypeFilter from '../components/graph/NodeTypeFilter';
 import ChatBox from '../components/chat/ChatBox';
 import type { ChatMessage } from '../components/chat/ChatBox';
 import DateRangeSlider from '../components/graph/DateRangeSlider';
+import OrbisStatsOverlay from '../components/graph/OrbisStatsOverlay';
 import { useDateFilterStore, computeDateFilteredNodeIds, getNodeDates } from '../stores/dateFilterStore';
 
 const ALL_FILTERABLE_TYPES = ['Education', 'WorkExperience', 'Certification', 'Language', 'Publication', 'Project', 'Skill', 'Patent', 'Award', 'Outreach', 'Training'];
@@ -324,6 +325,12 @@ export default function SharedOrbPage() {
         height={dimensions.height}
         focusNodeId={focusRequest?.nodeUid || null}
         focusNodeToken={focusRequest?.seq ?? 0}
+      />
+
+      <OrbisStatsOverlay
+        data={data}
+        filteredNodeIds={dateFilteredNodeIds}
+        hiddenNodeTypes={hiddenNodeTypes}
       />
 
       {/* ── Chat Box (no Add / Share buttons) ── */}


### PR DESCRIPTION
## Summary
Complete overhaul of the Orbis Pulse panel with more meaningful, interactive metrics.

### Metrics changes
- **Exclude Person node edges** from all edge computations (Active Edges, Density, etc.) — the central violet node is for visualization only
- **Replace Density** with **Avg Edges/Node** — intuitive and actionable
- **Add Orphan Nodes** (count + %) — expandable list showing unlinked nodes, with graph highlighting on hover
- **Add Freshness** (%) — % of dated nodes updated in the last 24 months, color-coded (green/amber/red)
- **Clickable Top Hub** — expands to show all 1-hop neighbors sorted by edge count, with graph highlighting on hover
- **Remove Share Readiness** — replaced by more granular metrics
- **Simplify Skill Coverage** tooltip — "% of non-skill nodes linked to at least one skill"
- **Add "Suggest a metric"** cell — users can submit metric ideas via the ideas API

### Interaction
- Hovering over Top Hub highlights its neighbors in the graph
- Hovering over Orphan Nodes highlights all orphan nodes in the graph
- Expanding a dropdown keeps highlights persistent; collapsing clears them
- Hover glow effect on all metric cards
- Metric info tooltips render above the chatbox (z-index fix)

### Other
- **Orbis Pulse on SharedOrbPage** — visitors see metrics computed from the nodes/edges visible to them
- **"edges" terminology** throughout (replaced "links")
- Top Hub moved to top of panel, Orphan Nodes below it

## Test plan
- [ ] Verify all metrics compute correctly (Active Nodes/Edges exclude Person node)
- [ ] Click Top Hub → neighbor list expands, sorted by edge count; hover highlights graph
- [ ] Click Orphan Nodes → list expands; hover highlights graph; collapsing clears highlights
- [ ] Freshness shows correct % with color coding
- [ ] Avg Edges/Node shows correct average
- [ ] "Suggest a metric" → modal opens, submit stores in ideas table, "Thanks!" shows for 4s
- [ ] Info tooltips render in front of chatbox (not behind)
- [ ] SharedOrbPage shows Orbis Pulse with correct metrics
- [ ] Desktop and mobile layouts correct

## Documentation
No doc changes needed — UI metrics panel only.