### PR TITLE
feat(cv): two-phase Gemini prompt + thinking budget + Person.email integrity (#388, #394)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,13 +40,18 @@ ENCRYPTION_KEYS_HISTORIC=
 # Claude API (for CV refinement)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
-# LLM Provider: "ollama" (local) or "claude" (Claude Code CLI, subscription-based)
-LLM_PROVIDER=claude
+# LLM Provider for the CV extraction pipeline.
+#   "vertex" — Vertex AI (Gemini / AnthropicVertex); production default.
+#   "cli"    — Claude Code CLI subprocess; uses your Claude subscription, no
+#              ADC required. Recommended for local dev.
+#   "ollama" — local Ollama model; zero external cost, lower quality.
+LLM_PROVIDER=cli
 CLAUDE_MODEL=claude-opus-4-6
 
 # LLM fallback chain — comma-separated providers tried in order.
-# Valid entries: claude-opus, claude-sonnet, ollama, rule-based
-LLM_FALLBACK_CHAIN=claude-opus,claude-sonnet,ollama,rule-based
+# Valid entries: claude-opus, claude-sonnet, gemini-pro, ollama, rule-based.
+# Local-dev default routes Claude via CLI first, then Ollama, then regex.
+LLM_FALLBACK_CHAIN=claude-opus,ollama,rule-based
 
 # Per-provider timeout in seconds before falling back (not required, default: 300)
 # LLM_TIMEOUT_SECONDS=300

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -79,6 +79,24 @@ async def _get_or_create_person(
             person = dict(record["p"])
             is_admin_user = bool(person.get("is_admin", False))
             has_code = person.get("signup_code") is not None
+
+            # Heal Person.email if an earlier CV-confirm flow overwrote it
+            # (#394). The OAuth claim is the only trusted source for the
+            # sign-up email — every login we see re-asserts it.
+            stored_email = person.get("email")
+            verified = encrypt_value(email)
+            try:
+                current_plain = decrypt_value(stored_email) if stored_email else None
+            except Exception:
+                current_plain = None
+            if current_plain != email:
+                await session.run(
+                    "MATCH (p:Person {user_id: $user_id}) "
+                    "SET p.email = $email, p.updated_at = datetime()",
+                    user_id=user_id,
+                    email=verified,
+                )
+
             return {
                 "activated": not invite_required or is_admin_user or has_code,
                 "gdpr_consent": bool(person.get("gdpr_consent", False)),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     llm_provider: str = "vertex"
     claude_model: str = "claude-opus-4-6"
     gemini_model: str = "gemini-2.5-pro"
+    # Gemini thinking budget in tokens. For gemini-2.5-pro the valid range is
+    # 128 → 32768; -1 = dynamic (model picks). Default to the ceiling so CV
+    # extraction gets the most reasoning headroom it can for complex CVs.
+    gemini_thinking_budget: int = 32768
 
     # Vertex AI configuration (used when llm_provider=vertex)
     gcp_project_id: str = ""

--- a/backend/app/cv/gemini_classifier.py
+++ b/backend/app/cv/gemini_classifier.py
@@ -28,7 +28,7 @@ async def call_gemini(
         output_tokens (int | None): Output token count if available.
     """
     from google import genai
-    from google.genai.types import GenerateContentConfig
+    from google.genai.types import GenerateContentConfig, ThinkingConfig
 
     from app.config import settings
 
@@ -43,15 +43,21 @@ async def call_gemini(
         location=settings.vertex_region,
     )
 
+    # Thinking budget — explicit so we can observe/tune it. Default in
+    # settings is 32 768 (the Pro ceiling). `-1` = dynamic (model chooses).
+    # `0` = thinking disabled (only valid on Flash / Flash-Lite; Pro ignores).
+    thinking_budget = settings.gemini_thinking_budget
     config = GenerateContentConfig(
         system_instruction=system_prompt,
         max_output_tokens=65536,
+        thinking_config=ThinkingConfig(thinking_budget=thinking_budget),
     )
 
     logger.info(
-        "Calling Gemini via Vertex AI: model=%s, region=%s",
+        "Calling Gemini via Vertex AI: model=%s, region=%s, thinking_budget=%s",
         model,
         settings.vertex_region,
+        thinking_budget,
     )
 
     response = await asyncio.to_thread(
@@ -66,9 +72,20 @@ async def call_gemini(
 
     input_tokens = None
     output_tokens = None
+    thinking_tokens = None
     if response.usage_metadata:
         input_tokens = response.usage_metadata.prompt_token_count
         output_tokens = response.usage_metadata.candidates_token_count
+        # `thoughts_token_count` on google-genai ≥ 1.22; guard for older SDKs.
+        thinking_tokens = getattr(response.usage_metadata, "thoughts_token_count", None)
+
+    if thinking_tokens is not None:
+        logger.info(
+            "Gemini usage: prompt=%s, output=%s, thinking=%s",
+            input_tokens,
+            output_tokens,
+            thinking_tokens,
+        )
 
     return {
         "content": content,
@@ -76,4 +93,5 @@ async def call_gemini(
         "duration_ms": None,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
+        "thinking_tokens": thinking_tokens,
     }

--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -26,6 +26,49 @@ logger = logging.getLogger(__name__)
 SYSTEM_PROMPT = """You are a CV/resume parsing assistant. Given raw text extracted from a CV document,
 extract the person's profile information AND classify every entry into structured nodes.
 
+## How to reason
+
+Work in **two explicit phases** — do not mix them. Use your full reasoning / thinking
+budget for each phase. The phases happen entirely *within your internal reasoning*;
+the only thing you emit is the final JSON at the end.
+
+### Phase 1 — per-entry classification (narrow context)
+
+Read the CV top to bottom and break it into **individual entries** (one job, one
+degree, one publication, one project, one course, ...). For each entry **in
+isolation**:
+
+1. Focus *only* on that entry's text — ignore what came before or after.
+2. Decide its `node_type` using the rules below.
+3. Extract the expected properties from just that entry's text.
+4. Do **not** attempt to derive relationships in this phase. Do not reference
+   other entries. Keep the mental context small.
+
+Collect the resulting nodes in order. Also detect and extract the person's
+profile fields as you encounter them (they usually sit at the top of the CV
+and don't need cross-entry reasoning).
+
+If an entry clearly cannot be classified into any of the node types below,
+append its raw text to `unmatched` and move on.
+
+### Phase 2 — cross-entry relationship discovery (wide context)
+
+Now that every entry has been classified, read the **entire list of nodes**
+you produced and look across them to find meaningful connections:
+
+- **USED_SKILL** edges — for every work_experience / project / education /
+  publication / patent / award / outreach / training, identify which `skill`
+  nodes were used or referenced (explicitly or implicitly). See the
+  *Relationships* section below for the detection heuristics.
+- If a skill is implied by an entry but no matching skill node was produced
+  in Phase 1, **add the missing skill node** and then create the USED_SKILL
+  edge to it. Do not skip relationships for missing nodes.
+- Be insightful: a paper on "Quantum Gate Synthesis" → link to "Quantum
+  Computing". A role titled "iOS Developer" → link to "Swift" / "iOS". An
+  outreach talk at PyCon → link to "Python".
+
+Only after Phase 2 is complete do you emit the final JSON.
+
 ## Person Profile
 
 Extract the following about the CV owner (all optional, include only if found):

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -471,15 +471,29 @@ async def _persist_nodes_inner(  # noqa: C901
 
 
 def _build_person_updates(data: ConfirmRequest) -> dict:
-    """Build Person node property updates from CV extraction results."""
+    """Build Person node property updates from CV extraction results.
+
+    Never overwrites the OAuth-verified sign-up email (`Person.email`). The
+    LLM can hallucinate contact info, CVs can contain someone else's email,
+    and the admin dashboard + transactional notifications must always use
+    the verified address (#394). CV-parsed email is captured separately as
+    `cv_email` if it differs, so it's visible but never treated as identity.
+    """
     updates: dict[str, str] = {}
     if data.cv_owner_name:
         updates["cv_display_name"] = data.cv_owner_name
     if data.profile:
         profile_dict = data.profile.model_dump(exclude_none=True)
-        for pii_field in ("email", "phone"):
-            if pii_field in profile_dict:
-                profile_dict[pii_field] = encrypt_value(profile_dict[pii_field])
+
+        # Move the CV-parsed email out of `email` (identity field) and into
+        # `cv_email` (reference-only field). Do NOT overwrite `p.email`.
+        cv_email = profile_dict.pop("email", None)
+        if cv_email:
+            updates["cv_email"] = encrypt_value(cv_email)
+
+        if "phone" in profile_dict:
+            profile_dict["phone"] = encrypt_value(profile_dict["phone"])
+
         updates.update(profile_dict)
     return updates
 

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -215,3 +215,58 @@ def test_confirm_cv_invalid_node_type(client, mock_db):
     response = client.post("/cv/confirm", json=payload)
     assert response.status_code == 200
     assert response.json()["created"] == 0
+
+
+# ── #394: CV-parsed profile must not overwrite the OAuth-verified email ──
+
+
+def test_build_person_updates_routes_cv_email_to_cv_email_field():
+    """CV-parsed email goes to `cv_email` (encrypted) — never to `email`."""
+    from app.cv.models import ConfirmRequest, ExtractedProfile
+    from app.cv.router import _build_person_updates
+    from app.graph.encryption import decrypt_value
+
+    data = ConfirmRequest(
+        cv_owner_name="CV Owner",
+        nodes=[],
+        relationships=[],
+        profile=ExtractedProfile(
+            email="someone-from-cv@example.com",
+            phone="+10000000000",
+            headline="Staff Engineer",
+            linkedin_url="https://linkedin.com/in/cvowner",
+        ),
+    )
+
+    updates = _build_person_updates(data)
+
+    # Identity field untouched — admin dashboard, notifications, etc. stay on OAuth email.
+    assert "email" not in updates, "CV-confirm must NEVER set Person.email"
+
+    # CV-parsed email is still captured, but as an encrypted reference-only field.
+    assert "cv_email" in updates
+    assert decrypt_value(updates["cv_email"]) == "someone-from-cv@example.com"
+
+    # Non-identity profile fields continue to flow through.
+    assert updates["headline"] == "Staff Engineer"
+    assert updates["linkedin_url"] == "https://linkedin.com/in/cvowner"
+    assert decrypt_value(updates["phone"]) == "+10000000000"
+
+
+def test_build_person_updates_with_profile_missing_email():
+    """If the LLM didn't extract any email, no cv_email field is added."""
+    from app.cv.models import ConfirmRequest, ExtractedProfile
+    from app.cv.router import _build_person_updates
+
+    data = ConfirmRequest(
+        cv_owner_name="CV Owner",
+        nodes=[],
+        relationships=[],
+        profile=ExtractedProfile(headline="Senior Researcher"),
+    )
+
+    updates = _build_person_updates(data)
+
+    assert "email" not in updates
+    assert "cv_email" not in updates
+    assert updates["headline"] == "Senior Researcher"

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,6 +132,8 @@ The client should poll `GET /cv/job/{job_id}` until `status` is `succeeded` or `
 
 When `document_id` is provided, the confirm endpoint records document metadata (including `entities_count` and `edges_count` computed from the nodes/relationships). If the user already has 3 documents, the oldest is automatically evicted.
 
+**Person-email invariant (#394):** the confirm payload's extracted `profile.email` is stored on `Person.cv_email` (Fernet-encrypted, reference-only), **never** on `Person.email`. `Person.email` is the OAuth sign-up address and is only set at account creation or on subsequent logins (self-healing in `_get_or_create_person`). Admin UI and every transactional notification (CV-ready / CV-failed / access-grant / activation) always read `Person.email`. The same invariant applies to `/cv/import-confirm`.
+
 ### Document Metadata Response (`GET /cv/documents`)
 
 ```json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,14 @@ JWT validation on protected endpoints via `HTTPBearer` scheme. Refresh tokens su
 
 ### Encryption
 
-Fernet symmetric encryption for PII fields (`email`, `phone`, `address`). Key from `ENCRYPTION_KEY` env var; auto-generated in dev mode if missing (data won't survive restarts).
+Fernet symmetric encryption for PII fields (`email`, `cv_email`, `phone`, `address`). Key from `ENCRYPTION_KEY` env var; auto-generated in dev mode if missing (data won't survive restarts).
+
+**Two separate email fields on `:Person` (#394):**
+
+- `email` — OAuth-verified sign-up address. Set at Person creation and self-healed on every subsequent login. Canonical address for admin UI, transactional notifications (CV ready / failed / access grant / activation), and identity.
+- `cv_email` — Email the LLM parsed from the CV text, if any. Reference-only. Never used as identity or for notifications. CV confirm (`POST /cv/confirm` + `POST /cv/import-confirm`) writes here, not to `email`.
+
+The separation exists because the LLM can hallucinate contact info, CVs can contain stale addresses, and uploaded CVs can even belong to third parties.
 
 ## Frontend Architecture
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -10,7 +10,8 @@ Orbis uses Neo4j 5 (Community Edition) as its graph database. All queries are in
 |----------|------|-------|
 | `user_id` | string | Unique identifier |
 | `orb_id` | string | User-chosen public slug |
-| `email` | string | Fernet-encrypted |
+| `email` | string | Fernet-encrypted. **OAuth-verified sign-up email** — set at Person creation from the Google / LinkedIn claim and kept in sync on every subsequent login (`auth/router.py::_get_or_create_person` heals it if it drifts). Never mutated by CV confirm. Canonical address for admin UI + transactional notifications. |
+| `cv_email` | string or null | Fernet-encrypted. Email the LLM parsed from the CV text, if it found one. Reference-only — never used as identity or for notifications (CVs can contain stale or third-party addresses). Written by `POST /cv/confirm` via `_build_person_updates` (#394). |
 | `name` | string | |
 | `headline` | string | |
 | `location` | string | |


### PR DESCRIPTION
Closes #388 (evaluation path — see below), closes #394.

## Summary

Bundles three reinforcing CV-pipeline improvements plus an env-config tidy:

- **Gemini thinking budget wired + capped at the Pro ceiling (#388).** `GenerateContentConfig` now carries `ThinkingConfig(thinking_budget=settings.gemini_thinking_budget)` — default `32768`, override via env. `thoughts_token_count` (new in `google-genai ≥ 1.22`) is captured as `thinking_tokens` so we can observe cost + tune later. Logged alongside model / region for debuggability.
- **Two-phase CV extraction prompt (#388).** The system prompt now instructs the model to reason in two explicit phases inside a single call:
  - Phase 1 — classify each entry in isolation (narrow context, no relationship reasoning).
  - Phase 2 — once every entry has a node, cross-read the list to derive `USED_SKILL` edges and add any implied-but-missing skill nodes.
  With the 32K thinking budget this fits comfortably in one call — no pipeline refactor, no parser / persistence change.
- **Person.email integrity (#394).** CV confirm used to let the LLM-parsed `profile.email` overwrite the OAuth sign-up email on `:Person.email`. That's now separated:
  - `Person.email` — OAuth-verified sign-up address. Never mutated by CV confirm. Self-healed on every subsequent login if drift is detected.
  - `Person.cv_email` — new encrypted, reference-only field. Holds whatever email the LLM parsed from the CV, so admins can still see it labelled as such.
  The existing CV-ready / CV-failed transactional emails (`jobs_router._send_success_email` / `_send_failure_email`) already read `p.email` — they now automatically go to the correct sign-up address.
- **Local-dev config (nit).** `.env.example` updated so Claude CLI is the recommended local primary out of the box, with clear comments on the three provider modes (`vertex` / `cli` / `ollama`). Production is primary-only (`FALLBACK_CHAIN=gemini-pro`) and unchanged.

## Files touched

| File | Change |
|---|---|
| `backend/app/config.py` | New `gemini_thinking_budget: int = 32768` setting (range 128 → 32768, `-1` for dynamic). |
| `backend/app/cv/gemini_classifier.py` | Pass `ThinkingConfig` on every call. Capture `thoughts_token_count`. Log the budget. |
| `backend/app/cv/ollama_classifier.py` | System prompt now opens with explicit "Phase 1 / Phase 2" reasoning instructions. All existing sections (Person Profile, Node Types, Rules, Relationships, Output Format) preserved verbatim. |
| `backend/app/cv/router.py` | `_build_person_updates` routes CV-parsed email to `cv_email` (encrypted) and strips it from the `Person.email` update path. |
| `backend/app/auth/router.py` | `_get_or_create_person` heals `Person.email` to the OAuth claim on every login. |
| `backend/tests/unit/test_cv_router.py` | Two new unit tests for `_build_person_updates`. |
| `docs/database.md` | Split `Person.email` (OAuth) vs `Person.cv_email` (LLM-parsed reference). |
| `docs/api.md` | Invariant on `/cv/confirm` + `/cv/import-confirm`. |
| `docs/architecture.md` | Two-email-fields block under *Encryption*. |
| `.env.example` | Local-dev Claude-CLI primary; primary-only fallback chain. |

## Test plan

- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run pytest tests/unit/test_cv_router.py -k build_person_updates -v` → 2 passed.
- [x] Smoke: uploaded a CV locally, verified extraction ran via Claude Opus CLI (`cv_jobs.llm_provider=claude`, `llm_model=claude-opus-4-6`).
- [ ] Manual in staging: CV-ready email lands on the sign-up inbox, not the CV-parsed address.
- [ ] Manual: admin /cv-jobs + /users tabs show the OAuth email.
- [ ] CI: `kg-quality` remains red because CI has no GCP ADC — pre-existing, not caused by this PR.

## Documentation

Listed above. No navigation-flow changes — no UI surface added.

## Related issues

- #388 — Gemini thinking evaluation. This PR lands the **budget + two-phase prompt** pieces. The full evaluation harness (run all fixtures, compare F1 / recall / composite with thinking on vs off) is still open and can be scoped as a follow-up.
- #394 — Email integrity. Fully closed.