### PR TITLE
docs: refresh /docs/* to reflect recent feature work (#368)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,19 @@ When adding/removing pages, routes, modals, or interactive elements, update `doc
 
 Before creating any pull request, you MUST:
 
-1. Run `git diff main...HEAD` to review all changes in the branch
-2. Assess whether changes affect project structure, architecture, API, conventions, or infrastructure
-3. If they do, update `CLAUDE.md` and/or the relevant `docs/*.md` file before committing
-4. Add a "## Documentation" section to the PR description listing which docs were updated, or "No doc changes needed" if the changes are purely internal/cosmetic
+1. Run `git diff main...HEAD` to review all changes in the branch.
+2. For each change, ask which of these docs it could affect — don't skip this check even for small PRs:
+
+   | Change type | Likely doc(s) to touch |
+   |---|---|
+   | New or renamed API endpoint, changed payload shape, new rate-limit tier | `docs/api.md` |
+   | New Neo4j node type, relationship, constraint, or index | `docs/database.md` |
+   | New backend module or cross-module data flow | `docs/architecture.md` |
+   | New page, modal, dropdown, or overlay on `/myorbis` (or change to an existing one) | `docs/navigation-flow.md` **and** `docs/navigation-actions.yaml` |
+   | New `data-tour` target or changed guided-tour step list | `docs/navigation-flow.md` (tour step count + order) |
+   | New Cloud Run flag, env var, or deploy-time policy change | `docs/deployment.md` |
+   | New env var or first-run command | `docs/onboarding.md` |
+   | Test threshold or fixture convention change | `docs/testing.md` / `docs/cv-extraction-quality.md` |
+
+3. Update the relevant files in the **same PR** as the code change. Never defer doc updates — history shows the gap accumulates faster than you'd expect (see #368).
+4. Add a "## Documentation" section to the PR description listing which docs were updated, or "No doc changes needed" if the changes are purely internal/cosmetic. If you claim "no doc changes needed", spot-check the table above one more time before trusting that claim.

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,6 +206,8 @@ Query params: `?format=json|jsonld|pdf`, `?filter_token=`, `?filter_keyword=`, `
 | PUT | `/drafts/{uid}` | JWT | Update a draft note |
 | DELETE | `/drafts/{uid}` | JWT | Delete a draft note |
 
+Drafts are also auto-populated by the CV flow: any entries the LLM returns in `result.unmatched[]` (lines it could not classify into a node type) are POSTed to `/drafts` by the frontend before the user enters the review step (#359), so no raw text is silently dropped. The user can then enhance and promote those drafts into nodes manually.
+
 ## Ideas (`/ideas`)
 
 | Method | Path | Auth | Description |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ Middleware stack (outermost first):
 | `drafts/` | Draft notes CRUD (create, list, update, delete) |
 | `ideas/` | Feature idea / feedback submission (source: `idea` or `feedback`) and admin listing |
 | `snapshots/` | Orb version snapshots (save, restore, delete, auto-create on CV import) |
-| `mcp_server/` | MCP server exposing 6 tools for AI agent access to orb data (API key auth) |
+| `mcp_server/` | MCP server exposing 5 tools for AI agent access to orb data (API key auth) |
 
 ### Dependency Injection
 
@@ -96,6 +96,7 @@ Stage 5: User polls GET /cv/job/{job_id} → result
     ▼
 Stage 6: User Review + Confirm
     ├─ Frontend shows extracted nodes for editing (tabbed by node type)
+    ├─ Any entries the LLM could not classify (`result.unmatched[]`) are persisted to the user's drafts collection via `POST /drafts` — the user can later enhance and promote them into nodes manually instead of losing the raw text (#359).
     └─ POST /cv/confirm: wipes existing graph, MERGE nodes with dedup keys, creates USED_SKILL links
 ```
 
@@ -140,6 +141,14 @@ Two distinct 3D contexts:
 2. **OrbGraph3D** (main app) — react-force-graph-3d with custom THREE.js node rendering, shared geometry pool, node object cache, animated orbital rings, background star field
 
 Performance optimizations: shared geometry (never recreated), node object cache (invalidated on data/filter changes), direct refs for animated objects, single `requestAnimationFrame` loop, ref-based state to avoid React re-renders.
+
+### Notable UI Surfaces on `/myorbis`
+
+- **Orbis Pulse** (`components/graph/OrbisStatsOverlay.tsx`) — floating metrics panel. Current metric set: *Top Hub* (clickable, expands to neighbor list), *Orphan Nodes* (clickable, expands to list), *Active Nodes / Active Edges* (plus "visible" subcounts under filters), *Avg Edges/Node* (replaced the older "density" metric in #354), *Skill Coverage*, *Freshness*. A *Suggest a metric* cell lets users submit feedback via `POST /ideas`. Panel collapses to a pill on small screens (`compactOpen` state). Dismissible via the `dismissed` state; pill returns to re-open.
+- **Share panel** (`components/graph/SharePanel.tsx`) — visibility switch, public/filtered URL rows, share-token management, access grants, and access-request (connection request) review. Each URL row exposes `Copy URL` + `Show QR` actions.
+- **QR share modal** (`components/graph/QrShareModal.tsx`) — renders a violet-on-white QR for any share URL (#365). SVG is rasterized client-side for PNG download at 4× scale; no center logo. Called from both the public link row and each share-token row.
+- **Pending connection-requests dropdown** (`components/graph/PendingConnectionsDropdown.tsx`) — header-level inbox of access requests backed by `backend/app/orbs/access_requests.py`. Accept creates an `AccessGrant` (with optional filters); reject marks the request resolved.
+- **Guided tour** (`components/GuidedTour.tsx`) — react-joyride overlay; 13 steps covering graph, header controls, connections dropdown, notes, search, user menu, Orbis Pulse, add-entry, visibility, and chatbox. Auto-triggers for new users; re-runnable from Settings.
 
 ### Routing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,6 +108,12 @@ curl -s -o /dev/null -w "%{http_code}" https://open-orbis.web.app
 
 Functional smoke test: log in, open an orb, upload a CV.
 
+### Cloud Run instance policy
+
+Backend (`orbis-api`) deploys with `--min-instances=1` (see `.github/workflows/deploy.yml`). This keeps one warm instance live at all times, trading a small baseline cost for first-request latency — a cold start on this stack can add several seconds because the container has to initialise the Neo4j async driver and validate connectivity before it can answer. The MCP server (`orbis-mcp`) runs `--min-instances=0` since it's called infrequently by agent clients and cold-start cost is tolerable.
+
+Rationale for `orbis-api` at `1` was landed in #363 — if you see it flipped back to `0`, expect user-visible latency regressions.
+
 ### GCP service accounts
 
 | Service Account | Purpose | Created by |

--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -2,7 +2,7 @@
 # Each entry defines a user action with its trigger, preconditions, effect, and next state.
 # Used by autonomous agents for end-to-end UX evaluation.
 #
-# Last updated: 2026-04-14 | Issue: #193, #216, #274
+# Last updated: 2026-04-17 | Issue: #193, #216, #274, #368
 
 # ── Landing Page ──
 
@@ -456,7 +456,72 @@
   selector_or_control: "Show QR button next to Copy URL"
   preconditions: [orb_id_set]
   expected_effect: Opens QrShareModal with a violet-on-white QR for the link; offers SVG/PNG download
-  next_state: SHARE_PANEL (qr modal open)
+  next_state: QR_MODAL
+  fallback_on_failure: null
+
+- id: QR_DOWNLOAD_SVG
+  from_state: QR_MODAL
+  action: Click SVG download button
+  selector_or_control: "primary violet SVG button inside QrShareModal"
+  preconditions: []
+  expected_effect: Downloads orbis-qr.svg (self-contained, no external refs) to disk
+  next_state: QR_MODAL
+  fallback_on_failure: null
+
+- id: QR_DOWNLOAD_PNG
+  from_state: QR_MODAL
+  action: Click PNG download button
+  selector_or_control: "tonal violet PNG button inside QrShareModal"
+  preconditions: []
+  expected_effect: Rasterizes the QR SVG to a 4x-scaled PNG (solid white background) and downloads orbis-qr.png
+  next_state: QR_MODAL
+  fallback_on_failure: null
+
+- id: QR_CLOSE
+  from_state: QR_MODAL
+  action: Close via X, backdrop click, or Esc
+  selector_or_control: "close affordances on QrShareModal"
+  preconditions: []
+  expected_effect: Dismisses QR modal, returns focus to SharePanel
+  next_state: SHARE_PANEL
+  fallback_on_failure: null
+
+# ── Pending Connections Dropdown ──
+
+- id: CONNECTIONS_OPEN
+  from_state: ORB_VIEW
+  action: Click header Connections button (lg+ viewport)
+  selector_or_control: "Connections button in right-aligned header cluster"
+  preconditions: [authenticated, viewport >= lg]
+  expected_effect: Opens dropdown and fetches pending requests via GET /orbs/me/connection-requests
+  next_state: CONNECTIONS_DROPDOWN
+  fallback_on_failure: Dropdown shows empty state
+
+- id: CONNECTIONS_ACCEPT
+  from_state: CONNECTIONS_DROPDOWN
+  action: Click Accept on a pending request (optionally with keyword / hidden-type filters)
+  selector_or_control: "Accept button per request row"
+  preconditions: [authenticated, request_pending]
+  expected_effect: POST /orbs/me/connection-requests/{request_id}/accept creates an AccessGrant for the requester's email with optional filters; row disappears from list
+  next_state: CONNECTIONS_DROPDOWN
+  fallback_on_failure: Toast "Failed to accept request"
+
+- id: CONNECTIONS_REJECT
+  from_state: CONNECTIONS_DROPDOWN
+  action: Click Reject on a pending request
+  selector_or_control: "Reject button per request row"
+  preconditions: [authenticated, request_pending]
+  expected_effect: POST /orbs/me/connection-requests/{request_id}/reject marks request resolved=rejected; row disappears from list
+  next_state: CONNECTIONS_DROPDOWN
+  fallback_on_failure: Toast "Failed to reject request"
+
+- id: CONNECTIONS_CLOSE
+  from_state: CONNECTIONS_DROPDOWN
+  action: Outside click or Esc
+  selector_or_control: null
+  preconditions: []
+  expected_effect: Closes dropdown
+  next_state: ORB_VIEW
   fallback_on_failure: null
 
 # ── Shared Orb (Public) ──

--- a/docs/navigation-flow.md
+++ b/docs/navigation-flow.md
@@ -2,7 +2,7 @@
 
 > Navigable user-flow map for agent-based UX evaluation. Covers all pages, modals, interactions, guards, and error states.
 >
-> **Last updated:** 2026-04-14 | **Issue:** #193, #274
+> **Last updated:** 2026-04-17 | **Issue:** #193, #274, #368
 
 ## How to Update This Map
 
@@ -97,9 +97,11 @@ stateDiagram-v2
     %% ── Modals & Panels ──
     state "FloatingInput (Add/Edit Node)" as FLOATING_INPUT
     state "SharePanel (modal)" as SHARE_PANEL
+    state "QR Share Modal" as QR_MODAL
     state "ProfilePanel (modal)" as PROFILE_PANEL
     state "AccountSettings (modal)" as ACCOUNT_SETTINGS
     state "DraftNotes (slide-out)" as DRAFT_NOTES
+    state "Pending Connections (dropdown)" as CONNECTIONS_DROPDOWN
     state "Import Review (overlay)" as IMPORT_REVIEW
     state "Import Limit Warning (modal)" as IMPORT_LIMIT
     state "Guided Tour (overlay)" as GUIDED_TOUR
@@ -121,6 +123,11 @@ stateDiagram-v2
     FLOATING_INPUT --> MAIN: Save / Cancel / Delete
     MAIN --> SHARE_PANEL: Click Share
     SHARE_PANEL --> MAIN: Close
+    SHARE_PANEL --> QR_MODAL: Click Show QR (public row or per-token row)
+    QR_MODAL --> SHARE_PANEL: Close / backdrop / Esc
+    MAIN --> CONNECTIONS_DROPDOWN: Click header Connections button
+    CONNECTIONS_DROPDOWN --> MAIN: Close / outside click / Esc / Reject
+    CONNECTIONS_DROPDOWN --> MAIN: Accept (creates AccessGrant)
     MAIN --> PROFILE_PANEL: Click profile image
     PROFILE_PANEL --> MAIN: Close
     MAIN --> ACCOUNT_SETTINGS: UserMenu > Account settings
@@ -205,13 +212,15 @@ flowchart TD
 | `PRIVACY` | `/privacy` | No | Privacy policy |
 | `CONSENT_GATE` | (overlay) | Yes | GDPR consent checkbox |
 | `FLOATING_INPUT` | (modal on ORB_VIEW) | Yes | Add/edit node form |
-| `SHARE_PANEL` | (modal on ORB_VIEW) | Yes | Share links + QR code |
+| `SHARE_PANEL` | (modal on ORB_VIEW) | Yes | Visibility switch, public/filtered URLs, share tokens, access grants, connection-request review |
+| `QR_MODAL` | (modal above SHARE_PANEL) | Yes | Violet-on-white QR for a given share URL; SVG + PNG downloads |
+| `CONNECTIONS_DROPDOWN` | (dropdown on ORB_VIEW header, `lg+`) | Yes | Inbox of pending access requests — accept (creates AccessGrant) or reject |
 | `PROFILE_PANEL` | (modal on ORB_VIEW) | Yes | Edit profile + social links |
 | `ACCOUNT_SETTINGS` | (modal on ORB_VIEW) | Yes | Orbis ID, Versions, Account tabs |
 | `DRAFT_NOTES` | (panel on ORB_VIEW) | Yes | Draft notes list + management |
 | `IMPORT_REVIEW` | (overlay on ORB_VIEW) | Yes | Review imported document data |
 | `IMPORT_LIMIT` | (modal on ORB_VIEW) | Yes | Document limit confirmation |
-| `GUIDED_TOUR` | (overlay on ORB_VIEW) | Yes | 9-step interactive tour (react-joyride). Auto-triggers for new users, restartable from Settings sidebar |
+| `GUIDED_TOUR` | (overlay on ORB_VIEW) | Yes | 13-step interactive tour (react-joyride). Steps: graph → node-types → keyword-filter → export → import → connections → notes → search → user-menu → orbis-pulse → add-entry → visibility → chatbox. Auto-triggers for new users, restartable from Settings sidebar |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,7 +32,7 @@ Unit tests mock Neo4j entirely (no database needed). The `conftest.py` provides:
 - `mock_db` — mock AsyncDriver with session/run/single chain
 - `client` — `TestClient` with `get_db` and `get_current_user` overrides
 
-Coverage minimum: **75%** (enforced in CI).
+Coverage minimum: **50%** (enforced in CI via `--cov-fail-under=50` in `.github/workflows/unit-tests.yml`).
 
 ### Integration Tests
 


### PR DESCRIPTION
Closes #368.

## Summary

A catch-up pass through `/docs/*` to bring the docs back in sync with code after recent feature work. No code changes — documentation only.

### `docs/architecture.md`
- New **Notable UI Surfaces on /myorbis** section: current Orbis Pulse metric set (Top Hub, Orphan Nodes, Active Nodes/Edges, Avg Edges/Node, Skill Coverage, Freshness, Suggest-a-metric cell), SharePanel, `QrShareModal`, Pending Connections dropdown, 13-step guided tour.
- CV pipeline now notes that `result.unmatched[]` persists to drafts before review (#359).
- Fix pre-existing inconsistency: MCP exposes **5** tools (not 6); matches the actual `@mcp.tool()` count.

### `docs/api.md`
- Add a note under Drafts describing auto-population from CV unmatched entries (#359). Endpoint tables audited — no other drift found.

### `docs/navigation-flow.md` + `docs/navigation-actions.yaml`
- Add `QR_MODAL` and `CONNECTIONS_DROPDOWN` sub-states to the OrbViewPage interaction map + states reference.
- Bump guided-tour row from "9-step" to "13-step" with the current step order.
- Add action entries for `QR_DOWNLOAD_SVG`, `QR_DOWNLOAD_PNG`, `QR_CLOSE`, and the full Pending Connections set (`CONNECTIONS_OPEN`, `CONNECTIONS_ACCEPT`, `CONNECTIONS_REJECT`, `CONNECTIONS_CLOSE`).
- Update both "Last updated" headers and include #368 in issue list.

### `docs/deployment.md`
- New **Cloud Run instance policy** subsection: explains `--min-instances=1` on `orbis-api` (#363) vs `--min-instances=0` on `orbis-mcp`, with the cold-start rationale, so a future "optimize cost" edit doesn't silently regress user-visible latency.

### `docs/testing.md`
- Correct coverage threshold claim (**50%**, not 75%) to match what's actually enforced in `.github/workflows/unit-tests.yml`.

### `CLAUDE.md` — guardrail
- Replaced the prior generic "assess whether docs need updating" instruction with an explicit **change-type → docs** mapping table, so each PR author can check every likely-affected file instead of eyeballing. This is the preventative fix for why this sweep was needed in the first place.

### Verified in-sync (no changes)
- `docs/database.md` — `ConnectionRequest` node + `HAS_CONNECTION_REQUEST` rel + constraints/indexes all already accurate.
- `docs/onboarding.md`, `docs/cv-extraction-quality.md` — spot-checked; commands + content still current.

## Test plan
- [ ] Mermaid diagrams in `navigation-flow.md` render correctly (GitHub renders on view — confirm visually).
- [ ] YAML parses (`python -c "import yaml; yaml.safe_load(open('docs/navigation-actions.yaml'))"` returns without errors).
- [ ] Open each updated `.md` and skim — sections flow, no broken links, tables render.

## Documentation
This PR **is** the documentation update. No further doc changes needed.