### PR TITLE
fix(header): push full tool row to xl to stop mid-size overlap (#386)

### DIFF
--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -657,7 +657,7 @@ export default function OrbViewPage() {
               </div>
               {/* Tools hamburger — visible below lg */}
               {!isPendingDeletion && (
-                <div className="relative lg:hidden" ref={toolsMenuRef}>
+                <div className="relative xl:hidden" ref={toolsMenuRef}>
                   <button
                     onClick={() => setShowToolsMenu((v) => !v)}
                     className="h-10 sm:h-8 leading-none flex items-center gap-1 text-xs font-medium py-1.5 px-3 sm:px-2 rounded-lg text-white/55 hover:text-white hover:bg-white/8 transition-all"
@@ -765,7 +765,7 @@ export default function OrbViewPage() {
               )}
 
               {!isPendingDeletion && (
-                <div className="hidden lg:flex items-center gap-1.5 ml-2">
+                <div className="hidden xl:flex items-center gap-1.5 ml-2">
                   <div data-tour="node-types">
                     <NodeTypeFilter
                       hiddenTypes={hiddenNodeTypes}
@@ -851,11 +851,11 @@ export default function OrbViewPage() {
             <div className="h-8 flex items-center gap-1">
               <ProcessingCounter />
 
-              <div data-tour="connections" className="hidden lg:block">
+              <div data-tour="connections" className="hidden xl:block">
                 <PendingConnectionsDropdown />
               </div>
 
-              <div data-tour="notes" className="hidden lg:block">
+              <div data-tour="notes" className="hidden xl:block">
                 <HeaderBtn onClick={() => setShowDrafts(true)} variant="outline">
                   <IconNotes />
                   <span>Notes</span>


### PR DESCRIPTION
Closes #386.

## Problem
At the old \`lg\` threshold (1024 px) the full tool row (Node types / Filters / Export / Import / Undo-Redo) appeared **together** with the right-cluster Connections + Notes pills. There wasn't room for a sensible gap — at ~1024 – 1200 px the Connections pill visibly overlapped the *Import new document* label.

## Fix
Shift every "desktop-only" breakpoint from \`lg\` to \`xl\`:

| Element | Before | After |
|---|---|---|
| Tools hamburger | \`lg:hidden\` | \`xl:hidden\` (visible until 1280 px) |
| Tool row | \`hidden lg:flex\` | \`hidden xl:flex\` |
| Connections pill | \`hidden lg:block\` | \`hidden xl:block\` |
| Notes pill | \`hidden lg:block\` | \`hidden xl:block\` |

The Tools hamburger already carries full-width *Node types / Filters / Export / Import / Connection / Notes* rows (round-3 refactor from #375), so the lg-to-xl range now shows a clean hamburger + brand + search + avatar header. At \`xl\` (1280 px+) the full desktop layout takes over.

## Verified at
- **900 px** — hamburger + search + avatar, no overlap.
- **1024 px** (old bug breakpoint) — same clean layout, no overlap.
- **1280 px** — full desktop layout, all items fit (Import new document wraps to 2 lines but no overlap).

## Documentation
No schema / API / navigation-flow changes. Breakpoint-only tweak.