### PR TITLE
fix(backend): regenerate uv.lock to pin neo4j to 5.x

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
@@ -1494,14 +1494,14 @@ wheels = [
 
 [[package]]
 name = "neo4j"
-version = "6.1.0"
+version = "5.28.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f2/9e386c8e7243c285768ecd2b71e6796009d3f6f3b202310e9ef972acf526/neo4j-5.28.3.tar.gz", hash = "sha256:0625aaaf0963bc99a7231e946952f579792c3be22687192b20e0b74aa1233a2b", size = 232122, upload-time = "2026-01-12T10:42:43.842Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
+    { url = "https://files.pythonhosted.org/packages/64/83/15b4ee7c081322ba3095e58bfa2c4214452fda9accaece68e25fc86a9bb4/neo4j-5.28.3-py3-none-any.whl", hash = "sha256:dbf6d9211b861bc3dd62dccbf8a74d1e33e0c602084dd123b753edf46e1fdfad", size = 313351, upload-time = "2026-01-12T10:42:40.507Z" },
 ]
 
 [[package]]
@@ -1556,7 +1556,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
-    { name = "neo4j", specifier = ">=5.20.0" },
+    { name = "neo4j", specifier = ">=5.20.0,<6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pymupdf", specifier = ">=1.24.0" },


### PR DESCRIPTION
## Summary
- `backend/uv.lock` still resolved `neo4j==6.1.0` because the `<6` upper bound was added to `pyproject.toml` without regenerating the lock.
- The import-time guard in `app/graph/neo4j_client.py::_assert_supported_driver_version` rejects 6.x (private driver internals are patched for 5.x) and crashed `orbis-api` Cloud Run revision **00047** on the `v0.1.0-alpha.6` deploy:
  ```
  RuntimeError: app.graph.neo4j_client expects neo4j==5.x; found neo4j==6.1.0
  ```
- Production is still served by revision **00046** (deploy aborted before flipping traffic), so no downtime — but the release pipeline is blocked.

## Fix
Regenerated the lock with `uv lock --upgrade-package neo4j` → `neo4j 5.28.3`. Also bumps `uv.lock` metadata `revision = 2 → 3` (uv format bump — no dependency-graph impact).

## Test plan
- [x] `uv sync --all-extras` resolves cleanly
- [x] `python -c "from app.main import app"` no longer raises
- [x] `ruff check .` passes
- [ ] CI green (lint + unit tests)
- [ ] After merge: cut `v0.1.0-alpha.7` and verify `orbis-api` rolls to the new revision

## Documentation
No doc changes needed — purely a dependency pin fix.