### PR TITLE
fix(z-index): metric info tooltip pierces every overlay (#387)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,28 @@ Performance optimizations: shared geometry (never recreated), node object cache 
 - **Pending connection-requests dropdown** (`components/graph/PendingConnectionsDropdown.tsx`) — header-level inbox of access requests backed by `backend/app/orbs/access_requests.py`. Accept creates an `AccessGrant` (with optional filters); reject marks the request resolved.
 - **Guided tour** (`components/GuidedTour.tsx`) — react-joyride overlay; 13 steps covering graph, header controls, connections dropdown, notes, search, user menu, Orbis Pulse, add-entry, visibility, and chatbox. Auto-triggers for new users; re-runnable from Settings.
 
+### Z-index tiers
+
+Overlays in the frontend share a conscious stacking scale — pick the right tier instead of guessing, so metric tooltips never slip behind a toast and a modal never slips behind the ChatBox:
+
+| Tier | Range | Used for |
+|---|---|---|
+| **Base** | default | 3D graph canvas, static page content |
+| **Pulse background** | `z-[30]` | Orbis Pulse compact pill + desktop panel |
+| **ChatBox** | `z-[40]` | Floating bottom chat/search bar |
+| **Pulse mobile sheet** | `z-[41]` backdrop / `z-[42]` panel | Mobile Orbis Pulse bottom sheet |
+| **Header** | `z-[50]` | Top-of-page OrbView header |
+| **UserMenu dropdown** | `z-[50]` | Avatar menu (inherits header context) |
+| **Toast** | `z-[100]` | Transient toast notifications |
+| **ProfileEditor modal** | `z-[130]` | Profile editor (portaled) |
+| **AccountSettings modal** | `z-[200]` | Account settings (portaled) |
+| **Metric info tooltip** | `z-[1000]` backdrop / `z-[1001]` panel | Orbis Pulse metric `(i)` tooltip — **must always win** (#387) |
+
+**Rules of thumb:**
+- New overlays pick the **lowest tier** that still wins over the surfaces they need to sit above. Don't jump straight to the top tier unless the UX really demands it.
+- Modals rendered via `createPortal` should live in the **Modal** tier (`z-[130]`–`z-[200]`) — not a bespoke value.
+- The **Metric info tier (`1000`)** is reserved for tooltips/explanations that must pierce through every modal. Don't reuse it for ordinary modals.
+
 ### Routing
 
 | Path | Page | Auth |

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -53,18 +53,18 @@ function MetricInfo({ description, label }: { description: string; label: string
         >
           i
         </button>
-        {open && (
+        {open && createPortal(
           <>
             {/* Metric info tooltip sits at the top of the z-index scale
-                (see docs/architecture.md) so it always wins over ChatBox,
-                header, Pulse overlay, toast, and any modal. */}
+                (see docs/architecture.md). Portaled to document.body so the
+                Pulse panel's stacking context (z-[30] / z-[42]) can't cap it. */}
             <div
               className="fixed inset-0 z-[1000] bg-black/50 sm:hidden"
               onClick={() => setOpen(false)}
               aria-hidden="true"
             />
-            <div className="fixed left-4 right-4 bottom-4 z-[1001] sm:absolute sm:inset-auto sm:right-0 sm:top-6 sm:left-auto sm:bottom-auto sm:w-56 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
-              <div className="flex items-start justify-between gap-3 sm:hidden mb-1.5">
+            <div className="fixed left-4 right-4 bottom-4 z-[1001] sm:left-auto sm:right-6 sm:bottom-auto sm:top-24 sm:w-56 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
+              <div className="flex items-start justify-between gap-3 mb-1.5 sm:hidden">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-white/45 font-semibold">{label}</span>
                 <button
                   type="button"
@@ -79,7 +79,8 @@ function MetricInfo({ description, label }: { description: string; label: string
               </div>
               {description}
             </div>
-          </>
+          </>,
+          document.body,
         )}
       </div>
     </div>

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -55,13 +55,15 @@ function MetricInfo({ description, label }: { description: string; label: string
         </button>
         {open && (
           <>
-            {/* Mobile backdrop — captures tap-to-dismiss and lifts the tooltip above the Pulse modal */}
+            {/* Metric info tooltip sits at the top of the z-index scale
+                (see docs/architecture.md) so it always wins over ChatBox,
+                header, Pulse overlay, toast, and any modal. */}
             <div
-              className="fixed inset-0 z-[60] bg-black/50 sm:hidden"
+              className="fixed inset-0 z-[1000] bg-black/50 sm:hidden"
               onClick={() => setOpen(false)}
               aria-hidden="true"
             />
-            <div className="fixed left-4 right-4 bottom-4 z-[61] sm:absolute sm:inset-auto sm:right-0 sm:top-6 sm:left-auto sm:bottom-auto sm:w-56 sm:z-50 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
+            <div className="fixed left-4 right-4 bottom-4 z-[1001] sm:absolute sm:inset-auto sm:right-0 sm:top-6 sm:left-auto sm:bottom-auto sm:w-56 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
               <div className="flex items-start justify-between gap-3 sm:hidden mb-1.5">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-white/45 font-semibold">{label}</span>
                 <button

--- a/frontend/src/components/graph/OrbisStatsOverlay.tsx
+++ b/frontend/src/components/graph/OrbisStatsOverlay.tsx
@@ -21,14 +21,46 @@ const COMPACT_BREAKPOINT_PX = 1280;
 
 function MetricInfo({ description, label }: { description: string; label: string }) {
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [anchor, setAnchor] = useState<{ left: number; top: number } | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Desktop-only: compute a position near the (i) button when the tooltip opens,
+  // and keep it correct on scroll/resize. Mobile uses the bottom-sheet layout
+  // (inset-x-4 bottom-4) and ignores `anchor`.
+  useEffect(() => {
+    if (!open) return;
+    const TOOLTIP_W = 224; // matches sm:w-56
+    const GAP = 8;
+    const updateAnchor = () => {
+      const btn = buttonRef.current;
+      if (!btn) return;
+      const rect = btn.getBoundingClientRect();
+      // Prefer opening to the LEFT of the button (toward the centre of the
+      // panel) so it stays on-screen; clamp inside the viewport.
+      const left = Math.max(
+        GAP,
+        Math.min(window.innerWidth - TOOLTIP_W - GAP, rect.right - TOOLTIP_W),
+      );
+      const top = rect.bottom + GAP;
+      setAnchor({ left, top });
+    };
+    updateAnchor();
+    window.addEventListener('resize', updateAnchor);
+    window.addEventListener('scroll', updateAnchor, true);
+    return () => {
+      window.removeEventListener('resize', updateAnchor);
+      window.removeEventListener('scroll', updateAnchor, true);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
     const handlePointer = (e: PointerEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false);
@@ -42,9 +74,10 @@ function MetricInfo({ description, label }: { description: string; label: string
   }, [open]);
 
   return (
-    <div ref={containerRef} className="absolute right-1.5 top-1.5 pointer-events-auto">
+    <div className="absolute right-1.5 top-1.5 pointer-events-auto">
       <div className="relative">
         <button
+          ref={buttonRef}
           type="button"
           aria-label={`${label} metric info`}
           aria-expanded={open}
@@ -55,15 +88,20 @@ function MetricInfo({ description, label }: { description: string; label: string
         </button>
         {open && createPortal(
           <>
-            {/* Metric info tooltip sits at the top of the z-index scale
-                (see docs/architecture.md). Portaled to document.body so the
-                Pulse panel's stacking context (z-[30] / z-[42]) can't cap it. */}
+            {/* Metric info tooltip — portaled to body to escape the Pulse
+                stacking context (z-[30] / z-[42]). Mobile: full-width bottom
+                sheet with backdrop. Desktop: small popover anchored near the
+                triggering (i) button via getBoundingClientRect. */}
             <div
               className="fixed inset-0 z-[1000] bg-black/50 sm:hidden"
               onClick={() => setOpen(false)}
               aria-hidden="true"
             />
-            <div className="fixed left-4 right-4 bottom-4 z-[1001] sm:left-auto sm:right-6 sm:bottom-auto sm:top-24 sm:w-56 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl">
+            <div
+              ref={panelRef}
+              style={anchor ? { left: anchor.left, top: anchor.top } : undefined}
+              className="fixed left-4 right-4 bottom-4 z-[1001] sm:left-auto sm:right-auto sm:bottom-auto sm:w-56 rounded-lg border border-white/15 bg-black/95 px-4 py-3 sm:px-3 sm:py-2 text-sm sm:text-[11px] leading-snug text-white/90 shadow-2xl"
+            >
               <div className="flex items-start justify-between gap-3 mb-1.5 sm:hidden">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-white/45 font-semibold">{label}</span>
                 <button


### PR DESCRIPTION
Closes #387.

## Problem
The metric info tooltip used \`z-[60]\`/\`z-[61]\` — above Pulse and ChatBox, but below ProfileEditor (\`z-[130]\`) and AccountSettings (\`z-[200]\`) modals. And there was no documented stacking scale, so every new overlay risked re-introducing the same bug.

## Fix
- \`OrbisStatsOverlay::MetricInfo\`: tooltip backdrop → \`z-[1000]\`, panel → \`z-[1001]\` (both mobile and desktop). Removed the \`sm:z-50\` fallback that was the root of the occlusion on desktop.
- **New** \`docs/architecture.md → Z-index tiers\` section listing every overlay in the app with its tier plus "rules of thumb" (pick the lowest tier that wins; reserve \`z-[1000]+\` for tooltips that must pierce modals).

## Z-index tiers (now documented)
| Tier | Range | Used for |
|---|---|---|
| Base | default | 3D graph, page content |
| Pulse background | \`z-[30]\` | Pulse compact pill + desktop panel |
| ChatBox | \`z-[40]\` | Floating chat/search bar |
| Pulse mobile sheet | \`z-[41]\`/\`z-[42]\` | Mobile bottom sheet + backdrop |
| Header | \`z-[50]\` | OrbView header |
| Toast | \`z-[100]\` | Transient notifications |
| ProfileEditor modal | \`z-[130]\` | Portaled |
| AccountSettings modal | \`z-[200]\` | Portaled |
| **Metric info** | \`z-[1000]\`/\`z-[1001]\` | **Reserved top tier** |

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm run build\` clean.
- [ ] Manual: open Account Settings on mobile, then tap (i) on an Orbis Pulse metric — tooltip sits on top.
- [ ] Manual: same on desktop (hover to open if supported, tap on touch).
- [ ] Manual: trigger a toast, then tap (i) — tooltip still on top.