### PR TITLE
feat(admin): default invite codes to XXXX-XXXX alphanumeric format

### DIFF
--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -44,7 +44,10 @@ class AccessCodeResponse(BaseModel):
 
 
 class AccessCodeBatchCreate(BaseModel):
-    prefix: str = Field(min_length=2, max_length=32)
+    # When omitted (or empty), codes are generated in the default
+    # XXXX-XXXX alphanumeric format. A non-empty prefix keeps the
+    # legacy `{prefix}-{suffix}` shape for campaign tagging.
+    prefix: str | None = Field(default=None, max_length=32)
     count: int = Field(ge=1, le=500)
     label: str = ""
 

--- a/backend/app/admin/service.py
+++ b/backend/app/admin/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import secrets
 
 from neo4j import AsyncDriver
 
@@ -62,6 +63,25 @@ from app.graph.queries import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Alphabet used when auto-generating default invite codes. Excludes
+# ambiguous glyphs (0/O, 1/I/L, U) so users can retype a code from a
+# screenshot or print without misreadings.
+DEFAULT_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789"
+DEFAULT_CODE_SEGMENT_LEN = 4
+
+
+def generate_default_code() -> str:
+    """Return a default-format invite code: 4 alphanumerics, hyphen, 4 alphanumerics."""
+
+    def _segment() -> str:
+        return "".join(
+            secrets.choice(DEFAULT_CODE_ALPHABET)
+            for _ in range(DEFAULT_CODE_SEGMENT_LEN)
+        )
+
+    return f"{_segment()}-{_segment()}"
 
 
 # ── BetaConfig (singleton) ──
@@ -279,17 +299,21 @@ async def count_access_codes(db: AsyncDriver) -> dict[str, int]:
 async def create_batch_access_codes(
     db: AsyncDriver,
     *,
-    prefix: str,
     count: int,
     label: str,
     created_by: str,
+    prefix: str | None = None,
 ) -> list[dict]:
     import uuid
 
+    clean_prefix = (prefix or "").strip()
     codes = []
     async with db.session() as session:
         for _ in range(count):
-            code = f"{prefix}-{uuid.uuid4().hex[:6]}"
+            if clean_prefix:
+                code = f"{clean_prefix}-{uuid.uuid4().hex[:6]}"
+            else:
+                code = generate_default_code()
             result = await session.run(
                 CREATE_ACCESS_CODE,
                 code=code,

--- a/backend/tests/unit/test_invitation_system.py
+++ b/backend/tests/unit/test_invitation_system.py
@@ -474,6 +474,115 @@ def test_admin_create_batch(admin_client):
     assert len(response.json()) == 1
 
 
+def test_admin_create_batch_without_prefix_uses_default_format(admin_client):
+    """Batch create accepts a null/missing prefix and returns default-format codes."""
+    with patch(
+        "app.admin.router.create_batch_access_codes",
+        AsyncMock(
+            return_value=[
+                {
+                    "code": "A3K9-B2X7",
+                    "label": "",
+                    "active": True,
+                    "used_at": None,
+                    "used_by": None,
+                    "created_at": "2026-04-10T12:00:00",
+                    "created_by": "admin-user",
+                }
+            ]
+        ),
+    ) as batch_mock:
+        response = admin_client.post(
+            "/admin/access-codes/batch",
+            json={"count": 1},
+        )
+
+    assert response.status_code == 201
+    assert batch_mock.await_args.kwargs["prefix"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Default code generation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_generate_default_code_format():
+    """Default invite codes are XXXX-XXXX with only the safe alphabet."""
+    import re
+
+    from app.admin.service import (
+        DEFAULT_CODE_ALPHABET,
+        generate_default_code,
+    )
+
+    pattern = re.compile(
+        rf"^[{re.escape(DEFAULT_CODE_ALPHABET)}]{{4}}-[{re.escape(DEFAULT_CODE_ALPHABET)}]{{4}}$"
+    )
+    for _ in range(50):
+        assert pattern.match(generate_default_code())
+
+
+def test_generate_default_code_is_random():
+    """Two consecutive calls must (overwhelmingly likely) differ."""
+    from app.admin.service import generate_default_code
+
+    samples = {generate_default_code() for _ in range(20)}
+    assert len(samples) > 15
+
+
+@pytest.mark.asyncio
+async def test_create_batch_access_codes_uses_default_when_no_prefix(mock_db):
+    """Without a prefix the batch helper generates default-format codes."""
+    import re
+
+    from app.admin.service import DEFAULT_CODE_ALPHABET, create_batch_access_codes
+
+    session_mock = mock_db.session.return_value.__aenter__.return_value
+    created_codes: list[str] = []
+
+    async def _run(query, **kwargs):
+        created_codes.append(kwargs["code"])
+        result = AsyncMock()
+        result.single = AsyncMock(return_value={"a": {"code": kwargs["code"]}})
+        return result
+
+    session_mock.run = _run
+
+    await create_batch_access_codes(
+        mock_db, count=3, label="", created_by="admin", prefix=None
+    )
+    pattern = re.compile(
+        rf"^[{re.escape(DEFAULT_CODE_ALPHABET)}]{{4}}-[{re.escape(DEFAULT_CODE_ALPHABET)}]{{4}}$"
+    )
+    assert len(created_codes) == 3
+    for code in created_codes:
+        assert pattern.match(code), code
+
+
+@pytest.mark.asyncio
+async def test_create_batch_access_codes_respects_prefix(mock_db):
+    """A non-empty prefix keeps the legacy `{prefix}-{suffix}` format."""
+    from app.admin.service import create_batch_access_codes
+
+    session_mock = mock_db.session.return_value.__aenter__.return_value
+    created_codes: list[str] = []
+
+    async def _run(query, **kwargs):
+        created_codes.append(kwargs["code"])
+        result = AsyncMock()
+        result.single = AsyncMock(return_value={"a": {"code": kwargs["code"]}})
+        return result
+
+    session_mock.run = _run
+
+    await create_batch_access_codes(
+        mock_db, count=2, label="", created_by="admin", prefix="launch"
+    )
+    assert len(created_codes) == 2
+    for code in created_codes:
+        assert code.startswith("launch-")
+
+
 def test_admin_pending_users(admin_client):
     with patch(
         "app.admin.router.list_pending_persons",

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,8 +42,8 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | GET | `/admin/beta-config` | Admin | Read `invite_code_required` toggle state |
 | PATCH | `/admin/beta-config` | Admin | Update `invite_code_required` (true = codes required, false = open platform) |
 | GET | `/admin/access-codes` | Admin | List all invite codes with status (used/available/inactive) |
-| POST | `/admin/access-codes` | Admin | Create single invite code (`{code, label?}`) |
-| POST | `/admin/access-codes/batch` | Admin | Batch create codes (`{prefix, count, label?}`) |
+| POST | `/admin/access-codes` | Admin | Create single invite code (`{code, label?}`). Default UI-generated format is `XXXX-XXXX` (4 alphanumerics + `-` + 4 alphanumerics); any 3–64 character custom code is also accepted. |
+| POST | `/admin/access-codes/batch` | Admin | Batch create codes (`{count, prefix?, label?}`). Empty/omitted `prefix` → codes in default `XXXX-XXXX` format; non-empty prefix → legacy `{prefix}-{suffix}` format for campaign tagging. |
 | PATCH | `/admin/access-codes/{code}` | Admin | Toggle code active/inactive |
 | DELETE | `/admin/access-codes/{code}` | Admin | Delete unused code |
 | GET | `/admin/pending-users` | Admin | List users registered but not yet activated |

--- a/docs/invitation-system.md
+++ b/docs/invitation-system.md
@@ -70,8 +70,8 @@ The admin dashboard is accessible at `/admin` (or via the UserMenu dropdown, vis
 - Toggle button: "Codice invito: OBBLIGATORIO" / "Piattaforma: APERTA A TUTTI" (with confirmation dialog)
 
 ### Codici Invito Tab
-- **Create single code** — specify code name + optional label
-- **Create batch** — specify prefix + count + optional label (generates codes like `prefix-a1b2c3`)
+- **Create single code** — pick a code (click **Generate** to fill the default `XXXX-XXXX` format, or type a custom 3–64 character code) + optional label.
+- **Create batch** — count + optional prefix + optional label. Empty prefix ⇒ codes are generated in the default `XXXX-XXXX` format; a non-empty prefix keeps the legacy `{prefix}-{suffix}` shape for campaign tagging.
 - **Filter** — All / Available / Used
 - **Table** — code (click to copy), label, status, used by, created date, actions (activate/deactivate, delete)
 
@@ -104,13 +104,19 @@ uv run python -m scripts.grant_admin --user-id google-112726584537002607480 --re
 Once you're admin, you can create codes from the dashboard UI or via curl:
 
 ```bash
-# Single code
+# Single code (any 3–64 character code — e.g. the default XXXX-XXXX format)
 curl -X POST http://localhost:8000/admin/access-codes \
   -H "Authorization: Bearer <your-jwt>" \
   -H "Content-Type: application/json" \
-  -d '{"code": "invito-mario", "label": "amici"}'
+  -d '{"code": "A3K9-B2X7", "label": "amici"}'
 
-# Batch (generates 50 codes with prefix "launch")
+# Batch default format (generates 50 codes shaped like XXXX-XXXX)
+curl -X POST http://localhost:8000/admin/access-codes/batch \
+  -H "Authorization: Bearer <your-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"count": 50, "label": "launch-day"}'
+
+# Batch with a custom prefix (keeps the legacy "{prefix}-{suffix}" shape)
 curl -X POST http://localhost:8000/admin/access-codes/batch \
   -H "Authorization: Bearer <your-jwt>" \
   -H "Content-Type: application/json" \

--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -686,19 +686,28 @@
 
 - id: ADMIN_CREATE_CODE
   from_state: ADMIN
-  action: Fill code name + optional label, click "Crea"
+  action: Type a code (or click "Generate" to fill the default XXXX-XXXX format) + optional label, click "Crea"
   selector_or_control: "single code creation form in Codici invito tab"
   preconditions: [authenticated, is_admin, code_not_empty]
   expected_effect: Creates single AccessCode node, refreshes code list
   next_state: ADMIN (code list updated)
   fallback_on_failure: Error toast (409 if code already exists)
 
+- id: ADMIN_GENERATE_DEFAULT_CODE
+  from_state: ADMIN
+  action: Click "Generate" button next to the single-code input
+  selector_or_control: "Generate button in single code creation form"
+  preconditions: [authenticated, is_admin]
+  expected_effect: Fills the code input with a client-side random XXXX-XXXX code (4 alphanumerics + '-' + 4 alphanumerics, ambiguous glyphs excluded)
+  next_state: ADMIN (form updated; no DB write yet)
+  fallback_on_failure: null
+
 - id: ADMIN_CREATE_BATCH_CODES
   from_state: ADMIN
-  action: Fill prefix + count + optional label, click "Genera N"
+  action: Fill count + optional prefix + optional label, click "Genera N"
   selector_or_control: "batch creation form in Codici invito tab"
-  preconditions: [authenticated, is_admin, prefix_not_empty]
-  expected_effect: Creates N AccessCode nodes with auto-generated suffixes, refreshes list
+  preconditions: [authenticated, is_admin]
+  expected_effect: Creates N AccessCode nodes — empty prefix ⇒ default XXXX-XXXX format, non-empty prefix ⇒ legacy "{prefix}-{suffix}" shape. Refreshes list.
   next_state: ADMIN (code list updated)
   fallback_on_failure: Error toast
 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -63,6 +63,25 @@ export async function updateBetaConfig(
 
 // ── Access Codes ──
 
+// Mirrors backend/app/admin/service.py:DEFAULT_CODE_ALPHABET — ambiguous
+// glyphs (0/O, 1/I/L, U) are excluded so users can retype a printed code.
+const DEFAULT_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTVWXYZ23456789';
+const DEFAULT_CODE_SEGMENT_LEN = 4;
+
+export function generateDefaultCode(): string {
+  const crypto = window.crypto ?? (globalThis as { crypto?: Crypto }).crypto;
+  const segment = () => {
+    const buf = new Uint32Array(DEFAULT_CODE_SEGMENT_LEN);
+    crypto.getRandomValues(buf);
+    let out = '';
+    for (let i = 0; i < DEFAULT_CODE_SEGMENT_LEN; i++) {
+      out += DEFAULT_CODE_ALPHABET[buf[i] % DEFAULT_CODE_ALPHABET.length];
+    }
+    return out;
+  };
+  return `${segment()}-${segment()}`;
+}
+
 export async function listAccessCodes(): Promise<AccessCode[]> {
   // Backend is paginated (L2 fix). Hit the cap so the admin dashboard
   // keeps showing everything until proper pagination UI lands.
@@ -85,8 +104,10 @@ export async function createBatchAccessCodes(
   count: number,
   label: string = '',
 ): Promise<AccessCode[]> {
+  const trimmed = prefix.trim();
   const { data } = await client.post('/admin/access-codes/batch', {
-    prefix,
+    // Empty prefix ⇒ backend falls back to default XXXX-XXXX format.
+    prefix: trimmed || null,
     count,
     label,
   });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -16,6 +16,7 @@ import {
   deleteUser,
   createAccessCode,
   createBatchAccessCodes,
+  generateDefaultCode,
   toggleAccessCode,
   deleteAccessCode,
   updateBetaConfig,
@@ -338,7 +339,7 @@ export default function AdminPage() {
   };
 
   const handleCreateBatch = async () => {
-    if (!batchPrefix.trim() || batchCount < 1) return;
+    if (batchCount < 1) return;
     setBatchCreating(true);
     try {
       await createBatchAccessCodes(batchPrefix.trim(), batchCount, batchLabel.trim());
@@ -735,20 +736,22 @@ export default function AdminPage() {
             <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-4 mb-4">
               <h3 className="text-white/60 text-xs uppercase tracking-wider font-medium mb-3">Create single code</h3>
               <div className="flex flex-col sm:flex-row gap-2">
-                <input type="text" value={newCode} onChange={(e) => setNewCode(e.target.value)} placeholder="Code (e.g. invite-john)" className="flex-1 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
+                <input type="text" value={newCode} onChange={(e) => setNewCode(e.target.value)} placeholder="XXXX-XXXX (or custom)" className="flex-1 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
+                <button type="button" onClick={() => setNewCode(generateDefaultCode())} className="sm:w-28 bg-white/[0.04] hover:bg-white/[0.08] border border-white/[0.08] text-white/80 text-sm font-medium px-3 py-2 rounded-lg transition-colors whitespace-nowrap" title="Fill with a random XXXX-XXXX code">Generate</button>
                 <input type="text" value={newLabel} onChange={(e) => setNewLabel(e.target.value)} placeholder="Label (opt.)" className="sm:w-40 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
                 <button onClick={handleCreateCode} disabled={creating || !newCode.trim()} className="bg-purple-600 hover:bg-purple-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors whitespace-nowrap">{creating ? '...' : 'Create'}</button>
               </div>
+              <p className="text-white/30 text-xs mt-2">Default format is 4 alphanumerics, a dash, then 4 more (e.g. A3K9-B2X7). Override with any 3–64 character code.</p>
             </div>
 
             {/* Create batch */}
             <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-4 mb-4">
               <h3 className="text-white/60 text-xs uppercase tracking-wider font-medium mb-3">Generate batch codes</h3>
               <div className="flex flex-col sm:flex-row gap-2">
-                <input type="text" value={batchPrefix} onChange={(e) => setBatchPrefix(e.target.value)} placeholder="Prefix (e.g. launch)" className="flex-1 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
+                <input type="text" value={batchPrefix} onChange={(e) => setBatchPrefix(e.target.value)} placeholder="Prefix — leave empty for XXXX-XXXX" className="flex-1 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
                 <input type="number" value={batchCount} onChange={(e) => setBatchCount(Math.max(1, parseInt(e.target.value) || 1))} min={1} max={500} className="sm:w-24 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none" />
                 <input type="text" value={batchLabel} onChange={(e) => setBatchLabel(e.target.value)} placeholder="Label (opt.)" className="sm:w-36 bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-lg px-3 py-2 outline-none placeholder:text-white/20" />
-                <button onClick={handleCreateBatch} disabled={batchCreating || !batchPrefix.trim()} className="bg-purple-600 hover:bg-purple-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors whitespace-nowrap">{batchCreating ? '...' : `Generate ${batchCount}`}</button>
+                <button onClick={handleCreateBatch} disabled={batchCreating} className="bg-purple-600 hover:bg-purple-500 disabled:opacity-40 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors whitespace-nowrap">{batchCreating ? '...' : `Generate ${batchCount}`}</button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Batch invite-code creation no longer requires a prefix. Omitting it generates codes shaped like `A3K9-B2X7` (4 alphanumerics + `-` + 4 alphanumerics), using an unambiguous alphabet that excludes `0/O`, `1/I/L`, `U` so admins and users can retype a printed/screenshot-captured code without misreadings.
- Admin UI single-code form gains a **Generate** button that fills the input with the same default format client-side. Admins can still enter any custom 3–64 character code, and non-empty batch prefixes keep the legacy `{prefix}-{suffix}` shape for campaign tagging.
- Uses `secrets.choice` on the backend and `crypto.getRandomValues` on the frontend — CSPRNG on both sides.

## Changes
- `backend/app/admin/service.py`: new `generate_default_code()` helper + `DEFAULT_CODE_ALPHABET` constant. `create_batch_access_codes` now accepts an optional `prefix`; empty/`None` ⇒ default format, non-empty ⇒ legacy `{prefix}-{suffix}`.
- `backend/app/admin/models.py`: `AccessCodeBatchCreate.prefix` is now `str | None = None` (only `count` is required).
- `frontend/src/api/admin.ts`: new `generateDefaultCode()` exported helper mirroring the backend alphabet; `createBatchAccessCodes` now sends `null` when the prefix is blank.
- `frontend/src/pages/AdminPage.tsx`: single-code form gets a **Generate** button + helper copy; batch form drops the prefix-required guard and its placeholder now advertises the default XXXX-XXXX fallback.

## Documentation
- `docs/api.md` — batch endpoint payload shape (`{count, prefix?, label?}`) and the new default vs legacy formats.
- `docs/invitation-system.md` — admin dashboard copy + curl examples (default batch, prefixed batch).
- `docs/navigation-actions.yaml` — updated `ADMIN_CREATE_CODE` / `ADMIN_CREATE_BATCH_CODES` preconditions and added a new `ADMIN_GENERATE_DEFAULT_CODE` action for the button.

## Test plan
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [x] `uv run pytest tests/unit/test_invitation_system.py -v` — 31/31 pass, including 5 new cases for format, randomness, batch-without-prefix, batch-with-prefix, and the admin router path.
- [x] `npm run lint` — 0 errors. `npm run build` — succeeds.
- [ ] Manual: admin dashboard → single-code **Generate** button fills `XXXX-XXXX`, Crea persists it.
- [ ] Manual: batch form with empty prefix generates N codes all matching `XXXX-XXXX`.
- [ ] Manual: batch form with `launch` prefix still generates `launch-abc123` style codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)