### PR TITLE
fix(tour): refresh guided tour to match current UI (#364)

### DIFF
--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -38,12 +38,6 @@ const STEPS: TourStep[] = [
     disableBeacon: true,
   },
   {
-    target: '[data-tour="undo-redo"]',
-    title: 'Undo And Redo',
-    content: 'Undo and redo your recent changes — adding or deleting nodes can be reversed.',
-    placement: 'bottom',
-  },
-  {
     target: '[data-tour="node-types"]',
     title: 'View Node Types',
     content: 'Open this to view your node categories (education, skills, work experience, and more).',
@@ -68,6 +62,12 @@ const STEPS: TourStep[] = [
     placement: 'bottom',
   },
   {
+    target: '[data-tour="connections"]',
+    title: 'Connection Requests',
+    content: 'When another user asks to connect their orbis to yours, the request lands here. Open the dropdown to review and accept or reject pending requests.',
+    placement: 'bottom',
+  },
+  {
     target: '[data-tour="notes"]',
     title: 'Draft Notes',
     content: 'Draft notes — jot down quick thoughts, then convert them into graph entries when ready. AI enhancement can help structure your notes.',
@@ -88,7 +88,7 @@ const STEPS: TourStep[] = [
   {
     target: '[data-tour="orbis-pulse"]',
     title: 'Orbis Pulse',
-    content: 'Orbis Pulse gives you live graph metrics (active nodes/edges, density, skill coverage, top hub, and share readiness) based on the current view and filters.',
+    content: 'Orbis Pulse gives you live graph metrics — top hub, orphan nodes, active nodes & edges, avg edges/node, skill coverage, and freshness — based on the current view and filters.',
     placement: 'left',
   },
   {

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -818,7 +818,7 @@ export default function OrbViewPage() {
                     />
                   </label>
                   {/* Undo / Redo */}
-                  <div data-tour="undo-redo" className="flex items-center">
+                  <div className="flex items-center">
                     <button
                       onClick={handleUndo}
                       disabled={undoStack.length === 0}
@@ -855,7 +855,7 @@ export default function OrbViewPage() {
             <div className="h-8 flex items-center gap-1">
               <ProcessingCounter />
 
-              <div className="hidden lg:block">
+              <div data-tour="connections" className="hidden lg:block">
                 <PendingConnectionsDropdown />
               </div>
 


### PR DESCRIPTION
Closes #364.

## Summary
- **Added** *Connection Requests* step — introduces the header connections dropdown, with a new `data-tour="connections"` marker on the wrapper.
- **Removed** *Undo And Redo* step — it's a secondary action in the current layout; dropped the now-unused `data-tour="undo-redo"` attribute as well.
- **Refreshed** Orbis Pulse description to list the metrics actually rendered today (top hub, orphan nodes, active nodes & edges, avg edges/node, skill coverage, freshness) and drop stale ones (density, share readiness).
- **Verified** all 13 remaining tour targets (`graph`, `node-types`, `keyword-filter`, `export`, `import`, `connections`, `notes`, `search-orbis-id`, `user-menu`, `orbis-pulse`, `add-entry`, `visibility`, `chatbox`) have matching markers in source — no silent-broken steps.

## Test plan
- [ ] Reset tour state (`localStorage.removeItem('orbis_tour_completed')`) and run through every step in sequence; each highlights the correct element and the copy matches what's on screen.
- [ ] Verify the Undo/Redo step no longer appears.
- [ ] Verify the new Connections step slots in between *Import* and *Notes* and highlights the connections dropdown button on `lg+` viewports.
- [ ] Verify the Orbis Pulse step text enumerates only metrics actually visible in the panel.

## Documentation
No doc changes needed — this is UI-only; architecture, API, and conventions are unchanged.