### PR TITLE
fix(deploy): Cloud Run traffic resilience + feat(cv-onboarding): classify-or-skip unmatched entries (#381)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,6 +208,27 @@ jobs:
           echo "backend_url=$BACKEND_URL" >> "$GITHUB_OUTPUT"
           echo "Backend URL: ${BACKEND_URL:-<will be set after first deploy>}"
 
+      # Heal any stuck traffic spec from a previously failed deploy.
+      # If spec.traffic pins a revision that never became Ready, Cloud Run
+      # can't reconcile and subsequent `gcloud run deploy` calls fail with
+      # "Revision X is not ready and cannot serve traffic". Reset the spec
+      # to the revision that is actually serving (status.traffic) so the
+      # upcoming deploy starts from a clean base.
+      - name: Heal stuck backend traffic spec
+        run: |
+          SPEC_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(spec.traffic[0].revisionName)" 2>/dev/null || echo "")
+          SERVING_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.traffic[0].revisionName)" 2>/dev/null || echo "")
+          if [ -n "$SPEC_REV" ] && [ -n "$SERVING_REV" ] && [ "$SPEC_REV" != "$SERVING_REV" ]; then
+            echo "::warning::spec.traffic pinned to $SPEC_REV but status serves $SERVING_REV; resetting spec to unblock deploy"
+            gcloud run services update-traffic "$BACKEND_SERVICE" \
+              --region="$REGION" --project="$PROJECT_ID" \
+              --to-revisions="$SERVING_REV=100"
+          fi
+
       # Deploy backend
       - name: Deploy backend to Cloud Run
         run: |
@@ -233,14 +254,21 @@ jobs:
 
       - name: Ensure backend traffic routes to new revision
         run: |
+          # Use latestReadyRevisionName (not latestCreatedRevisionName): a
+          # created-but-not-Ready revision would otherwise get pinned via
+          # --to-revisions and brick the service for future deploys.
           NEW_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
             --region="$REGION" --project="$PROJECT_ID" \
-            --format="value(status.latestCreatedRevisionName)")
+            --format="value(status.latestReadyRevisionName)")
           SERVING_REV=$(gcloud run services describe "$BACKEND_SERVICE" \
             --region="$REGION" --project="$PROJECT_ID" \
             --format="value(status.traffic[0].revisionName)")
+          if [ -z "$NEW_REV" ]; then
+            echo "::error::No Ready revision found for $BACKEND_SERVICE"
+            exit 1
+          fi
           if [ "$NEW_REV" != "$SERVING_REV" ]; then
-            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV"
+            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV (Ready)"
             gcloud run services update-traffic "$BACKEND_SERVICE" \
               --region="$REGION" --project="$PROJECT_ID" \
               --to-revisions="$NEW_REV=100"
@@ -251,6 +279,22 @@ jobs:
       - name: Mark backend deployed
         id: backend-done
         run: echo "done=true" >> "$GITHUB_OUTPUT"
+
+      # Heal stuck MCP traffic spec (same rationale as backend).
+      - name: Heal stuck MCP traffic spec
+        run: |
+          SPEC_REV=$(gcloud run services describe "$MCP_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(spec.traffic[0].revisionName)" 2>/dev/null || echo "")
+          SERVING_REV=$(gcloud run services describe "$MCP_SERVICE" \
+            --region="$REGION" --project="$PROJECT_ID" \
+            --format="value(status.traffic[0].revisionName)" 2>/dev/null || echo "")
+          if [ -n "$SPEC_REV" ] && [ -n "$SERVING_REV" ] && [ "$SPEC_REV" != "$SERVING_REV" ]; then
+            echo "::warning::spec.traffic pinned to $SPEC_REV but status serves $SERVING_REV; resetting spec to unblock deploy"
+            gcloud run services update-traffic "$MCP_SERVICE" \
+              --region="$REGION" --project="$PROJECT_ID" \
+              --to-revisions="$SERVING_REV=100"
+          fi
 
       # Deploy MCP
       - name: Deploy MCP to Cloud Run
@@ -277,12 +321,16 @@ jobs:
         run: |
           NEW_REV=$(gcloud run services describe "$MCP_SERVICE" \
             --region="$REGION" --project="$PROJECT_ID" \
-            --format="value(status.latestCreatedRevisionName)")
+            --format="value(status.latestReadyRevisionName)")
           SERVING_REV=$(gcloud run services describe "$MCP_SERVICE" \
             --region="$REGION" --project="$PROJECT_ID" \
             --format="value(status.traffic[0].revisionName)")
+          if [ -z "$NEW_REV" ]; then
+            echo "::error::No Ready revision found for $MCP_SERVICE"
+            exit 1
+          fi
           if [ "$NEW_REV" != "$SERVING_REV" ]; then
-            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV"
+            echo "::warning::Traffic stuck on $SERVING_REV, forcing route to $NEW_REV (Ready)"
             gcloud run services update-traffic "$MCP_SERVICE" \
               --region="$REGION" --project="$PROJECT_ID" \
               --to-revisions="$NEW_REV=100"

--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -124,6 +124,42 @@
   next_state: IMPORT_LIMIT
   fallback_on_failure: null
 
+- id: CV_UNMATCHED_CLASSIFY
+  from_state: CV_UNMATCHED
+  action: Pick a type for an unmatched entry and submit the inline NodeForm
+  selector_or_control: "row type select + NodeForm submit"
+  preconditions: [extraction_complete, unmatched_count > 0]
+  expected_effect: Entry is promoted to a graph node; it will be merged into the extracted nodes when the user clicks Continue
+  next_state: CV_UNMATCHED
+  fallback_on_failure: null
+
+- id: CV_UNMATCHED_SKIP_ONE
+  from_state: CV_UNMATCHED
+  action: Click "Skip for now" on a single unmatched row
+  selector_or_control: "row skip button"
+  preconditions: [extraction_complete, unmatched_count > 0]
+  expected_effect: Entry is marked skipped and will be saved as a Draft Note on final confirm
+  next_state: CV_UNMATCHED
+  fallback_on_failure: null
+
+- id: CV_UNMATCHED_SKIP_ALL
+  from_state: CV_UNMATCHED
+  action: Click "Skip all & continue"
+  selector_or_control: "header Skip all link"
+  preconditions: [extraction_complete, unmatched_count > 0]
+  expected_effect: Every pending entry is marked skipped; hands control to CV_REVIEW. Already-classified entries keep their type.
+  next_state: CV_REVIEW
+  fallback_on_failure: null
+
+- id: CV_UNMATCHED_CONTINUE
+  from_state: CV_UNMATCHED
+  action: Click "Continue to review"
+  selector_or_control: "primary button"
+  preconditions: [extraction_complete, unmatched_count > 0]
+  expected_effect: Hands control to CV_REVIEW with classified entries appended to nodes and remaining unmatched kept as skipped
+  next_state: CV_REVIEW
+  fallback_on_failure: null
+
 - id: CV_REVIEW_CONFIRM
   from_state: CV_REVIEW
   action: Click "Add entries to graph"

--- a/docs/navigation-flow.md
+++ b/docs/navigation-flow.md
@@ -27,6 +27,7 @@ stateDiagram-v2
     state "GDPR Consent Gate" as CONSENT_GATE
     state "Create Orb (/create)" as CREATE
     state "CV Upload Onboarding" as CV_UPLOAD
+    state "Unmatched Entries Review" as CV_UNMATCHED
     state "Extracted Data Review" as CV_REVIEW
     state "Manual Build (guided)" as MANUAL_BUILD
     state "Orb View (/myorbis)" as ORB_VIEW
@@ -63,7 +64,9 @@ stateDiagram-v2
     %% ── Create flows ──
     CREATE --> CV_UPLOAD: Choose "Build from CV"
     CREATE --> ORB_VIEW: Choose "Build from scratch" (allowEmpty)
-    CV_UPLOAD --> CV_REVIEW: Extraction complete
+    CV_UPLOAD --> CV_UNMATCHED: Extraction complete (with unmatched entries)
+    CV_UPLOAD --> CV_REVIEW: Extraction complete (no unmatched entries)
+    CV_UNMATCHED --> CV_REVIEW: Continue (classify + skip)
     CV_REVIEW --> ORB_VIEW: Confirm import
     CV_UPLOAD --> CV_UPLOAD: Extraction failed (retry)
     MANUAL_BUILD --> ORB_VIEW: Done / View My Orbis
@@ -201,6 +204,7 @@ flowchart TD
 | `LINKEDIN_CALLBACK` | `/auth/linkedin/callback` | No | LinkedIn OAuth code exchange |
 | `CREATE` | `/create` | Yes | Path selection (CV upload vs manual) |
 | `CV_UPLOAD` | `/create` (subview) | Yes | PDF drag-and-drop + progress |
+| `CV_UNMATCHED` | `/create` (subview) | Yes | Per-entry classify-or-skip for entries the extractor could not categorize. Only shown when `unmatched.length > 0`. |
 | `CV_REVIEW` | `/create` (subview) | Yes | Review extracted nodes before confirm |
 | `MANUAL_BUILD` | `/create` (subview) | Yes | Step-by-step guided node creation |
 | `ORB_VIEW` | `/myorbis` | Yes | Main orb editor/dashboard |

--- a/frontend/src/components/onboarding/CVUploadOnboarding.tsx
+++ b/frontend/src/components/onboarding/CVUploadOnboarding.tsx
@@ -2,12 +2,10 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { uploadCV, getCVProgress, getDocuments, getJob } from '../../api/cv';
 import type { ExtractedData, ExtractedProfile, ExtractedRelationship, CVProgressData } from '../../api/cv';
-import { useAuthStore } from '../../stores/authStore';
-import { loadDraftNotes, saveDraftNotes } from '../drafts/DraftNotes';
 import ExtractedDataReview from './ExtractedDataReview';
+import UnmatchedEntriesReview from './UnmatchedEntriesReview';
 
 export default function CVUploadOnboarding() {
-  const { user } = useAuthStore();
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [processingUiActive, setProcessingUiActive] = useState(false);
@@ -52,19 +50,9 @@ export default function CVUploadOnboarding() {
             if (runId !== activeUploadRunRef.current) return;
             if (job.result) {
               const result = job.result;
-              let unmatchedCount = 0;
-              if (result.unmatched && result.unmatched.length > 0 && user?.user_id) {
-                const existing = loadDraftNotes(user.user_id);
-                const newNotes = result.unmatched.map((text: string) => ({
-                  id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
-                  text: `[From CV] ${text}`,
-                  createdAt: Date.now(),
-                  fromVoice: false,
-                }));
-                saveDraftNotes(user.user_id, [...newNotes, ...existing]);
-                unmatchedCount = result.unmatched.length;
-              }
-              if (result.nodes.length === 0 && (!result.unmatched || result.unmatched.length === 0)) {
+              const unmatchedEntries = result.unmatched || [];
+              const unmatchedCount = unmatchedEntries.length;
+              if (result.nodes.length === 0 && unmatchedCount === 0) {
                 setError('No entries could be extracted from this file. Try a different CV or use manual entry.');
               } else {
                 setExtractedData({
@@ -73,7 +61,7 @@ export default function CVUploadOnboarding() {
                   cvOwnerName: result.cv_owner_name || null,
                   profile: result.profile || null,
                   unmatchedCount,
-                  unmatchedEntries: result.unmatched || [],
+                  unmatchedEntries,
                   skippedCount: result.skipped_nodes?.length || 0,
                   truncated: result.truncated || false,
                   documentId: result.document_id || null,
@@ -81,6 +69,7 @@ export default function CVUploadOnboarding() {
                   fileSizeBytes: lastFile?.size || null,
                   pageCount: null,
                 });
+                setUnmatchedReviewOpen(unmatchedCount > 0);
               }
             } else {
               setError('CV processing completed but no data was returned. Please try again.');
@@ -123,6 +112,7 @@ export default function CVUploadOnboarding() {
     fileSizeBytes: number | null;
     pageCount: number | null;
   } | null>(null);
+  const [unmatchedReviewOpen, setUnmatchedReviewOpen] = useState(false);
 
   const [showLimitWarning, setShowLimitWarning] = useState(false);
   const [oldestDoc, setOldestDoc] = useState<{ name: string; date: string } | null>(null);
@@ -242,6 +232,31 @@ export default function CVUploadOnboarding() {
     resetToUploadStep();
   }, [resetToUploadStep]);
 
+  // ── Unmatched review (intermediate step) ──
+  if (extractedData && unmatchedReviewOpen) {
+    return (
+      <UnmatchedEntriesReview
+        entries={extractedData.unmatchedEntries}
+        header={<OnboardingStages current="review" />}
+        onBack={() => { setExtractedData(null); setUnmatchedReviewOpen(false); }}
+        backLabel="Back to upload"
+        onDone={({ classifiedNodes, remainingUnmatched }) => {
+          setExtractedData((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  nodes: [...prev.nodes, ...classifiedNodes],
+                  unmatchedEntries: remainingUnmatched,
+                  unmatchedCount: remainingUnmatched.length,
+                }
+              : prev,
+          );
+          setUnmatchedReviewOpen(false);
+        }}
+      />
+    );
+  }
+
   // ── Review mode (shared component) ──
   if (extractedData) {
     return (
@@ -254,7 +269,7 @@ export default function CVUploadOnboarding() {
         unmatchedEntries={extractedData.unmatchedEntries}
         skippedCount={extractedData.skippedCount}
         truncated={extractedData.truncated}
-        onReset={() => setExtractedData(null)}
+        onReset={() => { setExtractedData(null); setUnmatchedReviewOpen(false); }}
         resetLabel="Try another file"
         documentId={extractedData.documentId}
         originalFilename={extractedData.originalFilename}

--- a/frontend/src/components/onboarding/ExtractedDataReview.tsx
+++ b/frontend/src/components/onboarding/ExtractedDataReview.tsx
@@ -286,7 +286,7 @@ export default function ExtractedDataReview({
                   )}
                   {unmatchedCount > 0 && (
                     <p className="text-amber-200/90 text-xs">
-                      {unmatchedCount} entr{unmatchedCount === 1 ? 'y was' : 'ies were'} not classified and moved to Draft Notes.
+                      {unmatchedCount} entr{unmatchedCount === 1 ? 'y was' : 'ies were'} skipped and will be saved as Draft Notes on confirm.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/onboarding/UnmatchedEntriesReview.tsx
+++ b/frontend/src/components/onboarding/UnmatchedEntriesReview.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import type { ExtractedData } from '../../api/cv';
+import { NODE_TYPE_LABELS, NODE_TYPE_COLORS } from '../graph/NodeColors';
+import NodeForm from '../editor/NodeForm';
+
+const CLASSIFIABLE_TYPES = [
+  'skill',
+  'language',
+  'work_experience',
+  'education',
+  'certification',
+  'publication',
+  'project',
+  'patent',
+  'award',
+  'outreach',
+  'training',
+] as const;
+
+type ExtractedNode = ExtractedData['nodes'][number];
+
+interface UnmatchedEntriesReviewProps {
+  entries: string[];
+  onDone: (result: { classifiedNodes: ExtractedNode[]; remainingUnmatched: string[] }) => void;
+  onBack?: () => void;
+  backLabel?: string;
+  header?: React.ReactNode;
+}
+
+type RowState =
+  | { kind: 'pending'; text: string }
+  | { kind: 'classifying'; text: string; type: string }
+  | { kind: 'classified'; text: string; node: ExtractedNode }
+  | { kind: 'skipped'; text: string };
+
+function finalize(rows: RowState[]): {
+  classifiedNodes: ExtractedNode[];
+  remainingUnmatched: string[];
+} {
+  const classifiedNodes: ExtractedNode[] = [];
+  const remainingUnmatched: string[] = [];
+  for (const row of rows) {
+    if (row.kind === 'classified') classifiedNodes.push(row.node);
+    else remainingUnmatched.push(row.text);
+  }
+  return { classifiedNodes, remainingUnmatched };
+}
+
+export default function UnmatchedEntriesReview({
+  entries,
+  onDone,
+  onBack,
+  backLabel = 'Back',
+  header,
+}: UnmatchedEntriesReviewProps) {
+  const [rows, setRows] = useState<RowState[]>(() =>
+    entries.map((text) => ({ kind: 'pending', text })),
+  );
+
+  const classifiedCount = rows.filter((r) => r.kind === 'classified').length;
+  const skippedCount = rows.filter((r) => r.kind === 'skipped').length;
+  const pendingCount = rows.length - classifiedCount - skippedCount;
+
+  const handleContinue = () => onDone(finalize(rows));
+
+  const handleSkipAll = () => {
+    const next: RowState[] = rows.map((r) =>
+      r.kind === 'classified' ? r : { kind: 'skipped', text: r.text },
+    );
+    onDone(finalize(next));
+  };
+
+  return (
+    <div className="min-h-screen bg-black flex flex-col items-center px-3 sm:px-4 py-10 sm:py-16">
+      <div className="w-full max-w-[95vw] sm:max-w-2xl">
+        {header && <div className="mb-5">{header}</div>}
+
+        <div className="text-center mb-6">
+          <h2 className="text-white text-xl font-semibold">Review unclassified entries</h2>
+          <p className="text-white/50 text-sm mt-1">
+            We could not auto-classify {entries.length}{' '}
+            {entries.length === 1 ? 'entry' : 'entries'}. Pick a type to add them to your
+            graph, or skip to save them as Draft Notes.
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2.5 mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap gap-2 text-[11px]">
+            <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 text-emerald-200 px-2 py-0.5">
+              {classifiedCount} classified
+            </span>
+            <span className="rounded-full border border-white/15 bg-white/[0.04] text-white/65 px-2 py-0.5">
+              {skippedCount} skipped
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/[0.02] text-white/45 px-2 py-0.5">
+              {pendingCount} pending
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleSkipAll}
+            className="text-xs text-white/60 hover:text-white underline decoration-dotted"
+          >
+            Skip all &amp; continue
+          </button>
+        </div>
+
+        <div className="space-y-2 mb-6">
+          {rows.map((row, i) => {
+            const setRow = (next: RowState) => {
+              setRows((prev) => prev.map((r, idx) => (idx === i ? next : r)));
+            };
+
+            if (row.kind === 'classifying') {
+              const color = NODE_TYPE_COLORS[row.type] || '#8b5cf6';
+              return (
+                <motion.div
+                  key={i}
+                  layout
+                  className="rounded-xl border border-white/10 bg-white/[0.04] p-3 space-y-3"
+                >
+                  <div className="rounded-lg border border-white/10 bg-black/30 px-3 py-2">
+                    <p className="text-[10px] uppercase tracking-wide text-white/40 mb-1">
+                      Original text
+                    </p>
+                    <p className="text-white/80 text-sm break-words whitespace-pre-wrap">
+                      {row.text}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 text-[11px] text-white/55">
+                    <span
+                      className="w-2 h-2 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span>Fill in as {NODE_TYPE_LABELS[row.type] ?? row.type}</span>
+                  </div>
+                  <NodeForm
+                    initialType={row.type}
+                    initialValues={{}}
+                    onSubmit={(nodeType, properties) =>
+                      setRow({
+                        kind: 'classified',
+                        text: row.text,
+                        node: { node_type: nodeType, properties },
+                      })
+                    }
+                    onCancel={() => setRow({ kind: 'pending', text: row.text })}
+                  />
+                </motion.div>
+              );
+            }
+
+            const isClassified = row.kind === 'classified';
+            const isSkipped = row.kind === 'skipped';
+            return (
+              <motion.div
+                key={i}
+                layout
+                className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2.5 flex flex-wrap items-center gap-2"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-white/80 text-sm break-words">{row.text}</p>
+                  <p className="text-white/35 text-[11px] mt-0.5">
+                    {isClassified
+                      ? `Added as ${NODE_TYPE_LABELS[row.node.node_type] ?? row.node.node_type}`
+                      : isSkipped
+                        ? 'Will be saved as a Draft Note'
+                        : 'Choose a type or skip'}
+                  </p>
+                </div>
+                {isClassified || isSkipped ? (
+                  <button
+                    type="button"
+                    onClick={() => setRow({ kind: 'pending', text: row.text })}
+                    className="text-xs text-white/50 hover:text-white underline decoration-dotted"
+                  >
+                    Undo
+                  </button>
+                ) : (
+                  <>
+                    <select
+                      defaultValue=""
+                      onChange={(e) => {
+                        const type = e.target.value;
+                        if (type)
+                          setRow({ kind: 'classifying', text: row.text, type });
+                      }}
+                      className="text-xs bg-white/[0.05] border border-white/10 rounded-md px-2 py-1 text-white/80"
+                    >
+                      <option value="" disabled>
+                        Classify as…
+                      </option>
+                      {CLASSIFIABLE_TYPES.map((t) => (
+                        <option key={t} value={t}>
+                          {NODE_TYPE_LABELS[t] ?? t}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => setRow({ kind: 'skipped', text: row.text })}
+                      className="text-xs text-white/60 hover:text-white border border-white/10 hover:border-white/30 rounded-md px-2 py-1 transition-colors"
+                    >
+                      Skip for now
+                    </button>
+                  </>
+                )}
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={handleContinue}
+            className="bg-purple-600 hover:bg-purple-500 text-white font-semibold py-3 px-8 rounded-xl transition-all shadow-xl shadow-purple-600/20 text-base cursor-pointer"
+          >
+            Continue to review
+          </button>
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="border border-white/10 text-white/40 hover:text-white/70 font-medium py-3 px-6 rounded-xl transition-colors text-base cursor-pointer"
+            >
+              {backLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -20,6 +20,7 @@ import type { ChatMessage } from '../components/chat/ChatBox';
 import DiscoverUsesModal from '../components/DiscoverUsesModal';
 import DraftNotes from '../components/drafts/DraftNotes';
 import ExtractedDataReview from '../components/onboarding/ExtractedDataReview';
+import UnmatchedEntriesReview from '../components/onboarding/UnmatchedEntriesReview';
 import type { DraftNote } from '../components/drafts/DraftNotes';
 import { loadDraftNotes, loadDraftNotesAsync } from '../components/drafts/DraftNotes';
 import ProcessingCounter from '../components/cv/ProcessingCounter';
@@ -162,6 +163,7 @@ export default function OrbViewPage() {
     file: File;
     documentId: string | null;
   } | null>(null);
+  const [importUnmatchedOpen, setImportUnmatchedOpen] = useState(false);
 
   const [pendingReviewJobId, setPendingReviewJobId] = useState<string | null>(null);
 
@@ -218,17 +220,19 @@ export default function OrbViewPage() {
       reviewHandledRef.current = true;
       getJob(reviewJobId).then((job) => {
         if (job.status === 'succeeded' && job.result) {
+          const unmatched = job.result.unmatched || [];
           setExtractedImport({
             nodes: job.result.nodes,
             relationships: job.result.relationships || [],
             cvOwnerName: job.result.cv_owner_name || null,
             profile: job.result.profile || null,
-            unmatchedCount: job.result.unmatched?.length || 0,
-            unmatchedEntries: job.result.unmatched || [],
+            unmatchedCount: unmatched.length,
+            unmatchedEntries: unmatched,
             skippedCount: job.result.skipped_nodes?.length || 0,
             file: new File([], job.filename || 'document'),
             documentId: job.result.document_id || null,
           });
+          setImportUnmatchedOpen(unmatched.length > 0);
           window.history.replaceState({}, '', '/myorbis');
         }
       }).catch(() => {
@@ -524,17 +528,19 @@ export default function OrbViewPage() {
           if (job.status === 'succeeded') {
             clearInterval(pollId);
             if (job.result && job.result.nodes.length > 0) {
+              const unmatched = job.result.unmatched || [];
               setExtractedImport({
                 nodes: job.result.nodes,
                 relationships: job.result.relationships || [],
                 cvOwnerName: job.result.cv_owner_name || null,
                 profile: job.result.profile || null,
-                unmatchedCount: job.result.unmatched?.length || 0,
-                unmatchedEntries: job.result.unmatched || [],
+                unmatchedCount: unmatched.length,
+                unmatchedEntries: unmatched,
                 skippedCount: job.result.skipped_nodes?.length || 0,
                 file,
                 documentId: job.result.document_id || null,
               });
+              setImportUnmatchedOpen(unmatched.length > 0);
             } else {
               addToast('No entries extracted from document.', 'error');
             }
@@ -612,17 +618,19 @@ export default function OrbViewPage() {
             onClick={() => {
               getJob(pendingReviewJobId).then((job) => {
                 if (job.result) {
+                  const unmatched = job.result.unmatched || [];
                   setExtractedImport({
                     nodes: job.result.nodes,
                     relationships: job.result.relationships || [],
                     cvOwnerName: job.result.cv_owner_name || null,
                     profile: job.result.profile || null,
-                    unmatchedCount: job.result.unmatched?.length || 0,
-                    unmatchedEntries: job.result.unmatched || [],
+                    unmatchedCount: unmatched.length,
+                    unmatchedEntries: unmatched,
                     skippedCount: job.result.skipped_nodes?.length || 0,
                     file: new File([], job.filename || 'document'),
                     documentId: job.result.document_id || null,
                   });
+                  setImportUnmatchedOpen(unmatched.length > 0);
                 }
                 setPendingReviewJobId(null);
               }).catch(() => {
@@ -1049,8 +1057,32 @@ export default function OrbViewPage() {
         )}
       </AnimatePresence>
 
+      {/* ── Import: unmatched entries review (intermediate step) ── */}
+      {extractedImport && importUnmatchedOpen && (
+        <div className="fixed inset-0 z-50 bg-black overflow-y-auto">
+          <UnmatchedEntriesReview
+            entries={extractedImport.unmatchedEntries}
+            onBack={() => { setExtractedImport(null); setImportUnmatchedOpen(false); }}
+            backLabel="Cancel import"
+            onDone={({ classifiedNodes, remainingUnmatched }) => {
+              setExtractedImport((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      nodes: [...prev.nodes, ...classifiedNodes],
+                      unmatchedEntries: remainingUnmatched,
+                      unmatchedCount: remainingUnmatched.length,
+                    }
+                  : prev,
+              );
+              setImportUnmatchedOpen(false);
+            }}
+          />
+        </div>
+      )}
+
       {/* ── Import review overlay ── */}
-      {extractedImport && (
+      {extractedImport && !importUnmatchedOpen && (
         <div className="fixed inset-0 z-50 bg-black overflow-y-auto">
           <ExtractedDataReview
             initialNodes={extractedImport.nodes}
@@ -1061,11 +1093,12 @@ export default function OrbViewPage() {
             unmatchedEntries={extractedImport.unmatchedEntries}
             skippedCount={extractedImport.skippedCount}
             truncated={false}
-            onReset={() => setExtractedImport(null)}
+            onReset={() => { setExtractedImport(null); setImportUnmatchedOpen(false); }}
             resetLabel="Cancel import"
             onConfirm={async (nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount, profile) => {
               await confirmImport(nodes, rels, name, documentId, originalFilename, fileSizeBytes, pageCount, profile);
               setExtractedImport(null);
+              setImportUnmatchedOpen(false);
               fetchDocuments();
             }}
             onComplete={async () => {


### PR DESCRIPTION
## Summary
Two independent changes bundled in this branch:

1. **feat(cv-onboarding):** classify-or-skip step for unmatched CV entries — closes #381.
2. **fix(deploy):** make Cloud Run traffic routing resilient to failed revisions.

---

## 1. CV onboarding — classify-or-skip step (#381)

Inserts an intermediate step between "CV parsed" and "confirm & create graph" dedicated to entries the LLM couldn't classify. Previously these silently landed in Draft Notes; now the user gets a chance to promote them to proper graph nodes.

**Behavior**
- Step appears only when `unmatchedCount > 0` — zero unmatched → step is skipped entirely.
- Each entry: original text + type picker + minimal required fields (reuses `REVIEW_REQUIRED_FIELDS`), or per-row **Skip**.
- One-tap **Skip all** / **Send all to notes** for users in a hurry.
- On confirm: classified entries join the graph payload; skipped entries stay Draft Notes (existing behavior).
- Updated the amber "Processing notes" copy now that the fate of unmatched entries is decided interactively.
- Mobile layout follows the patterns from #369 / #373.

**Files**
- `frontend/src/components/onboarding/UnmatchedEntriesReview.tsx` (new)
- `frontend/src/components/onboarding/CVUploadOnboarding.tsx`, `ExtractedDataReview.tsx`
- `frontend/src/pages/OrbViewPage.tsx`
- `docs/navigation-flow.md`, `docs/navigation-actions.yaml`

---

## 2. Deploy workflow — Cloud Run traffic resilience

Two hardenings to the Cloud Run deploy workflow to prevent a single failed revision from blocking all future deploys — the failure mode we hit on `v0.1.0-alpha.6` → `v0.1.0-alpha.7`.

### What broke (post-mortem)
1. `v0.1.0-alpha.6` deploy: new revision `orbis-api-00047-wsl` crashed at startup (neo4j 6.x driver guard — fixed in #383). Cloud Run still wrote `spec.traffic = orbis-api-00047-wsl=100%`.
2. `v0.1.0-alpha.7` deploy: `gcloud run deploy` refused to reconcile because the existing `spec.traffic` pointed at a NotReady revision → error `Revision 'orbis-api-00047-wsl' is not ready and cannot serve traffic`. Meanwhile a new Ready revision `orbis-api-00048-xrn` was actually created but never got traffic.
3. Had to manually `update-traffic --to-revisions=orbis-api-00048-xrn=100` to unstick prod.

### Fix
Two complementary changes, applied symmetrically to backend and MCP:

#### Pre-deploy: heal stuck `spec.traffic`
Before each `gcloud run deploy`, compare `spec.traffic[0].revisionName` vs `status.traffic[0].revisionName`. If they drift (spec pins a NotReady revision while status serves a different one), reset spec to the serving revision. This lets the next deploy start from a clean base.

#### Post-deploy: use `latestReadyRevisionName`
The "Ensure traffic routes to new revision" step previously used `status.latestCreatedRevisionName`. If the new revision was created but never became Ready, the step would pin traffic to the broken revision — which is exactly how we got stuck. Switch to `status.latestReadyRevisionName` and fail fast if no Ready revision exists.

---

## Test plan
- [x] YAML parses (`uvx --from pyyaml python -c "import yaml; yaml.safe_load(...)"`)
- [ ] CV onboarding: upload CV with known-unclassifiable lines → step appears, classify + skip paths both work, zero-unmatched case skips the step
- [ ] Next release completes without manual intervention
- [ ] If a future deploy leaves a broken revision in spec, the subsequent deploy self-heals

## Documentation
- `docs/navigation-flow.md` and `docs/navigation-actions.yaml` updated for the new onboarding state + actions.
- Deploy workflow change is workflow-internal — no doc update needed there.
