### PR TITLE
fix(backend): translate uvloop RuntimeError on dead Bolt sockets

### DIFF
--- a/backend/app/graph/neo4j_client.py
+++ b/backend/app/graph/neo4j_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 
 from neo4j import AsyncDriver, AsyncGraphDatabase
@@ -9,6 +10,116 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _driver: AsyncDriver | None = None
+
+
+def _patch_neo4j_uvloop_transport_resilience() -> None:
+    """Translate uvloop's ``RuntimeError`` on dead Bolt sockets into ``OSError``.
+
+    Under uvloop, ``StreamWriter.write`` on a ``TCPTransport`` whose peer
+    vanished (Cloud Run + VPC connector NAT idle drop is the classic case)
+    raises ``RuntimeError: unable to perform operation on <TCPTransport
+    closed=True>; the handler is closed`` — NOT ``OSError``.
+
+    The neo4j driver's error-handling code uniformly catches ``OSError``
+    (``Outbox.flush``, ``AsyncBolt.close``, the pool's liveness branch),
+    but none of it catches ``RuntimeError``. The raw ``RuntimeError``
+    therefore propagates out of ``_acquire_from_pool_checked`` /
+    ``liveness_check`` / ``release`` and surfaces as an HTTP 500 on every
+    first DB-touching request after idle.
+
+    Converting the exception to ``OSError`` at the single socket-layer
+    raise site lets the rest of the driver self-heal:
+
+    - ``Outbox.flush`` catches ``OSError`` and invokes the ``on_error``
+      hook ``_set_defunct_write`` (``_common.py:149-163``).
+    - ``_set_defunct`` (``_bolt.py:901``) synchronously sets
+      ``self._defunct = True``, calls ``self.close()`` (which guards its
+      own ``_send_all`` with ``except (OSError, BoltError, DriverError)``),
+      deactivates the pool address, and then **re-raises the error as
+      ``SessionExpired``** (a ``DriverError``).
+    - The ``SessionExpired`` propagates back up through ``flush`` →
+      ``_send_all`` → ``send_all`` → ``reset`` → ``liveness_check``,
+      where the pool's ``health_check`` catches it at ``_pool.py:357``
+      (``except (OSError, ServiceUnavailable, SessionExpired)``) and
+      returns ``False`` — the pool drops the dead conn and retries.
+    - The ``release`` path catches ``SessionExpired`` via its
+      ``except (Neo4jError, DriverError, BoltError)`` at ``_pool.py:499``.
+
+    Remove once the driver upstream catches ``RuntimeError`` in
+    ``Outbox.flush`` (or uvloop stops raising it for closed transports).
+    """
+    from neo4j._async_compat.network import _bolt_socket as _socket_mod
+
+    original_sendall = _socket_mod.AsyncBoltSocketBase.sendall
+    if getattr(original_sendall, "_orbis_patched", False):
+        return
+
+    async def sendall(self, data):
+        try:
+            return await original_sendall(self, data)
+        except RuntimeError as exc:
+            raise OSError(f"bolt transport closed: {exc}") from exc
+
+    sendall._orbis_patched = True  # type: ignore[attr-defined]
+    _socket_mod.AsyncBoltSocketBase.sendall = sendall
+
+
+def _patch_neo4j_pool_close_resilience() -> None:
+    """Swallow ``close()`` errors on already-dead pooled Bolt connections.
+
+    Belt-and-suspenders for ``_patch_neo4j_uvloop_transport_resilience``:
+    after that translation the pool's ``await connection.close()`` on a
+    stale conn should not raise anymore, but we guard against driver-body
+    drift by also wrapping the pool path in ``contextlib.suppress``.
+    The connection is removed from the pool and the loop tries again.
+    """
+    from neo4j._async.io import _pool as _pool_mod
+
+    original = _pool_mod.AsyncIOPool._acquire_from_pool_checked
+    if getattr(original, "_orbis_patched", False):
+        return
+
+    async def _acquire_from_pool_checked(self, address, health_check, deadline):
+        while not deadline.expired():
+            connection = await self._acquire_from_pool(address)
+            if not connection:
+                return None
+            if not await health_check(connection, deadline):
+                with contextlib.suppress(Exception):
+                    await connection.close()
+                self._remove_connection(connection)
+                continue
+            return connection
+        return None
+
+    _acquire_from_pool_checked._orbis_patched = True  # type: ignore[attr-defined]
+    _pool_mod.AsyncIOPool._acquire_from_pool_checked = _acquire_from_pool_checked
+
+
+def _assert_supported_driver_version() -> None:
+    """Fail loud if the neo4j driver's major version moves past the one we
+    patched.
+
+    The patches above reach into two private modules. A major bump can
+    reshape ``AsyncIOPool._acquire_from_pool_checked`` or
+    ``AsyncBoltSocketBase.sendall`` and silently revert us to buggy behavior.
+    Pin the upper bound in ``pyproject.toml`` AND assert here so a stray
+    ``uv lock`` upgrade is caught at import time, not in production.
+    """
+    import neo4j
+
+    major = int(neo4j.__version__.split(".")[0])
+    if major != 5:
+        raise RuntimeError(
+            "app.graph.neo4j_client expects neo4j==5.x (patches target "
+            f"private driver internals); found neo4j=={neo4j.__version__}. "
+            "Review the patches in this module before bumping."
+        )
+
+
+_assert_supported_driver_version()
+_patch_neo4j_uvloop_transport_resilience()
+_patch_neo4j_pool_close_resilience()
 
 
 async def get_driver() -> AsyncDriver:
@@ -23,7 +134,10 @@ async def get_driver() -> AsyncDriver:
             # VPC connector / NAT can silently drop idle Bolt TCP sockets; the
             # pool then hands out dead connections and the first request after
             # idle fails with "TCPTransport closed". Recycle aggressively and
-            # liveness-check before reuse.
+            # liveness-check before reuse. RuntimeErrors raised while writing
+            # to a dead transport are translated to OSError by
+            # _patch_neo4j_uvloop_transport_resilience so the driver's normal
+            # dead-connection handling takes over.
             max_connection_lifetime=60,
             liveness_check_timeout=30,
             keep_alive=True,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
-    "neo4j>=5.20.0",
+    "neo4j>=5.20.0,<6",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "python-jose[cryptography]>=3.3.0",

--- a/backend/tests/unit/test_neo4j_client.py
+++ b/backend/tests/unit/test_neo4j_client.py
@@ -1,0 +1,178 @@
+"""Regression tests for the Neo4j driver monkey-patches.
+
+Two interacting bugs kept surfacing as HTTP 500s on first DB-touching
+requests after Cloud Run + VPC idle (notably /auth/google):
+
+1. Under uvloop, ``StreamWriter.write`` on a dead ``TCPTransport`` raises
+   ``RuntimeError``, not ``OSError``. The neo4j driver catches ``OSError``
+   uniformly but not ``RuntimeError`` — so the exception escaped every
+   layer (``Outbox.flush``, ``AsyncBolt.close``, pool ``health_check``,
+   pool ``release``) and reached the endpoint.
+2. Even with the ``RuntimeError`` translated, the pool's
+   ``_acquire_from_pool_checked`` calls ``close()`` on the unhealthy
+   connection. We keep a belt-and-suspenders wrapper there in case a
+   future driver body drifts.
+
+These tests don't spin up Neo4j — they poke the patched functions with
+doubles that reproduce the failure modes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from neo4j._async.io import _pool as _pool_mod
+from neo4j._async_compat.network import _bolt_socket as _socket_mod
+
+# Importing the module applies the monkey-patches as a side effect.
+from app.graph import neo4j_client
+
+
+def test_pool_patch_is_applied_and_idempotent() -> None:
+    patched = _pool_mod.AsyncIOPool._acquire_from_pool_checked
+    assert getattr(patched, "_orbis_patched", False) is True
+
+    neo4j_client._patch_neo4j_pool_close_resilience()
+    assert _pool_mod.AsyncIOPool._acquire_from_pool_checked is patched
+
+
+def test_sendall_patch_is_applied_and_idempotent() -> None:
+    patched = _socket_mod.AsyncBoltSocketBase.sendall
+    assert getattr(patched, "_orbis_patched", False) is True
+
+    neo4j_client._patch_neo4j_uvloop_transport_resilience()
+    assert _socket_mod.AsyncBoltSocketBase.sendall is patched
+
+
+@pytest.mark.asyncio
+async def test_sendall_translates_uvloop_runtime_error_to_oserror() -> None:
+    """uvloop's ``RuntimeError`` on a dead transport must become ``OSError``
+    so ``Outbox.flush`` catches it and marks the connection defunct
+    instead of letting the exception escape to the endpoint."""
+    # The real ``sendall`` body is:
+    #   self._writer.write(data)
+    #   return await self._wait_for_io(self._writer.drain)
+    # Making ``write`` raise the uvloop-specific RuntimeError reproduces
+    # the production failure inside the wrapper's ``try`` block.
+    sock = MagicMock(spec=_socket_mod.AsyncBoltSocketBase)
+    sock._writer = MagicMock()
+    sock._writer.write = MagicMock(
+        side_effect=RuntimeError(
+            "unable to perform operation on <TCPTransport closed=True "
+            "reading=False>; the handler is closed"
+        )
+    )
+    sock._wait_for_io = AsyncMock()
+
+    # Bind the patched method to our mock socket and expect OSError.
+    bound = _socket_mod.AsyncBoltSocketBase.sendall.__get__(
+        sock, _socket_mod.AsyncBoltSocketBase
+    )
+    with pytest.raises(OSError) as exc_info:
+        await bound(b"bolt data")
+
+    assert "bolt transport closed" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_sendall_passes_through_normal_exceptions() -> None:
+    """OSError from the underlying writer must NOT be rewrapped — the
+    driver already handles it."""
+    sock = MagicMock(spec=_socket_mod.AsyncBoltSocketBase)
+    sock._writer = MagicMock()
+    sock._writer.write = MagicMock(side_effect=OSError("EPIPE"))
+    sock._wait_for_io = AsyncMock()
+
+    bound = _socket_mod.AsyncBoltSocketBase.sendall.__get__(
+        sock, _socket_mod.AsyncBoltSocketBase
+    )
+    with pytest.raises(OSError) as exc_info:
+        await bound(b"bolt data")
+
+    # Must be the original, not wrapped in another OSError chain.
+    assert str(exc_info.value) == "EPIPE"
+    assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_pool_stale_close_failure_is_swallowed() -> None:
+    """Regression for the original crash: close() on a stale conn raises —
+    pool must drop it and retry instead of propagating."""
+    dead_conn = MagicMock(name="dead_conn")
+    dead_conn.close = AsyncMock(
+        side_effect=RuntimeError(
+            "unable to perform operation on <TCPTransport closed=True>; "
+            "the handler is closed"
+        )
+    )
+    healthy_conn = MagicMock(name="healthy_conn")
+
+    pool = MagicMock()
+    pool._acquire_from_pool = AsyncMock(side_effect=[dead_conn, healthy_conn])
+    pool._remove_connection = MagicMock()
+
+    health_check = AsyncMock(side_effect=[False, True])
+    deadline = MagicMock()
+    deadline.expired = MagicMock(return_value=False)
+
+    result = await _pool_mod.AsyncIOPool._acquire_from_pool_checked(
+        pool, address=("neo4j", 7687), health_check=health_check, deadline=deadline
+    )
+
+    assert result is healthy_conn
+    dead_conn.close.assert_awaited_once()
+    pool._remove_connection.assert_called_once_with(dead_conn)
+
+
+@pytest.mark.asyncio
+async def test_pool_deadline_expired_returns_none() -> None:
+    pool = MagicMock()
+    pool._acquire_from_pool = AsyncMock()
+    deadline = MagicMock()
+    deadline.expired = MagicMock(return_value=True)
+
+    result = await _pool_mod.AsyncIOPool._acquire_from_pool_checked(
+        pool,
+        address=("neo4j", 7687),
+        health_check=AsyncMock(),
+        deadline=deadline,
+    )
+
+    assert result is None
+    pool._acquire_from_pool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pool_empty_pool_returns_none() -> None:
+    pool = MagicMock()
+    pool._acquire_from_pool = AsyncMock(return_value=None)
+    deadline = MagicMock()
+    deadline.expired = MagicMock(return_value=False)
+
+    result = await _pool_mod.AsyncIOPool._acquire_from_pool_checked(
+        pool,
+        address=("neo4j", 7687),
+        health_check=AsyncMock(),
+        deadline=deadline,
+    )
+
+    assert result is None
+
+
+def test_driver_version_guard_accepts_current_pin() -> None:
+    """Current install satisfies the ``neo4j==5.x`` contract — the guard
+    must not raise."""
+    # Already called at import; re-invoke to confirm no side effects.
+    neo4j_client._assert_supported_driver_version()
+
+
+def test_driver_version_guard_rejects_unsupported_major(monkeypatch) -> None:
+    """If a future ``uv lock`` pulls in neo4j 6.x, the guard must fail
+    loudly so we review the patches rather than silently revert."""
+    import neo4j
+
+    monkeypatch.setattr(neo4j, "__version__", "6.0.0")
+    with pytest.raises(RuntimeError, match="neo4j==5.x"):
+        neo4j_client._assert_supported_driver_version()


### PR DESCRIPTION
## Summary
- **Root cause of HTTP 500 on `/auth/google` (and any first DB-touching request after Cloud Run idle)**: under uvloop, `StreamWriter.write` on a closed `TCPTransport` raises `RuntimeError`, not `OSError`. The neo4j driver catches `OSError` uniformly (`Outbox.flush`, `AsyncBolt.close`, pool `health_check` / `release`) but has no `RuntimeError` branch — so the exception escaped every layer and surfaced to the endpoint. The stack trace from prod terminates at `neo4j/_async/io/_pool.py:222` inside `_acquire_from_pool_checked` → `await connection.close()`.
- **Fix**: wrap `AsyncBoltSocketBase.sendall` (the single socket-layer raise site) to translate `RuntimeError` → `OSError`. From there the driver self-heals: `Outbox.flush` catches → invokes `_set_defunct_write` → synchronously marks the connection defunct, closes it, deactivates the pool address, and re-raises as `SessionExpired` (a `DriverError`). `liveness_check` catches `SessionExpired` at `_pool.py:357`, `release` catches it at `_pool.py:499`. Dead conn is dropped, loop retries with a fresh one.
- **Belt-and-suspenders**: keep `contextlib.suppress` around the pool's `close()` in `_acquire_from_pool_checked`, assert at import that the neo4j major version matches the one we patched, and pin `neo4j<6` in `pyproject.toml` so a major bump can't silently restore the bug.

Two independent critical reviews (including trace through `_common.py`, `_bolt.py`, `_pool.py`) confirm all paths in the production failure mode now self-heal. The first review caught that the previous fix only covered `_acquire_from_pool_checked` and missed the `liveness_check` / `release` paths — this revision addresses that at the source.

## Test plan
- [x] 9 new unit tests in `backend/tests/unit/test_neo4j_client.py` (patch idempotency, `RuntimeError` → `OSError` translation, `OSError` pass-through, stale-close swallowed in the pool, deadline/empty-pool guards, version-guard accepts 5.x and rejects 6.x). All pass.
- [x] `ruff check` and `ruff format --check` clean.
- [x] Full unit suite: no new regressions (pre-existing failures in `test_cv_storage_file.py` and `test_search_router.py` are unrelated and also fail on `main`).
- [ ] Verify in production after deploy: tail `gcloud logging read` for the `RuntimeError: TCPTransport closed` stack trace and confirm it stops recurring on `/auth/google`, `/auth/refresh`, and other DB endpoints.

## Documentation
No doc changes needed — this is a targeted driver-interaction bugfix with no API, schema, or convention changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)