### PR TITLE
feat(landing+graph): poster-style hero + logo-matched central node (#371)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ Axios instance with base URL controlled by `VITE_API_URL` env var (defaults to `
 ### 3D Graph Rendering
 
 Two distinct 3D contexts:
-1. **HeroOrb** (landing page) — React Three Fiber with animated sphere, particles, rays, and Bloom post-processing
+1. **HeroOrb** (landing page) — CSS-animated SVG composition matching the GDG DevFest 2026 poster mark (`print/openorbis-a3-poster.html`): outer halo, 4 tilted orbital rings, 4 ring-bound satellite nodes that orbit via CSS `offset-path`, a slowly-rotating background "constellation" group, and a central node styled after the top-left myorbis logo. No WebGL on first paint — landing is now the lightest route.
 2. **OrbGraph3D** (main app) — react-force-graph-3d with custom THREE.js node rendering, shared geometry pool, node object cache, animated orbital rings, background star field
 
 Performance optimizations: shared geometry (never recreated), node object cache (invalidated on data/filter changes), direct refs for animated objects, single `requestAnimationFrame` loop, ref-based state to avoid React re-renders.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@react-oauth/google": "0.13.4",
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.5.0",
-        "@react-three/postprocessing": "3.0.4",
         "axios": "1.13.6",
         "framer-motion": "12.38.0",
         "html2canvas": "1.4.1",
@@ -1062,32 +1061,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@react-three/postprocessing": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
-      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "maath": "^0.6.0",
-        "n8ao": "^1.9.4",
-        "postprocessing": "^6.36.6"
-      },
-      "peerDependencies": {
-        "@react-three/fiber": "^9.0.0",
-        "react": "^19.0",
-        "three": ">= 0.156.0"
-      }
-    },
-    "node_modules/@react-three/postprocessing/node_modules/maath": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
-      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/three": ">=0.144.0",
-        "three": ">=0.144.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4642,16 +4615,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/n8ao": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
-      "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
-      "license": "ISC",
-      "peerDependencies": {
-        "postprocessing": ">=6.30.0",
-        "three": ">=0.137"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4964,15 +4927,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postprocessing": {
-      "version": "6.38.3",
-      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
-      "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
-      "license": "Zlib",
-      "peerDependencies": {
-        "three": ">= 0.157.0 < 0.184.0"
       }
     },
     "node_modules/potpack": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "@react-oauth/google": "0.13.4",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.5.0",
-    "@react-three/postprocessing": "3.0.4",
     "axios": "1.13.6",
     "framer-motion": "12.38.0",
     "html2canvas": "1.4.1",

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -31,6 +31,7 @@ interface OrbGraph3DProps {
 const SHARED_GEO = {
   personCore: new THREE.SphereGeometry(6, 24, 24),
   personInnerGlow: new THREE.SphereGeometry(2.4, 12, 12),
+  personInnerDot: new THREE.SphereGeometry(1.1, 12, 12),
   personMidGlow: new THREE.SphereGeometry(8.4, 12, 12),
   personRing1: new THREE.TorusGeometry(9.6, 0.15, 8, 48),
   personRing2: new THREE.TorusGeometry(11.4, 0.1, 8, 48),
@@ -409,21 +410,33 @@ export default function OrbGraph3D({
     const group = new THREE.Group();
 
     if (isPerson) {
-      // ── Person node: emissive core + orbital rings (no PointLight) ──
+      // ── Person node: styled after the top-left myorbis logo mark — a
+      // semi-transparent purple-600 outer disc with a solid purple-400
+      // inner dot. Orbital rings + mid-glow retained so the root node
+      // still reads as the graph's focal point. ──
       const coreMat = new THREE.MeshBasicMaterial({
-        color: nodeCol,
+        color: isFiltered ? new THREE.Color('#ffffff') : new THREE.Color('#9333ea'),
         transparent: true,
-        opacity: (isDimmed ? 0.2 : 0.9) * fo,
+        opacity: (isDimmed ? 0.12 : 0.35) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.personCore, coreMat));
 
-      // Inner white glow
+      // Inner solid — matches purple-400 inner dot in the logo
       const innerGlowMat = new THREE.MeshBasicMaterial({
-        color: '#ffffff',
+        color: isFiltered ? new THREE.Color('#ffffff') : new THREE.Color('#c084fc'),
         transparent: true,
-        opacity: (isDimmed ? 0.05 : 0.55) * fo,
+        opacity: (isDimmed ? 0.3 : 1) * fo,
       });
       group.add(new THREE.Mesh(SHARED_GEO.personInnerGlow, innerGlowMat));
+
+      // Innermost bright dot — a third, brighter purple layer at the very
+      // centre reinforces the logo's concentric-circle identity in 3D.
+      const innerDotMat = new THREE.MeshBasicMaterial({
+        color: isFiltered ? new THREE.Color('#ffffff') : new THREE.Color('#e9d5ff'),
+        transparent: true,
+        opacity: (isDimmed ? 0.4 : 1) * fo,
+      });
+      group.add(new THREE.Mesh(SHARED_GEO.personInnerDot, innerDotMat));
 
       // Orbital ring 1
       const ring1Mat = new THREE.MeshBasicMaterial({
@@ -588,7 +601,15 @@ export default function OrbGraph3D({
       className="relative w-full h-full"
       onPointerMove={handlePointerMove}
       onPointerEnter={() => { isHoveringRef.current = true; }}
-      onPointerLeave={() => { isHoveringRef.current = false; }}
+      onPointerLeave={() => {
+        isHoveringRef.current = false;
+        // Dismiss the tooltip immediately when the pointer leaves the canvas.
+        // react-force-graph only fires onNodeHover(null) on ray-miss INSIDE the
+        // canvas — if the pointer exits the canvas while over a node, the
+        // tooltip would otherwise stay stuck open.
+        setHoveredNode(null);
+        hoveredNodeRef.current = null;
+      }}
     >
       <ForceGraph3D
         ref={fgRef}

--- a/frontend/src/components/landing/HeroOrb.tsx
+++ b/frontend/src/components/landing/HeroOrb.tsx
@@ -1,11 +1,16 @@
-// Ported from print/openorbis-a3-poster.html (issue #371) — keeps the composition
-// consistent with the marketing poster / DevFest handouts. CSS-animated SVG rather
-// than Three.js so landing-page first paint isn't blocked on a WebGL context.
+// Ported from print/openorbis-a3-poster.html (issue #371) — CSS-animated SVG
+// rather than Three.js so landing-page first paint isn't blocked on a WebGL
+// context. The main composition is static (poster-accurate); the 4 ring-bound
+// satellite nodes orbit via CSS offset-path.
 
 const KEYFRAMES = `
   @keyframes hero-orb-halo-pulse {
-    0%, 100% { opacity: 0.85; transform: scale(1); }
-    50%      { opacity: 1;    transform: scale(1.03); }
+    0%, 100% { opacity: 0.95; transform: scale(1); }
+    50%      { opacity: 0.55; transform: scale(0.99); }
+  }
+  @keyframes hero-orb-halo-purple-pulse {
+    0%, 100% { opacity: 0;    transform: scale(0.96); }
+    50%      { opacity: 0.75; transform: scale(1.015); }
   }
   @keyframes hero-orb-core-pulse {
     0%, 100% { opacity: 0.85; }
@@ -15,30 +20,102 @@ const KEYFRAMES = `
     0%, 100% { opacity: 1; }
     50%      { opacity: 0.55; }
   }
+  @keyframes hero-orb-orbit-loop {
+    to { offset-distance: 100%; }
+  }
+  @keyframes hero-orb-constellation-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
   .hero-orb-halo,
+  .hero-orb-halo-purple,
   .hero-orb-core,
   .hero-orb-node {
     transform-box: fill-box;
     transform-origin: center;
   }
-  .hero-orb-halo { animation: hero-orb-halo-pulse 5s ease-in-out infinite; }
+  .hero-orb-halo        { animation: hero-orb-halo-pulse 5s ease-in-out infinite; }
+  .hero-orb-halo-purple { animation: hero-orb-halo-purple-pulse 5s ease-in-out infinite; }
   .hero-orb-core { animation: hero-orb-core-pulse 4s ease-in-out infinite; }
   .hero-orb-node.delay-1 { animation: hero-orb-node-twinkle 3.2s ease-in-out infinite 0.4s; }
   .hero-orb-node.delay-2 { animation: hero-orb-node-twinkle 4.1s ease-in-out infinite 1.1s; }
   .hero-orb-node.delay-3 { animation: hero-orb-node-twinkle 3.6s ease-in-out infinite 2.0s; }
+
+  /* Background constellation (static stars + their connection lines) rotates
+     slowly around the orb centre (200,200 in view-box coordinates). */
+  .hero-orb-constellation {
+    transform-box: view-box;
+    transform-origin: 200px 200px;
+    animation: hero-orb-constellation-spin 180s linear infinite;
+  }
+
+  /* Ring-bound orbiting nodes. Each class locks its own offset-path (the
+     ring's unrotated ellipse) and its own duration / starting position.
+     The parent <g transform="rotate(...)"> rotates the whole orbit, so the
+     node follows the tilted ring in rendered SVG space. */
+  .hero-orb-orbit {
+    offset-rotate: 0deg;
+    animation: hero-orb-orbit-loop linear infinite;
+  }
+  .hero-orb-orbit-0 {
+    offset-path: path('M 15 200 A 185 58 0 1 1 385 200 A 185 58 0 1 1 15 200');
+    animation-duration: 42s;
+  }
+  .hero-orb-orbit-1 {
+    offset-path: path('M 35 200 A 165 48 0 1 1 365 200 A 165 48 0 1 1 35 200');
+    animation-duration: 32s;
+    animation-delay: -9.6s;
+  }
+  .hero-orb-orbit-2 {
+    offset-path: path('M 55 200 A 145 38 0 1 1 345 200 A 145 38 0 1 1 55 200');
+    animation-duration: 55s;
+    animation-delay: -33s;
+  }
+  .hero-orb-orbit-3 {
+    offset-path: path('M 80 200 A 120 30 0 1 1 320 200 A 120 30 0 1 1 80 200');
+    animation-duration: 24s;
+    animation-delay: -3.6s;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .hero-orb-halo,
+    .hero-orb-halo-purple,
     .hero-orb-core,
-    .hero-orb-node { animation: none !important; }
+    .hero-orb-node,
+    .hero-orb-orbit,
+    .hero-orb-constellation { animation: none !important; }
+    .hero-orb-halo-purple { opacity: 0; }
   }
 `;
+
+interface RingSpec {
+  rx: number;
+  ry: number;
+  rotation: number;
+  stroke: string;
+  dash?: string;
+  nodeColor: string;
+  nodeRadius: number;
+}
+
+const RINGS: RingSpec[] = [
+  { rx: 185, ry: 58, rotation: -22, stroke: '#a78bfa', dash: '1 3', nodeColor: '#fbbf24', nodeRadius: 3.5 },
+  { rx: 165, ry: 48, rotation: 18,  stroke: '#8b5cf6',               nodeColor: '#a78bfa', nodeRadius: 3 },
+  { rx: 145, ry: 38, rotation: -35, stroke: '#a78bfa', dash: '2 2',  nodeColor: '#c4b5fd', nodeRadius: 2.5 },
+  { rx: 120, ry: 30, rotation: 50,  stroke: '#c4b5fd',               nodeColor: '#818cf8', nodeRadius: 2.5 },
+];
 
 export default function HeroOrb() {
   return (
     <>
       <style>{KEYFRAMES}</style>
-      <div className="w-80 h-80 md:w-[28rem] md:h-[28rem]">
-        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" className="w-full h-full" aria-hidden>
+      <div className="w-96 h-96 md:w-[36rem] md:h-[36rem]">
+        <svg
+          viewBox="0 0 400 400"
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-full h-full"
+          aria-hidden
+        >
           <defs>
             <radialGradient id="hero-orb-core-grad" cx="50%" cy="50%" r="50%">
               <stop offset="0%" stopColor="#e9d5ff" stopOpacity={1} />
@@ -51,42 +128,66 @@ export default function HeroOrb() {
               <stop offset="70%" stopColor="#6d28d9" stopOpacity={0.05} />
               <stop offset="100%" stopColor="#000000" stopOpacity={0} />
             </radialGradient>
+            {/* Secondary halo in the myorbis top-left logo palette
+                (purple-500 / purple-600). Cross-fades with the violet halo
+                so the glow cools toward purple on the down-beat. */}
+            <radialGradient id="hero-orb-halo-grad-purple" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#a855f7" stopOpacity={0.42} />
+              <stop offset="55%" stopColor="#9333ea" stopOpacity={0.12} />
+              <stop offset="100%" stopColor="#000000" stopOpacity={0} />
+            </radialGradient>
             <filter id="hero-orb-soft-glow" x="-50%" y="-50%" width="200%" height="200%">
               <feGaussianBlur stdDeviation="4" />
             </filter>
           </defs>
 
+          {/* Outer halo — two layers cross-fade so the glow shifts from violet
+              on the up-beat to the myorbis-logo purple on the down-beat. */}
           <circle className="hero-orb-halo" cx="200" cy="200" r="195" fill="url(#hero-orb-halo-grad)" />
+          <circle className="hero-orb-halo-purple" cx="200" cy="200" r="195" fill="url(#hero-orb-halo-grad-purple)" />
 
-          <g>
-            <g strokeWidth="0.8" fill="none" opacity={0.55}>
-              <ellipse cx="200" cy="200" rx="185" ry="58" stroke="#a78bfa" strokeDasharray="1 3" transform="rotate(-22 200 200)" />
-              <ellipse cx="200" cy="200" rx="165" ry="48" stroke="#8b5cf6" transform="rotate(18 200 200)" />
-              <ellipse cx="200" cy="200" rx="145" ry="38" stroke="#a78bfa" strokeDasharray="2 2" transform="rotate(-35 200 200)" />
-              <ellipse cx="200" cy="200" rx="120" ry="30" stroke="#c4b5fd" transform="rotate(50 200 200)" />
+          {/* Rings + their orbiting satellite nodes. The rotation on the <g>
+              tilts both the ring and the node's offset path together. */}
+          {RINGS.map((ring, i) => (
+            <g key={`${ring.rx}-${ring.rotation}`} transform={`rotate(${ring.rotation} 200 200)`}>
+              <ellipse
+                cx="200"
+                cy="200"
+                rx={ring.rx}
+                ry={ring.ry}
+                fill="none"
+                stroke={ring.stroke}
+                strokeWidth="0.8"
+                strokeDasharray={ring.dash}
+                opacity={0.55}
+              />
+              <circle
+                className={`hero-orb-orbit hero-orb-orbit-${i}`}
+                r={ring.nodeRadius}
+                fill={ring.nodeColor}
+              />
             </g>
+          ))}
 
-            <g>
-              <circle className="hero-orb-node delay-1" cx="385" cy="200" r="3.5" fill="#fbbf24" />
-              <circle cx="58" cy="160" r="3" fill="#a78bfa" />
-              <circle className="hero-orb-node delay-2" cx="340" cy="275" r="2.5" fill="#8b5cf6" />
-              <circle cx="80" cy="255" r="2.5" fill="#c4b5fd" />
-              <circle cx="260" cy="60" r="3" fill="#a78bfa" />
-              <circle className="hero-orb-node delay-3" cx="310" cy="115" r="2" fill="#f59e0b" />
-              <circle cx="140" cy="340" r="2.5" fill="#818cf8" />
-              <circle cx="135" cy="75" r="2" fill="#c4b5fd" />
-            </g>
-
+          {/* Background constellation — stars + connection lines — rotates
+              slowly around the orb centre. Twinkle still plays on top. */}
+          <g className="hero-orb-constellation">
             <g stroke="#8b5cf6" strokeWidth="0.4" opacity={0.35}>
-              <line x1="385" y1="200" x2="200" y2="200" />
               <line x1="58" y1="160" x2="200" y2="200" />
               <line x1="260" y1="60" x2="200" y2="200" />
               <line x1="140" y1="340" x2="200" y2="200" />
               <line x1="310" y1="115" x2="260" y2="60" />
               <line x1="80" y1="255" x2="140" y2="340" />
             </g>
+            <circle cx="58" cy="160" r="3" fill="#a78bfa" />
+            <circle cx="260" cy="60" r="3" fill="#a78bfa" />
+            <circle className="hero-orb-node delay-1" cx="310" cy="115" r="2" fill="#f59e0b" />
+            <circle className="hero-orb-node delay-2" cx="140" cy="340" r="2.5" fill="#818cf8" />
+            <circle cx="135" cy="75" r="2" fill="#c4b5fd" />
+            <circle className="hero-orb-node delay-3" cx="80" cy="255" r="2.5" fill="#c4b5fd" />
           </g>
 
+          {/* Core glow + bright cores */}
           <circle
             className="hero-orb-core"
             cx="200"

--- a/frontend/src/components/landing/HeroOrb.tsx
+++ b/frontend/src/components/landing/HeroOrb.tsx
@@ -3,10 +3,6 @@
 // than Three.js so landing-page first paint isn't blocked on a WebGL context.
 
 const KEYFRAMES = `
-  @keyframes hero-orb-rotate {
-    from { transform: rotate(0deg); }
-    to   { transform: rotate(360deg); }
-  }
   @keyframes hero-orb-halo-pulse {
     0%, 100% { opacity: 0.85; transform: scale(1); }
     50%      { opacity: 1;    transform: scale(1.03); }
@@ -19,21 +15,18 @@ const KEYFRAMES = `
     0%, 100% { opacity: 1; }
     50%      { opacity: 0.55; }
   }
-  .hero-orb-system,
   .hero-orb-halo,
   .hero-orb-core,
   .hero-orb-node {
     transform-box: fill-box;
     transform-origin: center;
   }
-  .hero-orb-system { animation: hero-orb-rotate 90s linear infinite; }
-  .hero-orb-halo   { animation: hero-orb-halo-pulse 5s ease-in-out infinite; }
-  .hero-orb-core   { animation: hero-orb-core-pulse 4s ease-in-out infinite; }
+  .hero-orb-halo { animation: hero-orb-halo-pulse 5s ease-in-out infinite; }
+  .hero-orb-core { animation: hero-orb-core-pulse 4s ease-in-out infinite; }
   .hero-orb-node.delay-1 { animation: hero-orb-node-twinkle 3.2s ease-in-out infinite 0.4s; }
   .hero-orb-node.delay-2 { animation: hero-orb-node-twinkle 4.1s ease-in-out infinite 1.1s; }
   .hero-orb-node.delay-3 { animation: hero-orb-node-twinkle 3.6s ease-in-out infinite 2.0s; }
   @media (prefers-reduced-motion: reduce) {
-    .hero-orb-system,
     .hero-orb-halo,
     .hero-orb-core,
     .hero-orb-node { animation: none !important; }
@@ -44,7 +37,7 @@ export default function HeroOrb() {
   return (
     <>
       <style>{KEYFRAMES}</style>
-      <div className="w-64 h-64 md:w-80 md:h-80">
+      <div className="w-80 h-80 md:w-[28rem] md:h-[28rem]">
         <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" className="w-full h-full" aria-hidden>
           <defs>
             <radialGradient id="hero-orb-core-grad" cx="50%" cy="50%" r="50%">
@@ -65,7 +58,7 @@ export default function HeroOrb() {
 
           <circle className="hero-orb-halo" cx="200" cy="200" r="195" fill="url(#hero-orb-halo-grad)" />
 
-          <g className="hero-orb-system">
+          <g>
             <g strokeWidth="0.8" fill="none" opacity={0.55}>
               <ellipse cx="200" cy="200" rx="185" ry="58" stroke="#a78bfa" strokeDasharray="1 3" transform="rotate(-22 200 200)" />
               <ellipse cx="200" cy="200" rx="165" ry="48" stroke="#8b5cf6" transform="rotate(18 200 200)" />

--- a/frontend/src/components/landing/HeroOrb.tsx
+++ b/frontend/src/components/landing/HeroOrb.tsx
@@ -1,173 +1,111 @@
-import { useRef, useMemo } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
-import { Bloom, EffectComposer } from '@react-three/postprocessing';
-import * as THREE from 'three';
+// Ported from print/openorbis-a3-poster.html (issue #371) — keeps the composition
+// consistent with the marketing poster / DevFest handouts. CSS-animated SVG rather
+// than Three.js so landing-page first paint isn't blocked on a WebGL context.
 
-function OrbSphere() {
-  const meshRef = useRef<THREE.Mesh>(null);
-  const glowRef = useRef<THREE.Mesh>(null);
-
-  useFrame(({ clock }) => {
-    const t = clock.getElapsedTime();
-    if (meshRef.current) {
-      meshRef.current.rotation.y = t * 0.15;
-      meshRef.current.rotation.x = Math.sin(t * 0.1) * 0.1;
-    }
-    if (glowRef.current) {
-      glowRef.current.scale.setScalar(1 + Math.sin(t * 0.8) * 0.05);
-    }
-  });
-
-  return (
-    <group>
-      {/* Outer glow sphere — dark purple ring */}
-      <mesh ref={glowRef}>
-        <sphereGeometry args={[2.2, 32, 32]} />
-        <meshBasicMaterial color="#7c3aed" transparent opacity={0.12} />
-      </mesh>
-
-      {/* Main orb — bright vibrant purple core */}
-      <mesh ref={meshRef}>
-        <sphereGeometry args={[1.8, 64, 64]} />
-        <meshStandardMaterial
-          color="#a855f6"
-          emissive="#a855f6"
-          emissiveIntensity={0.8}
-          roughness={0.2}
-          metalness={0.6}
-        />
-      </mesh>
-
-      {/* Inner bright core */}
-      <mesh>
-        <sphereGeometry args={[1.0, 32, 32]} />
-        <meshBasicMaterial color="#c084fc" transparent opacity={0.4} />
-      </mesh>
-
-      {/* Highlight ring */}
-      <mesh rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[2.0, 0.015, 16, 100]} />
-        <meshBasicMaterial color="#c084fc" transparent opacity={0.4} />
-      </mesh>
-    </group>
-  );
-}
-
-function Particles() {
-  const count = 300;
-  const ref = useRef<THREE.Points>(null);
-
-  const positions = useMemo(() => {
-    const pos = new Float32Array(count * 3);
-    for (let i = 0; i < count; i++) {
-      const theta = Math.random() * Math.PI * 2;
-      const phi = Math.acos(2 * Math.random() - 1);
-      const r = 2.5 + Math.random() * 2.5;
-      pos[i * 3] = r * Math.sin(phi) * Math.cos(theta);
-      pos[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
-      pos[i * 3 + 2] = r * Math.cos(phi);
-    }
-    return pos;
-  }, []);
-
-  useFrame(({ clock }) => {
-    if (ref.current) {
-      ref.current.rotation.y = clock.getElapsedTime() * 0.03;
-      ref.current.rotation.x = clock.getElapsedTime() * 0.01;
-    }
-  });
-
-  return (
-    <points ref={ref}>
-      <bufferGeometry>
-        <bufferAttribute
-          attach="attributes-position"
-          args={[positions, 3]}
-        />
-      </bufferGeometry>
-      <pointsMaterial
-        color="#a78bfa"
-        size={0.03}
-        transparent
-        opacity={0.7}
-        sizeAttenuation
-      />
-    </points>
-  );
-}
-
-function Rays() {
-  const groupRef = useRef<THREE.Group>(null);
-  const rayCount = 12;
-
-  const rays = useMemo(() => {
-    return Array.from({ length: rayCount }, (_, i) => {
-      const angle = (i / rayCount) * Math.PI * 2;
-      const length = 1.5 + Math.random() * 1.5;
-      return { angle, length, phase: Math.random() * Math.PI * 2 };
-    });
-  }, []);
-
-  useFrame(({ clock }) => {
-    if (!groupRef.current) return;
-    const t = clock.getElapsedTime();
-    groupRef.current.children.forEach((child, i) => {
-      const ray = rays[i];
-      const pulse = 0.5 + 0.5 * Math.sin(t * 1.2 + ray.phase);
-      (child as THREE.Mesh).scale.set(1, pulse, 1);
-    });
-  });
-
-  return (
-    <group ref={groupRef}>
-      {rays.map((ray, i) => (
-        <mesh
-          key={i}
-          position={[
-            Math.cos(ray.angle) * 2.1,
-            Math.sin(ray.angle) * 2.1,
-            0,
-          ]}
-          rotation={[0, 0, ray.angle - Math.PI / 2]}
-        >
-          <planeGeometry args={[0.02, ray.length]} />
-          <meshBasicMaterial
-            color="#8b5cf6"
-            transparent
-            opacity={0.3}
-            side={THREE.DoubleSide}
-          />
-        </mesh>
-      ))}
-    </group>
-  );
-}
+const KEYFRAMES = `
+  @keyframes hero-orb-rotate {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+  @keyframes hero-orb-halo-pulse {
+    0%, 100% { opacity: 0.85; transform: scale(1); }
+    50%      { opacity: 1;    transform: scale(1.03); }
+  }
+  @keyframes hero-orb-core-pulse {
+    0%, 100% { opacity: 0.85; }
+    50%      { opacity: 1; }
+  }
+  @keyframes hero-orb-node-twinkle {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+  }
+  .hero-orb-system,
+  .hero-orb-halo,
+  .hero-orb-core,
+  .hero-orb-node {
+    transform-box: fill-box;
+    transform-origin: center;
+  }
+  .hero-orb-system { animation: hero-orb-rotate 90s linear infinite; }
+  .hero-orb-halo   { animation: hero-orb-halo-pulse 5s ease-in-out infinite; }
+  .hero-orb-core   { animation: hero-orb-core-pulse 4s ease-in-out infinite; }
+  .hero-orb-node.delay-1 { animation: hero-orb-node-twinkle 3.2s ease-in-out infinite 0.4s; }
+  .hero-orb-node.delay-2 { animation: hero-orb-node-twinkle 4.1s ease-in-out infinite 1.1s; }
+  .hero-orb-node.delay-3 { animation: hero-orb-node-twinkle 3.6s ease-in-out infinite 2.0s; }
+  @media (prefers-reduced-motion: reduce) {
+    .hero-orb-system,
+    .hero-orb-halo,
+    .hero-orb-core,
+    .hero-orb-node { animation: none !important; }
+  }
+`;
 
 export default function HeroOrb() {
   return (
-    <div className="w-64 h-64 md:w-80 md:h-80">
-      <Canvas
-        camera={{ position: [0, 0, 8], fov: 45 }}
-        gl={{ antialias: true, alpha: true }}
-        style={{ background: 'transparent' }}
-      >
-        <ambientLight intensity={0.3} />
-        <pointLight position={[5, 5, 5]} intensity={1} color="#a855f6" />
-        <pointLight position={[-5, -3, 3]} intensity={0.5} color="#7c3aed" />
+    <>
+      <style>{KEYFRAMES}</style>
+      <div className="w-64 h-64 md:w-80 md:h-80">
+        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" className="w-full h-full" aria-hidden>
+          <defs>
+            <radialGradient id="hero-orb-core-grad" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#e9d5ff" stopOpacity={1} />
+              <stop offset="30%" stopColor="#a78bfa" stopOpacity={0.9} />
+              <stop offset="70%" stopColor="#7c3aed" stopOpacity={0.5} />
+              <stop offset="100%" stopColor="#4c1d95" stopOpacity={0} />
+            </radialGradient>
+            <radialGradient id="hero-orb-halo-grad" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#7c3aed" stopOpacity={0.35} />
+              <stop offset="70%" stopColor="#6d28d9" stopOpacity={0.05} />
+              <stop offset="100%" stopColor="#000000" stopOpacity={0} />
+            </radialGradient>
+            <filter id="hero-orb-soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="4" />
+            </filter>
+          </defs>
 
-        <OrbSphere />
-        <Particles />
-        <Rays />
+          <circle className="hero-orb-halo" cx="200" cy="200" r="195" fill="url(#hero-orb-halo-grad)" />
 
-        <EffectComposer>
-          <Bloom
-            intensity={1.2}
-            luminanceThreshold={0.2}
-            luminanceSmoothing={0.9}
-            mipmapBlur
+          <g className="hero-orb-system">
+            <g strokeWidth="0.8" fill="none" opacity={0.55}>
+              <ellipse cx="200" cy="200" rx="185" ry="58" stroke="#a78bfa" strokeDasharray="1 3" transform="rotate(-22 200 200)" />
+              <ellipse cx="200" cy="200" rx="165" ry="48" stroke="#8b5cf6" transform="rotate(18 200 200)" />
+              <ellipse cx="200" cy="200" rx="145" ry="38" stroke="#a78bfa" strokeDasharray="2 2" transform="rotate(-35 200 200)" />
+              <ellipse cx="200" cy="200" rx="120" ry="30" stroke="#c4b5fd" transform="rotate(50 200 200)" />
+            </g>
+
+            <g>
+              <circle className="hero-orb-node delay-1" cx="385" cy="200" r="3.5" fill="#fbbf24" />
+              <circle cx="58" cy="160" r="3" fill="#a78bfa" />
+              <circle className="hero-orb-node delay-2" cx="340" cy="275" r="2.5" fill="#8b5cf6" />
+              <circle cx="80" cy="255" r="2.5" fill="#c4b5fd" />
+              <circle cx="260" cy="60" r="3" fill="#a78bfa" />
+              <circle className="hero-orb-node delay-3" cx="310" cy="115" r="2" fill="#f59e0b" />
+              <circle cx="140" cy="340" r="2.5" fill="#818cf8" />
+              <circle cx="135" cy="75" r="2" fill="#c4b5fd" />
+            </g>
+
+            <g stroke="#8b5cf6" strokeWidth="0.4" opacity={0.35}>
+              <line x1="385" y1="200" x2="200" y2="200" />
+              <line x1="58" y1="160" x2="200" y2="200" />
+              <line x1="260" y1="60" x2="200" y2="200" />
+              <line x1="140" y1="340" x2="200" y2="200" />
+              <line x1="310" y1="115" x2="260" y2="60" />
+              <line x1="80" y1="255" x2="140" y2="340" />
+            </g>
+          </g>
+
+          <circle
+            className="hero-orb-core"
+            cx="200"
+            cy="200"
+            r="80"
+            fill="url(#hero-orb-core-grad)"
+            filter="url(#hero-orb-soft-glow)"
           />
-        </EffectComposer>
-      </Canvas>
-    </div>
+          <circle cx="200" cy="200" r="22" fill="#e9d5ff" />
+          <circle cx="200" cy="200" r="14" fill="#ffffff" />
+        </svg>
+      </div>
+    </>
   );
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -270,22 +270,22 @@ export default function LandingPage() {
           <div className="w-[600px] h-[600px] rounded-full bg-purple-600/8 blur-[150px]" />
         </div>
 
-        {/* 3D Orb */}
+        {/* 3D Orb — sits behind the headline so the text reads on top */}
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 2.5, ease: 'easeOut' }}
-          className="relative z-10 mb-6"
+          className="relative z-0 -mb-24 sm:-mb-40 pointer-events-none"
         >
           <HeroOrb />
         </motion.div>
 
-        {/* Title */}
+        {/* Title — rendered above the orb for the poster-style overlap */}
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3, duration: 0.8 }}
-          className="text-4xl sm:text-7xl font-bold mb-4 sm:mb-8 z-10 tracking-tight text-center"
+          className="relative text-4xl sm:text-7xl font-bold mb-4 sm:mb-8 z-20 tracking-tight text-center"
         >
           Beyond the{' '}
           <span className="bg-gradient-to-r from-purple-400 to-indigo-400 bg-clip-text text-transparent">
@@ -297,7 +297,7 @@ export default function LandingPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5, duration: 0.8 }}
-          className="text-white/40 text-base sm:text-xl mb-8 sm:mb-16 z-10 max-w-lg text-center leading-relaxed"
+          className="text-white/40 text-base sm:text-xl mb-3 sm:mb-5 z-10 max-w-lg text-center leading-relaxed"
         >
           <span className="text-white/60 font-semibold">Your career reimagined for the AI era.</span><br />
           Queryable, shareable, portable.
@@ -360,7 +360,7 @@ export default function LandingPage() {
       </section>
 
       {/* ── Interactive Demo Orb ── */}
-      <section className="relative px-4 sm:px-6">
+      <section className="relative px-4 sm:px-6 mt-10 sm:mt-16">
         <FadeIn className="max-w-5xl mx-auto">
           {/* Text above the canvas */}
           <div className="text-center mb-4">


### PR DESCRIPTION
Closes #371.

## Summary

Replace the React-Three-Fiber landing hero with a CSS-animated SVG composition matching the GDG DevFest 2026 poster mark (`print/openorbis-a3-poster.html`), then iterate: bigger, overlapping the headline, ring-bound satellites that actually orbit, a slowly-rotating background constellation, and a colour-shifting halo that breathes between violet and the myorbis logo's purple on the down-beat. Finally restyle the 3D-graph Person node to mirror the same logo mark so "your Orbis" always reads the same visually on landing, `/myorbis`, and public orbs.

## Landing — `HeroOrb`
- **Bigger.** `w-64 md:w-80` → `w-96 md:w-[36rem]` (~+20% / +29%).
- **Overlap.** Orb pulled down with `-mb-24 sm:-mb-40` and `z-0`; headline promoted to `z-20 relative` so *Beyond the CV.* reads on top of the orb (poster composition).
- **Tighter vertical rhythm.** Subheadline bottom margin `mb-8 sm:mb-16` → `mb-3 sm:mb-5`, so the amber tagline + sign-in block slides up under the headline.
- **Satellites actually orbit.** Each of the 4 rings carries one node whose motion is driven by CSS `offset-path` on the ring's unrotated ellipse, wrapped in the ring's rotated `<g>` so it follows the tilt. Varied `animation-duration` (24–55 s) + negative `animation-delay` stagger start positions so nothing marches in sync.
- **Constellation.** The 6 static background stars + their 5 connection lines live in a single `<g class="hero-orb-constellation">` that rotates 360° over 180 s around `(200,200)` in view-box coords.
- **Glow pulse shifts colour.** Violet halo (`#7c3aed`) and a second purple halo in the myorbis palette (`#a855f7` / `#9333ea`) cross-fade on the same 5 s cycle — violet on the up-beat, purple on the down-beat.
- **`prefers-reduced-motion`.** Disables all animations; forces the purple overlay to `opacity: 0` so the static state looks clean.

## Graph — `OrbGraph3D` Person node
- Recolour the Person node to the myorbis top-left logo palette: outer sphere `#9333ea` @ 35 % opacity (purple-600 disc), middle sphere `#c084fc` solid (purple-400), new innermost `#e9d5ff` highlight dot to reinforce the logo's nested-circle identity in 3D. Orbital rings + mid-glow kept so the root node still reads as the graph's focal point. Filter/dimmed opacity multipliers preserved.
- **Tooltip sticking fix.** react-force-graph only fires `onNodeHover(null)` on ray-miss inside the canvas; if the pointer exits over a node the tooltip stayed open. Now `onPointerLeave` on the container force-clears `hoveredNode`.

## Bundle size
`@react-three/postprocessing` was only used by the old hero (`Bloom` + `EffectComposer`); nothing else imports it. Dropped the dep already in the first commit of this branch. Main chunk: `2693 → 2142 kB` raw, `771 → 575 kB` gzip (~**196 kB gzip saved** on first paint). `@react-three/fiber` + `@react-three/drei` stay — `OrbGraph3D` still needs them.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` on changed files clean (no new warnings).
- [x] `npm run build` succeeds; bundle smaller.
- [ ] Open `/` on desktop Chrome — hero overlaps headline, satellites orbit on each ring at visibly different speeds, constellation rotates slowly, halo subtly shifts violet→purple.
- [ ] Mobile viewport 375 × 812 — hero stays 1:1, no overflow, headline still reads on top.
- [ ] OS "reduce motion" → all motion pauses.
- [ ] Firefox + WebKit — `transform-box: view-box` and `offset-path` render correctly (both supported since Firefox 72 / Safari 16).
- [ ] `/myorbis` — Person node is the nested purple disc; hover a node, then move the pointer out of the canvas — tooltip closes immediately.
- [ ] `/:orbId` public view — same.

## Documentation
- `docs/architecture.md` line about HeroOrb being React-Three-Fiber updated to reflect the SVG rewrite (halo, 4 rings, orbiting satellites, constellation, logo-matched core). No API/schema/routing changes.

## Out of scope
- In-app top-left brand mark (unchanged).
- Favicon (separate pixel budget).
- Removing `@react-three/fiber` or `@react-three/drei` (still used by `OrbGraph3D`).