### PR TITLE
feat(share): add Show QR button to share panel (#365)

### DIFF
--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -450,6 +450,15 @@
   next_state: SHARE_PANEL (copied feedback)
   fallback_on_failure: null
 
+- id: SHARE_SHOW_QR
+  from_state: SHARE_PANEL
+  action: Click Show QR on public or per-token link
+  selector_or_control: "Show QR button next to Copy URL"
+  preconditions: [orb_id_set]
+  expected_effect: Opens QrShareModal with a violet-on-white QR for the link; offers SVG/PNG download
+  next_state: SHARE_PANEL (qr modal open)
+  fallback_on_failure: null
+
 # ── Shared Orb (Public) ──
 
 - id: SHARED_SEARCH

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -438,7 +438,7 @@ function AccountSettingsModal({ orbId, onOrbIdChanged, onClose, onStartTour }: {
   ];
 
   return (
-    <div className="fixed inset-0 z-[120] flex items-start sm:items-center justify-center p-2 sm:p-4 overflow-y-auto">
+    <div className="fixed inset-0 z-[200] flex items-start sm:items-center justify-center p-2 sm:p-4 overflow-y-auto">
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -348,7 +348,7 @@ export default function OrbisStatsOverlay({
     <div
       ref={containerRef}
       data-tour="orbis-pulse"
-      className="pointer-events-none fixed right-4 bottom-32 z-[45] sm:right-6 sm:bottom-8"
+      className="pointer-events-none fixed right-4 bottom-32 z-[30] sm:right-6 sm:bottom-8"
     >
       {dismissed ? (
         /* Collapsed pill — click to re-open */

--- a/frontend/src/components/graph/QrShareModal.tsx
+++ b/frontend/src/components/graph/QrShareModal.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { QRCodeSVG } from 'qrcode.react';
+
+interface QrShareModalProps {
+  open: boolean;
+  url: string;
+  onClose: () => void;
+}
+
+// Orbis brand — violet family (derived from public/favicon.svg + manifest theme_color).
+// Foreground is #7c3aed on white ≈ 8:1 contrast (AAA), safe for reliable scanning.
+const QR_FG = '#7c3aed';
+const QR_BG = '#ffffff';
+
+function serializeQr(svgWrap: HTMLDivElement): { blob: Blob; width: number; height: number } | null {
+  const svgEl = svgWrap.querySelector('svg');
+  if (!svgEl) return null;
+  const clone = svgEl.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  const rect = svgEl.getBoundingClientRect();
+  const serialized = new XMLSerializer().serializeToString(clone);
+  return {
+    blob: new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' }),
+    width: Math.max(1, Math.round(rect.width)),
+    height: Math.max(1, Math.round(rect.height)),
+  };
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const href = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(href);
+}
+
+export default function QrShareModal({ open, url, onClose }: QrShareModalProps) {
+  const svgWrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  const handleDownloadSvg = () => {
+    if (!svgWrapRef.current) return;
+    const data = serializeQr(svgWrapRef.current);
+    if (!data) return;
+    triggerDownload(data.blob, 'orbis-qr.svg');
+  };
+
+  const handleDownloadPng = () => {
+    if (!svgWrapRef.current) return;
+    const data = serializeQr(svgWrapRef.current);
+    if (!data) return;
+    const svgUrl = URL.createObjectURL(data.blob);
+    const img = new Image();
+    img.onload = () => {
+      const scale = 4; // crisp for print
+      const canvas = document.createElement('canvas');
+      canvas.width = data.width * scale;
+      canvas.height = data.height * scale;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        URL.revokeObjectURL(svgUrl);
+        return;
+      }
+      ctx.fillStyle = QR_BG;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob((pngBlob) => {
+        URL.revokeObjectURL(svgUrl);
+        if (!pngBlob) return;
+        triggerDownload(pngBlob, 'orbis-qr.png');
+      }, 'image/png');
+    };
+    img.onerror = () => URL.revokeObjectURL(svgUrl);
+    img.src = svgUrl;
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+          />
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Share via QR code"
+            initial={{ opacity: 0, scale: 0.92, y: 24 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.92, y: 24 }}
+            transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+            className="relative w-[92vw] max-w-sm mx-2 sm:mx-4 rounded-3xl p-1 shadow-[0_0_80px_rgba(124,58,237,0.35)]"
+            style={{
+              background:
+                'linear-gradient(140deg, rgba(196,181,253,0.65) 0%, rgba(124,58,237,0.55) 50%, rgba(59,7,100,0.55) 100%)',
+            }}
+          >
+            <div className="relative rounded-[22px] bg-white px-6 pt-6 pb-5 flex flex-col items-center">
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center text-violet-900/40 hover:text-violet-900 hover:bg-violet-100 transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+
+              <p className="text-[10px] tracking-[0.25em] uppercase text-violet-600/70 font-semibold mb-4">
+                Orbis QR
+              </p>
+
+              <div
+                ref={svgWrapRef}
+                className="rounded-2xl bg-white p-3 ring-1 ring-violet-200/80 shadow-inner"
+              >
+                <QRCodeSVG
+                  value={url || ' '}
+                  size={224}
+                  bgColor={QR_BG}
+                  fgColor={QR_FG}
+                  level="M"
+                  marginSize={2}
+                />
+              </div>
+
+              <div className="mt-5 grid grid-cols-2 gap-2 w-full">
+                <button
+                  type="button"
+                  onClick={handleDownloadSvg}
+                  className="h-9 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold transition-colors flex items-center justify-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3" />
+                  </svg>
+                  SVG
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDownloadPng}
+                  className="h-9 rounded-lg bg-violet-100 hover:bg-violet-200 text-violet-800 text-xs font-semibold transition-colors flex items-center justify-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3" />
+                  </svg>
+                  PNG
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/graph/SharePanel.tsx
+++ b/frontend/src/components/graph/SharePanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useFilterStore } from '../../stores/filterStore';
 import { useToastStore } from '../../stores/toastStore';
+import QrShareModal from './QrShareModal';
 import {
   createAccessGrant,
   createShareToken,
@@ -58,6 +59,7 @@ export default function SharePanel({
   const { keywords, activeKeywords, addKeyword, removeKeyword, toggleKeyword, deactivateAll } = useFilterStore();
   const [inlineFilterKeyword, setInlineFilterKeyword] = useState('');
   const [privacyHiddenTypes, setPrivacyHiddenTypes] = useState<Set<string>>(new Set());
+  const [qrShareUrl, setQrShareUrl] = useState<string | null>(null);
   const privacyHiddenTypesArray = useMemo(() => Array.from(privacyHiddenTypes), [privacyHiddenTypes]);
   const hiddenTypesArray = useMemo(() => Array.from(hiddenNodeTypes), [hiddenNodeTypes]);
   const hasActiveFilters = activeKeywords.length > 0 || privacyHiddenTypesArray.length > 0;
@@ -431,7 +433,18 @@ export default function SharePanel({
                 onClick={() => { navigator.clipboard.writeText(bareUrl); addToast('Orbis link copied', 'success'); }}
                 className="h-10 px-4 rounded-lg bg-gray-700 hover:bg-gray-600 border border-gray-600 text-white text-sm font-medium transition-colors shrink-0"
               >
-                Copy
+                Copy URL
+              </button>
+              <button
+                type="button"
+                onClick={() => setQrShareUrl(bareUrl)}
+                className="h-10 px-4 rounded-lg bg-violet-600 hover:bg-violet-700 border border-violet-500 text-white text-sm font-medium transition-colors shrink-0 flex items-center gap-1.5"
+                aria-label="Show QR code for Orbis link"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h3v3h-3zM17 17h3v3h-3zM14 20h3" />
+                </svg>
+                Show QR
               </button>
             </div>
           </div>
@@ -680,6 +693,17 @@ export default function SharePanel({
                                 className="h-7 px-2 rounded border border-gray-700 bg-gray-800 hover:bg-gray-700 text-white text-[10px] font-medium transition-colors shrink-0"
                               >
                                 Copy URL
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setQrShareUrl(`${bareUrl}?token=${token.token_id}`)}
+                                className="h-7 px-2 rounded border border-violet-500/60 bg-violet-600/80 hover:bg-violet-600 text-white text-[10px] font-medium transition-colors shrink-0 flex items-center gap-1"
+                                aria-label="Show QR code for this token URL"
+                              >
+                                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h3v3h-3zM17 17h3v3h-3zM14 20h3" />
+                                </svg>
+                                Show QR
                               </button>
                               <button
                                 type="button"
@@ -1019,6 +1043,11 @@ export default function SharePanel({
           </>
         )}
       </AnimatePresence>
+      <QrShareModal
+        open={!!qrShareUrl}
+        url={qrShareUrl ?? ''}
+        onClose={() => setQrShareUrl(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -645,7 +645,7 @@ export default function OrbViewPage() {
       )}
 
       {/* ── Header ── */}
-      <div className={`absolute left-0 right-0 z-30 px-3 sm:px-5 py-2 sm:py-3 ${isPendingDeletion ? 'top-8' : 'top-0'}`}>
+      <div className={`absolute left-0 right-0 z-[50] px-3 sm:px-5 py-2 sm:py-3 ${isPendingDeletion ? 'top-8' : 'top-0'}`}>
         <div className="rounded-xl border border-white/10 bg-black/45 backdrop-blur-md shadow-lg shadow-black/30">
           <div className="flex items-center justify-between gap-2 px-2.5 sm:px-3 py-2 min-h-[44px]">
             <div className="flex items-center gap-2 sm:gap-3 min-w-0">


### PR DESCRIPTION
Closes #365.

## Summary
- New `QrShareModal` component renders a violet-on-white QR for any share URL with side-by-side **SVG** and **PNG** download actions. Violet `#7c3aed` on white (~8:1 contrast, AAA) scans reliably; no center logo.
- Wired into `SharePanel` for both share entry points:
  - **Public** *Orbis Link* row — renamed `Copy` → `Copy URL` and added `Show QR`.
  - **Restricted** *share-token* rows — added `Show QR` next to `Copy URL`.
- Fixed the stacking bug where the UserMenu dropdown rendered behind the Orbis Pulse panel: header wrapper lifted to `z-[50]`, Pulse dropped to `z-[30]`, and `AccountSettingsModal` bumped to `z-[200]`.

## Test plan
- [ ] Open SharePanel on a public orb → click **Show QR** → scan with phone, verify it resolves to the bareUrl.
- [ ] Download SVG and PNG → open both, verify crisp rendering and that PNG has a solid white background at 4× scale.
- [ ] Switch orb to restricted → create a share token → click **Show QR** on that row → scan, verify token URL resolves with the correct filter.
- [ ] Open the UserMenu dropdown while the Orbis Pulse panel is visible — dropdown must overlap pulse.
- [ ] Open Account Settings while Pulse is visible — modal must cover pulse.
- [ ] ESC, backdrop click, and X button all close the QR modal.

## Documentation
- Updated `docs/navigation-actions.yaml` with the new `SHARE_SHOW_QR` action.
- No architectural/API changes; `CLAUDE.md` unchanged.