### PR TITLE
fix(ui): suggest-a-metric modal click fix, favicon and web manifest

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon-192.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#7c3aed" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/public/favicon-192.svg
+++ b/frontend/public/favicon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192" fill="none">
+  <circle cx="96" cy="96" r="84" fill="#7c3aed" fill-opacity="0.4" stroke="#a78bfa" stroke-opacity="0.5" stroke-width="4"/>
+  <circle cx="96" cy="96" r="30" fill="#c4b5fd"/>
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
-  <circle cx="16" cy="16" r="14" fill="#7c3aed" fill-opacity="0.3" stroke="#8b5cf6" stroke-opacity="0.4" stroke-width="1.5"/>
-  <circle cx="16" cy="16" r="6" fill="#a78bfa"/>
+  <circle cx="16" cy="16" r="14" fill="#7c3aed" fill-opacity="0.4" stroke="#a78bfa" stroke-opacity="0.5" stroke-width="1.5"/>
+  <circle cx="16" cy="16" r="5" fill="#c4b5fd"/>
 </svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "OpenOrbis",
+  "short_name": "OpenOrbis",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/favicon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#08060d",
+  "theme_color": "#7c3aed"
+}

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -223,9 +223,17 @@ function OrbisPulsePanel({ stats, onHighlight }: OrbisPulsePanelProps) {
       </div>
 
       {showSuggest && createPortal(
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/60" onClick={() => setShowSuggest(false)} />
-          <div className="relative bg-gray-900 border border-gray-700 rounded-2xl p-5 max-w-md w-full mx-4 shadow-2xl">
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center"
+          onClick={() => setShowSuggest(false)}
+          onPointerDown={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="absolute inset-0 bg-black/60" />
+          <div
+            className="relative bg-gray-900 border border-gray-700 rounded-2xl p-5 max-w-md w-full mx-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <button
               type="button"
               onClick={() => setShowSuggest(false)}


### PR DESCRIPTION
## Summary
- **Modal click fix**: prevent "Suggest a metric" modal from closing when clicking inside it — added `stopPropagation` on `pointerdown`, `mousedown`, and `click` events on both the wrapper and inner modal div
- **Favicon brightened**: more vivid purple to better match the OpenOrbis logo
- **Web manifest + apple-touch-icon**: added `manifest.json` with proper app name, icons, and theme color so browsers, bookmark sidebars, and mobile home screens show the correct OpenOrbis purple orb icon

Closes #360

## Test plan
- [ ] Click "Suggest a metric" → modal stays open when clicking textarea, empty space, or buttons inside
- [ ] Modal closes only on: Submit, Cancel, X, or backdrop click
- [ ] Browser tab shows updated purple favicon
- [ ] Bookmark sidebar / mobile home screen shows OpenOrbis icon (may need cache clear)

## Documentation
No doc changes needed.