### PR TITLE
ops(deploy): keep orbis-api warm with min-instances=1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,7 +223,7 @@ jobs:
             --memory=1Gi \
             --cpu=1 \
             --concurrency=80 \
-            --min-instances=0 \
+            --min-instances=1 \
             --max-instances=10 \
             --timeout=300s \
             --allow-unauthenticated \


### PR DESCRIPTION
## Summary
- Bumps `--min-instances` from `0` to `1` for the `orbis-api` Cloud Run service in the deploy workflow.
- `orbis-mcp` stays at `min-instances=0` (admin-only traffic, not worth the idle cost).

## Why
Cold starts on `orbis-api` are ~5–6s because the container has to init VPC connector + Cloud SQL + Neo4j bolt session on boot. Evidence from prod logs (last 24h):

- `18:50:33` — new instance (reason: `AUTOSCALING`, no warm capacity)
- `18:50:39` — `Application startup complete` → ~6s boot
- the `/api/auth/me` request that triggered the spin-up returned after **5.99s**

`startup-cpu-boost` is already on, so there's no further boot-time tuning available without a container redesign. Pinning one warm instance is the simplest fix.

## Cost impact
1 vCPU + 1Gi RAM always-allocated in `europe-west1` ≈ **\$13–15/month**. Worth monitoring billing after 1–2 days.

## Rollout note
The workflow triggers on `release.published`, so this only takes effect at the next tagged release. To apply immediately without waiting, run once manually:

\`\`\`
gcloud run services update orbis-api \\
  --region=europe-west1 --project=open-orbis \\
  --min-instances=1
\`\`\`

## Test plan
- [ ] Merge, cut a release, confirm the deploy job runs with the new flag
- [ ] After deploy, \`gcloud run services describe orbis-api\` shows \`autoscaling.knative.dev/minScale: '1'\`
- [ ] First request after idle returns in <1s (no cold start)
- [ ] Check billing dashboard 24–48h later to confirm cost delta is in the expected range

## Documentation
No doc changes needed — this is a deploy-config tweak, no architectural or API change.