### PR TITLE
fix(mobile): CV_REVIEW layout + Pulse metric-info tooltip (#373)

### DIFF
--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -20,19 +20,44 @@ interface OrbisPulsePanelProps {
 const COMPACT_BREAKPOINT_PX = 1280;
 
 function MetricInfo({ description, label }: { description: string; label: string }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
   return (
-    <div className="absolute right-1.5 top-1.5 pointer-events-auto">
-      <div className="group relative">
+    <div ref={containerRef} className="absolute right-1.5 top-1.5 pointer-events-auto">
+      <div className="relative">
         <button
           type="button"
           aria-label={`${label} metric info`}
-          className="h-[18px] w-[18px] rounded-full border border-white/20 bg-white/5 text-[10px] font-semibold text-white/75 flex items-center justify-center cursor-help"
+          aria-expanded={open}
+          onClick={(e) => { e.stopPropagation(); setOpen((v) => !v); }}
+          className="h-5 w-5 sm:h-[18px] sm:w-[18px] rounded-full border border-white/20 bg-white/5 text-[11px] sm:text-[10px] font-semibold text-white/75 flex items-center justify-center cursor-pointer hover:bg-white/10 hover:text-white transition-colors"
         >
           i
         </button>
-        <div className="pointer-events-none absolute right-0 top-6 z-50 w-56 rounded-lg border border-white/15 bg-black/90 px-2 py-1.5 text-[10px] leading-snug text-white/80 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
-          {description}
-        </div>
+        {open && (
+          <div className="absolute right-0 top-7 sm:top-6 z-50 w-[min(18rem,calc(100vw-3rem))] sm:w-56 rounded-lg border border-white/15 bg-black/95 px-3 py-2 text-xs sm:text-[11px] leading-snug text-white/90 shadow-xl">
+            {description}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -54,9 +54,30 @@ function MetricInfo({ description, label }: { description: string; label: string
           i
         </button>
         {open && (
-          <div className="absolute right-0 top-7 sm:top-6 z-50 w-[min(18rem,calc(100vw-3rem))] sm:w-56 rounded-lg border border-white/15 bg-black/95 px-3 py-2 text-xs sm:text-[11px] leading-snug text-white/90 shadow-xl">
-            {description}
-          </div>
+          <>
+            {/* Mobile backdrop — captures tap-to-dismiss and lifts the tooltip above the Pulse modal */}
+            <div
+              className="fixed inset-0 z-[60] bg-black/50 sm:hidden"
+              onClick={() => setOpen(false)}
+              aria-hidden="true"
+            />
+            <div className="fixed left-4 right-4 bottom-4 z-[61] sm:absolute sm:inset-auto sm:right-0 sm:top-6 sm:left-auto sm:bottom-auto sm:w-56 sm:z-50 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
+              <div className="flex items-start justify-between gap-3 sm:hidden mb-1.5">
+                <span className="text-[10px] uppercase tracking-[0.15em] text-white/45 font-semibold">{label}</span>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setOpen(false); }}
+                  aria-label="Close"
+                  className="-my-1 -mr-1 p-1 text-white/50 hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              {description}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -325,8 +325,8 @@ export default function ExtractedDataReview({
           )}
           {typeKeys.length > 0 && (
             <>
-              {/* Type tabs */}
-              <div className="flex flex-wrap gap-1.5 mb-4">
+              {/* Type tabs — horizontal scroll rail on mobile, wrap on sm+ */}
+              <div className="flex sm:flex-wrap overflow-x-auto gap-1.5 mb-4 -mx-1 px-1 pb-1 sm:pb-0 sm:overflow-visible sm:mx-0 sm:px-0">
                 {typeKeys.map((type) => {
                   const color = NODE_TYPE_COLORS[type] || '#8b5cf6';
                   const label = NODE_TYPE_LABELS[type] || type;
@@ -336,7 +336,7 @@ export default function ExtractedDataReview({
                     <button
                       key={type}
                       onClick={() => setActiveTypeTab(type)}
-                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                      className={`shrink-0 sm:shrink flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-all ${
                         isActive
                           ? 'bg-white/10 text-white border border-white/20'
                           : 'bg-white/[0.03] text-white/40 border border-white/[0.06] hover:text-white/60 hover:bg-white/[0.06]'
@@ -467,19 +467,19 @@ export default function ExtractedDataReview({
           </p>
         )}
 
-        <div className="flex gap-3 justify-center">
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-center gap-2 sm:gap-3">
+          <button
+            onClick={onReset}
+            className="w-full sm:w-auto border border-white/10 text-white/40 hover:text-white/70 font-medium py-3 px-6 rounded-xl transition-colors text-base cursor-pointer"
+          >
+            {resetLabel}
+          </button>
           <button
             onClick={handleConfirmClick}
             disabled={confirming || extractedNodes.length === 0}
-            className="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 text-base cursor-pointer"
+            className="w-full sm:w-auto bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white font-semibold py-3 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 text-base cursor-pointer"
           >
             {confirming ? 'Adding...' : `Add ${extractedNodes.length} entries to graph`}
-          </button>
-          <button
-            onClick={onReset}
-            className="border border-white/10 text-white/40 hover:text-white/70 font-medium py-3 px-6 rounded-xl transition-colors text-base cursor-pointer"
-          >
-            {resetLabel}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Closes #373.

## Summary
Fixes three mobile layout issues discovered while walking the CV review flow and the Orbis Pulse panel on a 360 px viewport.

### 1. CV_REVIEW — tabs + action buttons
- Node-type tab bar (~11 entries) was using `flex-wrap` and piled into 3–4 messy rows at 360 px. Switched to a horizontal scroll rail on `<sm` (`flex overflow-x-auto shrink-0 whitespace-nowrap`); keeps the wrap layout on `sm+`.
- *Add N entries to graph* + *Try another file* sat side-by-side and overflowed with long labels. Now stack column on `<sm` (`flex-col-reverse` so the primary confirm button sits at the bottom, closest to the thumb); full-width each. Reverts to centered row on `sm+`.

### 2. Orbis Pulse — metric `(i)` tooltips on mobile
- Tooltips were hover-only. A tap gave focus briefly, tooltip faded, user never read it. Converted to state-driven **tap-to-toggle** with outside-click / ESC dismiss; `aria-expanded` wired.
- Tooltip text was 10 px — unreadable. Bumped to `text-xs` (12 px) on mobile.
- Button grew slightly on mobile (`h-5 w-5`) with hover feedback.

### 3. Orbis Pulse — tooltip escapes clipping
- Even after the toggle + sizing, the tooltip was being **clipped by the Pulse panel**. Switched to a **fixed bottom sheet** on `<sm` (`fixed left-4 right-4 bottom-4 z-[61]`) with its own `z-[60]` backdrop + title + close button, so it sits on top of everything. Desktop keeps the anchored popover.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [ ] Manual: at 360 px — CV_REVIEW tabs scroll horizontally; confirm button spans width.
- [ ] Manual: at 360 px — tap (i) on any Pulse metric: bottom sheet appears fully readable.