### PR TITLE
fix(cv): persist unmatched CV entries as draft notes

### DIFF
--- a/backend/app/drafts/db.py
+++ b/backend/app/drafts/db.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from app.db.postgres import get_pool
 
 
@@ -15,7 +17,7 @@ async def list_drafts(user_id: str) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-async def create_draft(uid: str, user_id: str, text: str, now: str) -> dict:
+async def create_draft(uid: str, user_id: str, text: str, now: datetime) -> dict:
     pool = await get_pool()
     await pool.execute(
         "INSERT INTO drafts (uid, user_id, text, created_at, updated_at) "
@@ -29,7 +31,7 @@ async def create_draft(uid: str, user_id: str, text: str, now: str) -> dict:
     return {"uid": uid, "text": text, "created_at": now, "updated_at": now}
 
 
-async def update_draft(uid: str, user_id: str, text: str, now: str) -> dict | None:
+async def update_draft(uid: str, user_id: str, text: str, now: datetime) -> dict | None:
     pool = await get_pool()
     result = await pool.execute(
         "UPDATE drafts SET text = $1, updated_at = $2 WHERE uid = $3 AND user_id = $4",

--- a/backend/app/drafts/models.py
+++ b/backend/app/drafts/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
@@ -16,5 +18,5 @@ class DraftUpdate(BaseModel):
 class DraftOut(BaseModel):
     uid: str
     text: str
-    created_at: str
-    updated_at: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/drafts/router.py
+++ b/backend/app/drafts/router.py
@@ -14,8 +14,8 @@ from app.drafts.models import DraftCreate, DraftOut, DraftUpdate
 router = APIRouter(prefix="/drafts", tags=["drafts"])
 
 
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 @router.get("", response_model=list[DraftOut])
@@ -31,8 +31,7 @@ async def create_draft(
 ):
     """Create a new draft note."""
     uid = str(uuid.uuid4())
-    now = _now_iso()
-    return await db.create_draft(uid, current_user["user_id"], body.text, now)
+    return await db.create_draft(uid, current_user["user_id"], body.text, _now())
 
 
 @router.put("/{uid}", response_model=DraftOut)
@@ -42,8 +41,7 @@ async def update_draft(
     current_user: dict = Depends(get_current_user),
 ):
     """Update a draft's text."""
-    now = _now_iso()
-    result = await db.update_draft(uid, current_user["user_id"], body.text, now)
+    result = await db.update_draft(uid, current_user["user_id"], body.text, _now())
     if result is None:
         raise HTTPException(status_code=404, detail="Draft not found")
     return result

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -71,6 +71,8 @@ interface ExtractedDataReviewProps {
     pageCount?: number | null,
     profile?: ExtractedProfile | null,
   ) => Promise<void>;
+  /** Fired after confirm + unmatched drafts save completes, before navigation. */
+  onComplete?: () => void | Promise<void>;
   /** Extra content rendered below the header (e.g., checkbox) */
   children?: React.ReactNode;
 }
@@ -90,6 +92,7 @@ export default function ExtractedDataReview({
   fileSizeBytes,
   pageCount,
   onConfirm: onConfirmOverride,
+  onComplete,
   children,
 }: ExtractedDataReviewProps) {
   const navigate = useNavigate();
@@ -157,6 +160,9 @@ export default function ExtractedDataReview({
             } catch { /* best effort */ }
           }
         }
+      }
+      if (onComplete) {
+        try { await onComplete(); } catch { /* best effort */ }
       }
       await fetchUser();
       if (isReplaceMode && replaced > 0) {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1072,6 +1072,13 @@ export default function OrbViewPage() {
               setExtractedImport(null);
               fetchDocuments();
             }}
+            onComplete={async () => {
+              if (!userId) return;
+              try {
+                const notes = await loadDraftNotesAsync(userId);
+                setDraftNotes(notes);
+              } catch { /* best effort */ }
+            }}
             documentId={extractedImport.documentId}
             originalFilename={extractedImport.file.name}
             fileSizeBytes={extractedImport.file.size}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -157,6 +157,7 @@ export default function OrbViewPage() {
     cvOwnerName: string | null;
     profile: import('../api/cv').ExtractedProfile | null;
     unmatchedCount: number;
+    unmatchedEntries: string[];
     skippedCount: number;
     file: File;
     documentId: string | null;
@@ -223,6 +224,7 @@ export default function OrbViewPage() {
             cvOwnerName: job.result.cv_owner_name || null,
             profile: job.result.profile || null,
             unmatchedCount: job.result.unmatched?.length || 0,
+            unmatchedEntries: job.result.unmatched || [],
             skippedCount: job.result.skipped_nodes?.length || 0,
             file: new File([], job.filename || 'document'),
             documentId: job.result.document_id || null,
@@ -528,6 +530,7 @@ export default function OrbViewPage() {
                 cvOwnerName: job.result.cv_owner_name || null,
                 profile: job.result.profile || null,
                 unmatchedCount: job.result.unmatched?.length || 0,
+                unmatchedEntries: job.result.unmatched || [],
                 skippedCount: job.result.skipped_nodes?.length || 0,
                 file,
                 documentId: job.result.document_id || null,
@@ -615,6 +618,7 @@ export default function OrbViewPage() {
                     cvOwnerName: job.result.cv_owner_name || null,
                     profile: job.result.profile || null,
                     unmatchedCount: job.result.unmatched?.length || 0,
+                    unmatchedEntries: job.result.unmatched || [],
                     skippedCount: job.result.skipped_nodes?.length || 0,
                     file: new File([], job.filename || 'document'),
                     documentId: job.result.document_id || null,
@@ -1058,6 +1062,7 @@ export default function OrbViewPage() {
             cvOwnerName={extractedImport.cvOwnerName}
             profile={extractedImport.profile}
             unmatchedCount={extractedImport.unmatchedCount}
+            unmatchedEntries={extractedImport.unmatchedEntries}
             skippedCount={extractedImport.skippedCount}
             truncated={false}
             onReset={() => setExtractedImport(null)}


### PR DESCRIPTION
## Summary
The "N entries were not classified and moved to Draft Notes" banner shown after a CV import was a no-op: users saw the promise but the drafts never appeared. Three independent bugs stacked on top of each other:

1. **Frontend (import overlay)** — `OrbViewPage` stored only `unmatchedCount` (a number) in `extractedImport` state and dropped the actual strings, so the draft-save loop inside `ExtractedDataReview.handleConfirm` had no payload to save.
2. **Frontend (drafts panel stale)** — After confirming an import, `OrbViewPage` stays mounted and its `draftNotes` state is only hydrated once on `userId` change, so even a successful save wouldn't appear until a full page refresh.
3. **Backend (silent 500 on every draft save)** — `_now_iso()` passed ISO strings to asyncpg, which rejects strings for `TIMESTAMP WITH TIME ZONE` columns (`DataError: expected a datetime.date or datetime.datetime instance, got 'str'`). Every `POST /drafts` returned 500, and the frontend `try/catch` fallback silently returned an in-memory "ghost" draft that was never persisted. `DraftOut` was also broken on the read side: the DB returns `datetime` while the model declared `str`, so `GET /drafts` would 500 as soon as the table had rows.

## Changes
- `OrbViewPage.tsx` — add `unmatchedEntries: string[]` to the `extractedImport` state and populate it at all three `setExtractedImport` call sites (`?review=` deeplink, `doImport` poll, "Review now" banner), then pass it as a prop to `ExtractedDataReview`.
- `ExtractedDataReview.tsx` — add an `onComplete?: () => void | Promise<void>` prop fired after the drafts save loop (best-effort), so callers can refresh their local draft state.
- `OrbViewPage.tsx` (import overlay) — pass `onComplete` that re-runs `loadDraftNotesAsync(userId)` and calls `setDraftNotes(...)` so the panel reflects the new entries without a page refresh.
- `backend/app/drafts/models.py` — switch `DraftOut.created_at` / `updated_at` from `str` to `datetime`. FastAPI serializes `datetime` to ISO strings in JSON and the frontend already parses with `new Date(...)`, so no client-side change required.
- `backend/app/drafts/router.py` — rename `_now_iso()` → `_now()` returning `datetime`, pass it through to the DB layer.
- `backend/app/drafts/db.py` — update `create_draft` / `update_draft` signatures to accept `datetime` for the timestamp parameter.

## Test plan
- [ ] Upload a CV with unclassifiable sections (e.g. `scripts/test_cv_with_unmatched.pdf`) via Import document in `/myorbis`
- [ ] Confirm the extraction review shows "N entries were not classified and moved to Draft Notes"
- [ ] Click Add and verify:
  - [ ] The N entries appear in the Draft Notes panel without a page refresh
  - [ ] The `drafts` table in Postgres has N new rows for the user
  - [ ] No 500 in the browser Network tab for `POST /api/drafts`
- [ ] Repeat the flow via the `?review=<job_id>` deep link and the "Review now" banner
- [ ] `GET /api/drafts` returns the created entries with ISO-string timestamps

## Documentation
No doc changes needed — bug fixes only, no API-contract or structural changes (`DraftOut` timestamps were already ISO strings over the wire; only the backend representation changed).