### PR TITLE
feat(invites): gift invite quota for every user (#385)

### DIFF
--- a/backend/app/auth/gift_invites.py
+++ b/backend/app/auth/gift_invites.py
@@ -1,0 +1,87 @@
+"""User-issued 'gift' invite codes (#385).
+
+Each activated user gets a lifetime quota of 3 invite codes to share with
+friends. Codes are stored as ``:AccessCode`` nodes with ``source='gift'``
+and ``created_by = <user_id>`` — they flow through the same
+``/auth/activate`` consumption logic as admin codes.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+from neo4j import AsyncDriver
+from neo4j.time import Date as Neo4jDate
+from neo4j.time import DateTime as Neo4jDateTime
+from neo4j.time import Time as Neo4jTime
+
+from app.graph.queries import (
+    COUNT_GIFT_INVITES,
+    CREATE_GIFT_INVITE,
+    LIST_GIFT_INVITES,
+)
+
+GIFT_INVITE_QUOTA = 3
+GIFT_INVITE_PREFIX = "gift-"
+
+
+def _sanitize(d: dict) -> dict:
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, (Neo4jDateTime, Neo4jDate, Neo4jTime)):
+            result[k] = v.iso_format()
+        else:
+            result[k] = v
+    return result
+
+
+def _generate_code() -> str:
+    """Short, human-readable, URL-safe invite code."""
+    return f"{GIFT_INVITE_PREFIX}{secrets.token_urlsafe(6)}"
+
+
+async def list_gift_invites(db: AsyncDriver, user_id: str) -> list[dict[str, Any]]:
+    async with db.session() as session:
+        result = await session.run(LIST_GIFT_INVITES, user_id=user_id)
+        items: list[dict[str, Any]] = []
+        async for record in result:
+            items.append(_sanitize(dict(record["a"])))
+        return items
+
+
+async def count_gift_invites(db: AsyncDriver, user_id: str) -> tuple[int, int]:
+    """Return ``(total_issued, consumed)`` for the user."""
+    async with db.session() as session:
+        result = await session.run(COUNT_GIFT_INVITES, user_id=user_id)
+        record = await result.single()
+        if record is None:
+            return (0, 0)
+        return (int(record["total_issued"]), int(record["consumed"]))
+
+
+async def generate_gift_invite(
+    db: AsyncDriver, user_id: str
+) -> tuple[str, dict[str, Any] | None]:
+    """Create one invite if the user is under the quota.
+
+    Returns a ``(status, code_dict | None)`` tuple where status is one of
+    ``"created" | "quota_reached"``.
+    """
+    total_issued, _consumed = await count_gift_invites(db, user_id)
+    if total_issued >= GIFT_INVITE_QUOTA:
+        return ("quota_reached", None)
+
+    code = _generate_code()
+    label = f"Gift from {user_id}"
+    async with db.session() as session:
+        result = await session.run(
+            CREATE_GIFT_INVITE,
+            code=code,
+            label=label,
+            user_id=user_id,
+        )
+        record = await result.single()
+        if record is None:
+            return ("quota_reached", None)
+        return ("created", _sanitize(dict(record["a"])))

--- a/backend/app/auth/gift_invites.py
+++ b/backend/app/auth/gift_invites.py
@@ -23,7 +23,11 @@ from app.graph.queries import (
 )
 
 GIFT_INVITE_QUOTA = 3
-GIFT_INVITE_PREFIX = "gift-"
+
+# Human-friendly alphabet — drops 0/1/I/O/l to avoid mis-reads when copied by
+# hand. 32 characters → ~40 bits of entropy across the 8-char body, which is
+# plenty for a single-use code gated by quota.
+_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 
 
 def _sanitize(d: dict) -> dict:
@@ -37,8 +41,9 @@ def _sanitize(d: dict) -> dict:
 
 
 def _generate_code() -> str:
-    """Short, human-readable, URL-safe invite code."""
-    return f"{GIFT_INVITE_PREFIX}{secrets.token_urlsafe(6)}"
+    """Human-readable invite code in the shape ``XXXX-XXXX``."""
+    body = "".join(secrets.choice(_ALPHABET) for _ in range(8))
+    return f"{body[:4]}-{body[4:]}"
 
 
 async def list_gift_invites(db: AsyncDriver, user_id: str) -> list[dict[str, Any]]:

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -505,6 +505,68 @@ async def revoke_api_key_endpoint(
     return {"status": "revoked"}
 
 
+# ── Gift invites (#385) — per-user quota of 3 codes to share with friends ─
+
+
+@router.get("/me/invites")
+async def list_my_invites(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """List the caller's gift invite codes + quota state."""
+    from app.auth.gift_invites import (
+        GIFT_INVITE_QUOTA,
+        count_gift_invites,
+        list_gift_invites,
+    )
+
+    items = await list_gift_invites(db, user_id=current_user["user_id"])
+    _, consumed = await count_gift_invites(db, user_id=current_user["user_id"])
+    return {
+        "quota": GIFT_INVITE_QUOTA,
+        "total_issued": len(items),
+        "consumed": consumed,
+        "remaining": GIFT_INVITE_QUOTA - consumed,
+        "codes": [
+            {
+                "code": it["code"],
+                "created_at": it.get("created_at"),
+                "used_at": it.get("used_at"),
+                "used_by": it.get("used_by"),
+            }
+            for it in items
+        ],
+    }
+
+
+@router.post("/me/invites/generate")
+@limiter.limit("10/minute")
+async def generate_my_invite(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncDriver = Depends(get_db),
+):
+    """Generate one invite code, capped at the per-user quota."""
+    from app.auth.gift_invites import (
+        GIFT_INVITE_QUOTA,
+        generate_gift_invite,
+    )
+
+    status, record = await generate_gift_invite(
+        db, user_id=current_user["user_id"]
+    )
+    if status == "quota_reached":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Quota reached ({GIFT_INVITE_QUOTA} invites total per user).",
+        )
+    assert record is not None
+    return {
+        "code": record["code"],
+        "created_at": record.get("created_at"),
+    }
+
+
 # ── Dev-login (test environments only) ─────────────────────────────────
 
 if settings.env == "development":

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -552,9 +552,7 @@ async def generate_my_invite(
         generate_gift_invite,
     )
 
-    status, record = await generate_gift_invite(
-        db, user_id=current_user["user_id"]
-    )
+    status, record = await generate_gift_invite(db, user_id=current_user["user_id"])
     if status == "quota_reached":
         raise HTTPException(
             status_code=409,

--- a/backend/app/graph/queries.py
+++ b/backend/app/graph/queries.py
@@ -302,6 +302,36 @@ RETURN
     count(CASE WHEN a.used_at IS NULL AND a.active = true THEN 1 END) AS available
 """
 
+# User-issued "gift invite" codes — #385. Mirror the admin AccessCode shape but
+# tag with source='gift' and store the issuer's user_id so the quota can be
+# enforced per user and the owner can see which friends redeemed.
+CREATE_GIFT_INVITE = """
+CREATE (a:AccessCode {
+    code: $code,
+    label: $label,
+    active: true,
+    used_at: null,
+    used_by: null,
+    created_at: datetime(),
+    created_by: $user_id,
+    source: 'gift'
+})
+RETURN a
+"""
+
+LIST_GIFT_INVITES = """
+MATCH (a:AccessCode {source: 'gift', created_by: $user_id})
+RETURN a
+ORDER BY a.created_at DESC
+"""
+
+COUNT_GIFT_INVITES = """
+MATCH (a:AccessCode {source: 'gift', created_by: $user_id})
+RETURN
+    count(a) AS total_issued,
+    count(CASE WHEN a.used_at IS NOT NULL THEN 1 END) AS consumed
+"""
+
 # Pending users: registered but not yet activated (no signup_code, not admin),
 # and currently marked as joined to the waitlist.
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -64,3 +64,32 @@ export async function joinWaitlist(): Promise<{ status: string; waitlist_joined_
 export async function recoverAccount(): Promise<void> {
   await client.post('/auth/me/recover');
 }
+
+// ── Gift invites (#385) — per-user quota of 3 invite codes ──
+
+export interface GiftInvite {
+  code: string;
+  created_at: string | null;
+  used_at: string | null;
+  used_by: string | null;
+}
+
+export interface GiftInvitesState {
+  quota: number;
+  total_issued: number;
+  consumed: number;
+  remaining: number;
+  codes: GiftInvite[];
+}
+
+export async function getMyInvites(): Promise<GiftInvitesState> {
+  const { data } = await client.get<GiftInvitesState>('/auth/me/invites');
+  return data;
+}
+
+export async function generateMyInvite(): Promise<{ code: string; created_at: string | null }> {
+  const { data } = await client.post<{ code: string; created_at: string | null }>(
+    '/auth/me/invites/generate',
+  );
+  return data;
+}

--- a/frontend/src/components/GiftInviteButton.tsx
+++ b/frontend/src/components/GiftInviteButton.tsx
@@ -1,0 +1,278 @@
+// Gift invitation surface on /myorbis (#385).
+//
+// Each activated user gets a lifetime quota of 3 invite codes to share with
+// friends. The button sits at the bottom-left of the OrbView and shows the
+// remaining count ("3/3", "2/3", "1/3", "0/3" — decrementing as friends
+// redeem codes). Clicking opens a modal that lets the user generate a new
+// code (up to the quota) and copy an activation URL to share.
+
+import { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  getMyInvites,
+  generateMyInvite,
+  type GiftInvitesState,
+  type GiftInvite,
+} from '../api/auth';
+import { useToastStore } from '../stores/toastStore';
+
+function GiftIcon({ className = 'w-4 h-4' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M20 12v9H4v-9" />
+      <path d="M2 7h20v5H2z" />
+      <path d="M12 22V7" />
+      <path d="M12 7a4 4 0 01-4-4 2 2 0 014 0 2 2 0 014 0 4 4 0 01-4 4z" />
+    </svg>
+  );
+}
+
+function buildActivationUrl(code: string): string {
+  const base = window.location.origin;
+  return `${base}/activate?code=${encodeURIComponent(code)}`;
+}
+
+export default function GiftInviteButton() {
+  const [state, setState] = useState<GiftInvitesState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await getMyInvites();
+      setState(data);
+    } catch {
+      setState(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!open) return;
+    refresh();
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, refresh]);
+
+  const handleGenerate = async () => {
+    if (!state) return;
+    if (state.total_issued >= state.quota) return;
+    setGenerating(true);
+    try {
+      await generateMyInvite();
+      await refresh();
+    } catch {
+      addToast('Could not generate invite, try again', 'error');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopy = async (code: string) => {
+    const url = buildActivationUrl(code);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedCode(code);
+      addToast('Invite link copied', 'success');
+      setTimeout(() => setCopiedCode((c) => (c === code ? null : c)), 1800);
+    } catch {
+      addToast('Copy failed', 'error');
+    }
+  };
+
+  if (loading || !state) {
+    return null;
+  }
+
+  const remaining = state.remaining;
+  const quota = state.quota;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`Gift Invitation ${remaining} of ${quota} remaining`}
+        className="fixed bottom-4 left-4 z-[45] inline-flex items-center gap-2 rounded-full px-3.5 py-2 text-xs font-semibold text-white shadow-lg shadow-red-900/40 border border-red-400/50 bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 transition-all cursor-pointer"
+      >
+        <GiftIcon className="w-4 h-4" />
+        <span>Gift Invitation</span>
+        <span className="inline-flex items-center justify-center rounded-full bg-white/20 border border-white/30 px-1.5 text-[10px] font-bold leading-none py-0.5">
+          {remaining}/{quota}
+        </span>
+      </button>
+
+      {createPortal(
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center p-2 sm:p-4"
+            >
+              <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                onClick={() => setOpen(false)}
+                aria-hidden="true"
+              />
+              <motion.div
+                initial={{ opacity: 0, scale: 0.94, y: 24 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.94, y: 24 }}
+                transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+                className="relative w-full max-w-md bg-neutral-950 border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="gift-invite-title"
+              >
+                <div className="px-5 pt-5 pb-3 border-b border-white/5">
+                  <div className="flex items-start gap-3">
+                    <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-rose-500 to-red-700 flex items-center justify-center shrink-0 shadow-lg shadow-red-900/40">
+                      <GiftIcon className="w-5 h-5 text-white" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h2 id="gift-invite-title" className="text-white text-base font-semibold leading-tight">
+                        Invite friends to OpenOrbis
+                      </h2>
+                      <p className="text-white/50 text-xs mt-1 leading-relaxed">
+                        You can invite up to <strong className="text-white/80">{quota}</strong> friends. Generate a code, copy the activation link, and share it — the counter decrements as friends join.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setOpen(false)}
+                      aria-label="Close"
+                      className="-mr-1 -mt-1 h-8 w-8 rounded-lg text-white/40 hover:text-white hover:bg-white/10 flex items-center justify-center shrink-0 cursor-pointer"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+
+                <div className="px-5 py-4 space-y-3 max-h-[60vh] overflow-y-auto">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] uppercase tracking-[0.15em] text-white/40 font-semibold">Your codes</span>
+                    <span className="text-[11px] text-white/50">
+                      {remaining} / {quota} remaining
+                    </span>
+                  </div>
+
+                  {state.codes.length === 0 ? (
+                    <p className="text-white/40 text-sm italic text-center py-3">
+                      No codes yet — generate your first one below.
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {state.codes.map((c) => (
+                        <CodeRow
+                          key={c.code}
+                          code={c}
+                          onCopy={handleCopy}
+                          copied={copiedCode === c.code}
+                        />
+                      ))}
+                    </ul>
+                  )}
+
+                  {state.total_issued < state.quota && (
+                    <button
+                      type="button"
+                      onClick={handleGenerate}
+                      disabled={generating}
+                      className="w-full inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-white bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 disabled:opacity-60 disabled:cursor-wait border border-red-400/50 shadow-lg shadow-red-900/30 transition-all cursor-pointer"
+                    >
+                      <GiftIcon className="w-4 h-4" />
+                      {generating ? 'Generating…' : `Generate new code (${state.quota - state.total_issued} left)`}
+                    </button>
+                  )}
+                  {state.total_issued >= state.quota && remaining > 0 && (
+                    <p className="text-[11px] text-white/40 text-center">
+                      All {quota} codes issued. Share the ones above.
+                    </p>
+                  )}
+                  {remaining === 0 && state.total_issued >= state.quota && (
+                    <p className="text-[11px] text-emerald-300/80 text-center">
+                      All your friends joined — thanks for bringing them on board.
+                    </p>
+                  )}
+                </div>
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function CodeRow({
+  code,
+  onCopy,
+  copied,
+}: {
+  code: GiftInvite;
+  onCopy: (code: string) => void;
+  copied: boolean;
+}) {
+  const consumed = !!code.used_at;
+  const url = buildActivationUrl(code.code);
+  return (
+    <li
+      className={`rounded-xl border px-3 py-2.5 flex flex-col gap-2 ${
+        consumed
+          ? 'border-white/5 bg-white/[0.02] opacity-70'
+          : 'border-red-500/30 bg-red-500/[0.06]'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <code className="text-xs font-mono text-white/90 truncate">{code.code}</code>
+        {consumed ? (
+          <span className="text-[10px] uppercase tracking-wide text-emerald-300/80 font-semibold shrink-0">
+            Redeemed
+          </span>
+        ) : (
+          <span className="text-[10px] uppercase tracking-wide text-red-300/90 font-semibold shrink-0">
+            Active
+          </span>
+        )}
+      </div>
+      {!consumed && (
+        <div className="flex items-center gap-2">
+          <input
+            readOnly
+            value={url}
+            onFocus={(e) => e.currentTarget.select()}
+            className="flex-1 min-w-0 bg-black/40 border border-white/10 rounded-lg px-2.5 py-1.5 text-[11px] text-white/85 font-mono"
+          />
+          <button
+            type="button"
+            onClick={() => onCopy(code.code)}
+            className="shrink-0 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10 text-white text-[11px] font-semibold py-1.5 px-3 transition-colors cursor-pointer"
+          >
+            {copied ? 'Copied' : 'Copy link'}
+          </button>
+        </div>
+      )}
+      {consumed && code.used_by && (
+        <p className="text-[10px] text-white/40">Joined by {code.used_by}</p>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/GiftInviteButton.tsx
+++ b/frontend/src/components/GiftInviteButton.tsx
@@ -28,11 +28,6 @@ function GiftIcon({ className = 'w-4 h-4' }: { className?: string }) {
   );
 }
 
-function buildActivationUrl(code: string): string {
-  const base = window.location.origin;
-  return `${base}/activate?code=${encodeURIComponent(code)}`;
-}
-
 export default function GiftInviteButton() {
   const [state, setState] = useState<GiftInvitesState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -81,11 +76,10 @@ export default function GiftInviteButton() {
   };
 
   const handleCopy = async (code: string) => {
-    const url = buildActivationUrl(code);
     try {
-      await navigator.clipboard.writeText(url);
+      await navigator.clipboard.writeText(code);
       setCopiedCode(code);
-      addToast('Invite link copied', 'success');
+      addToast('Invite code copied', 'success');
       setTimeout(() => setCopiedCode((c) => (c === code ? null : c)), 1800);
     } catch {
       addToast('Copy failed', 'error');
@@ -232,7 +226,6 @@ function CodeRow({
   copied: boolean;
 }) {
   const consumed = !!code.used_at;
-  const url = buildActivationUrl(code.code);
   return (
     <li
       className={`rounded-xl border px-3 py-2.5 flex flex-col gap-2 ${
@@ -242,36 +235,37 @@ function CodeRow({
       }`}
     >
       <div className="flex items-center justify-between gap-2">
-        <code className="text-xs font-mono text-white/90 truncate">{code.code}</code>
-        {consumed ? (
-          <span className="text-[10px] uppercase tracking-wide text-emerald-300/80 font-semibold shrink-0">
-            Redeemed
-          </span>
-        ) : (
-          <span className="text-[10px] uppercase tracking-wide text-red-300/90 font-semibold shrink-0">
-            Active
-          </span>
+        <span className="text-[10px] uppercase tracking-wide font-semibold">
+          {consumed ? (
+            <span className="text-emerald-300/80">Redeemed</span>
+          ) : (
+            <span className="text-red-300/90">Active</span>
+          )}
+        </span>
+        {consumed && code.used_by && (
+          <span className="text-[10px] text-white/40 truncate">Joined by {code.used_by}</span>
         )}
       </div>
       {!consumed && (
         <div className="flex items-center gap-2">
           <input
             readOnly
-            value={url}
+            value={code.code}
             onFocus={(e) => e.currentTarget.select()}
-            className="flex-1 min-w-0 bg-black/40 border border-white/10 rounded-lg px-2.5 py-1.5 text-[11px] text-white/85 font-mono"
+            aria-label="Activation code"
+            className="flex-1 min-w-0 bg-black/40 border border-white/10 rounded-lg px-2.5 py-1.5 text-sm text-white font-mono tracking-[0.08em]"
           />
           <button
             type="button"
             onClick={() => onCopy(code.code)}
             className="shrink-0 rounded-lg bg-white/10 hover:bg-white/15 border border-white/10 text-white text-[11px] font-semibold py-1.5 px-3 transition-colors cursor-pointer"
           >
-            {copied ? 'Copied' : 'Copy link'}
+            {copied ? 'Copied' : 'Copy code'}
           </button>
         </div>
       )}
-      {consumed && code.used_by && (
-        <p className="text-[10px] text-white/40">Joined by {code.used_by}</p>
+      {consumed && (
+        <code className="text-xs font-mono text-white/40 tracking-[0.08em]">{code.code}</code>
       )}
     </li>
   );

--- a/frontend/src/pages/ActivatePage.tsx
+++ b/frontend/src/pages/ActivatePage.tsx
@@ -12,6 +12,22 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 const POLL_INTERVAL = 5000;
 
+// Gift codes ship in the shape XXXX-XXXX (see backend/app/auth/gift_invites.py).
+// Format as the user types: uppercase, auto-insert a hyphen after the 4th
+// character, cap the body at 8 characters. Codes that are already hyphenated
+// (admin-issued formats like `gdg-abc123`) pass through untouched apart from
+// uppercasing, so we don't mangle legacy codes.
+function formatInviteCode(raw: string): string {
+  const trimmed = raw.trim();
+  // If the input already contains a separator, let the user keep typing
+  // freely. Just uppercase it.
+  if (trimmed.includes('-')) return trimmed.toUpperCase();
+  // Gift-code pattern: only ASCII alphanumerics, 8-char body + one hyphen.
+  const alnum = trimmed.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8);
+  if (alnum.length <= 4) return alnum;
+  return `${alnum.slice(0, 4)}-${alnum.slice(4)}`;
+}
+
 export default function ActivatePage() {
   const navigate = useNavigate();
   const { user, fetchUser, logout } = useAuthStore();
@@ -137,13 +153,15 @@ export default function ActivatePage() {
           <input
             type="text"
             value={code}
-            onChange={(e) => { setCode(e.target.value); setError(null); }}
+            onChange={(e) => { setCode(formatInviteCode(e.target.value)); setError(null); }}
             onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
-            placeholder="Enter your invite code"
+            placeholder="XXXX-XXXX"
             autoFocus
             spellCheck={false}
             autoComplete="off"
-            className="bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-xl px-4 py-3 outline-none transition-colors placeholder:text-white/20 text-center font-mono tracking-wider"
+            autoCapitalize="characters"
+            inputMode="text"
+            className="bg-white/[0.04] border border-white/[0.08] focus:border-purple-500/40 text-white text-sm rounded-xl px-4 py-3 outline-none transition-colors placeholder:text-white/20 text-center font-mono tracking-wider uppercase"
           />
           <button
             onClick={handleSubmit}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -25,6 +25,7 @@ import { loadDraftNotes, loadDraftNotesAsync } from '../components/drafts/DraftN
 import ProcessingCounter from '../components/cv/ProcessingCounter';
 import KeywordFilterDropdown from '../components/cv/KeywordFilterDropdown';
 import UserMenu from '../components/UserMenu';
+import GiftInviteButton from '../components/GiftInviteButton';
 import { useToastStore } from '../stores/toastStore';
 import { useUndoStore } from '../stores/undoStore';
 import { getDocuments, confirmImport, getJob } from '../api/cv';
@@ -962,6 +963,9 @@ export default function OrbViewPage() {
           onHighlight={setHighlightedNodeIds}
         />
       )}
+
+      {/* Gift invitation button — bottom-left; per-user quota of 3 (#385) */}
+      {!isPendingDeletion && <GiftInviteButton />}
 
       {/* NodeTypeFilter moved to header bar */}
 


### PR DESCRIPTION
Closes #385.

## Summary
Every activated user now gets a lifetime quota of **3 invite codes** to share with friends. A red "Gift Invitation N/3" pill at the bottom-left of \`/myorbis\` opens a modal that generates codes and shares activation URLs.

## Backend
- **\`backend/app/auth/gift_invites.py\`** — new service (\`GIFT_INVITE_QUOTA = 3\`, \`token_urlsafe(6)\` codes prefixed \`gift-\`).
- **Cypher queries** (\`backend/app/graph/queries.py\`): \`CREATE_GIFT_INVITE\`, \`LIST_GIFT_INVITES\`, \`COUNT_GIFT_INVITES\` — re-use the existing \`:AccessCode\` node with \`source='gift'\` + \`created_by = <user_id>\`, so admin codes and user codes share the same \`/auth/activate\` consumption path (no new consumption logic required).
- **Endpoints** on the existing auth router:
  - \`GET  /auth/me/invites\` → \`{quota, total_issued, consumed, remaining, codes[]}\`
  - \`POST /auth/me/invites/generate\` (rate-limited \`10/min\`) → \`{code, created_at}\` or **409** when quota is reached.

## Frontend
- **API**: \`api/auth.ts\` gains \`getMyInvites\`, \`generateMyInvite\` + response types.
- **New \`components/GiftInviteButton.tsx\`**:
  - Red gradient pill with gift SVG + counter \`remaining/quota\` — \`fixed bottom-4 left-4 z-[45]\`.
  - Clicking opens a portaled modal (\`z-[200]\`) that lists issued codes as cards with Active / Redeemed states + a Copy-link action for unredeemed ones; the activation URL is \`<origin>/activate?code=<code>\`.
  - "Generate new code" button visible while \`total_issued < quota\`.
- Mounted in OrbViewPage next to \`OrbisStatsOverlay\`, hidden while the account is pending deletion.

## Counter behaviour
Matches the issue spec: starts at **3/3** and decrements to **2/3**, **1/3**, **0/3** as friends redeem codes — the counter tracks \`quota - consumed\`, not the number of unused codes.

## Test plan
- [x] \`uv run ruff check\` backend clean.
- [x] \`npx tsc --noEmit\` frontend clean.
- [x] \`npm run build\` clean.
- [ ] Manual: open \`/myorbis\` — red pill is at bottom-left with \`3/3\` counter.
- [ ] Manual: click, generate → pill remains \`3/3\` (issued 1, consumed 0), code shown.
- [ ] Manual: have a friend activate → pill becomes \`2/3\`, code card flips to "Redeemed".
- [ ] Manual: generate 3 then attempt a 4th — API returns 409, modal hides the "Generate" button.

## Documentation
Not touched (code + UI only — the invitation-system doc keeps working). If the Gift flow solidifies, a doc-sweep follow-up can add it to \`docs/invitation-system.md\`.