### PR TITLE
fix(cv): stop overwriting Person.email with CV-parsed address (#394)

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -41,7 +41,7 @@ from app.config import settings
 from app.dependencies import get_current_user, get_db
 from app.email.service import send_activation_email
 from app.graph.encryption import decrypt_value, encrypt_value
-from app.graph.queries import CREATE_PERSON, GET_PERSON_BY_USER_ID
+from app.graph.queries import CREATE_PERSON, GET_PERSON_BY_USER_ID, UPDATE_PERSON
 from app.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,25 @@ async def _get_or_create_person(
             person = dict(record["p"])
             is_admin_user = bool(person.get("is_admin", False))
             has_code = person.get("signup_code") is not None
+
+            # Self-heal :Person.email if it drifted from the OAuth claim.
+            # Historically a confirmed CV could overwrite it (see #394).
+            # OAuth is the identity of record, so on every login we snap
+            # the encrypted email back to what the provider gave us.
+            stored_email_ct = person.get("email") or ""
+            try:
+                stored_email_pt = (
+                    decrypt_value(stored_email_ct) if stored_email_ct else ""
+                )
+            except Exception:
+                stored_email_pt = ""
+            if stored_email_pt != email:
+                await session.run(
+                    UPDATE_PERSON,
+                    user_id=user_id,
+                    properties={"email": encrypt_value(email)},
+                )
+
             return {
                 "activated": not invite_required or is_admin_user or has_code,
                 "gdpr_consent": bool(person.get("gdpr_consent", False)),

--- a/backend/app/cv/router.py
+++ b/backend/app/cv/router.py
@@ -470,6 +470,28 @@ async def _persist_nodes_inner(  # noqa: C901
                     logger.warning("Failed to link %s -> %s: %s", from_uid, to_uid, e)
 
 
+# Profile fields the CV pipeline is allowed to write onto :Person.
+#
+# email is deliberately excluded: :Person.email is the OAuth sign-up address,
+# is the single contact channel for every transactional email (activation,
+# CV-ready, access grants, …), and must never be rewritten by an LLM reading
+# an arbitrary PDF. A user whose CV contains a stale or third-party address
+# would otherwise have all notifications silently rerouted. See #394.
+_CV_PROFILE_WRITABLE_FIELDS = (
+    "headline",
+    "location",
+    "phone",
+    "linkedin_url",
+    "github_url",
+    "twitter_url",
+    "instagram_url",
+    "scholar_url",
+    "website_url",
+    "open_to_work",
+)
+_CV_PROFILE_ENCRYPTED_FIELDS = ("phone",)
+
+
 def _build_person_updates(data: ConfirmRequest) -> dict:
     """Build Person node property updates from CV extraction results."""
     updates: dict[str, str] = {}
@@ -477,10 +499,13 @@ def _build_person_updates(data: ConfirmRequest) -> dict:
         updates["cv_display_name"] = data.cv_owner_name
     if data.profile:
         profile_dict = data.profile.model_dump(exclude_none=True)
-        for pii_field in ("email", "phone"):
-            if pii_field in profile_dict:
-                profile_dict[pii_field] = encrypt_value(profile_dict[pii_field])
-        updates.update(profile_dict)
+        for field in _CV_PROFILE_WRITABLE_FIELDS:
+            if field not in profile_dict:
+                continue
+            value = profile_dict[field]
+            if field in _CV_PROFILE_ENCRYPTED_FIELDS:
+                value = encrypt_value(value)
+            updates[field] = value
     return updates
 
 

--- a/backend/tests/unit/test_auth_router.py
+++ b/backend/tests/unit/test_auth_router.py
@@ -1,4 +1,6 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def test_get_me_success(client, mock_db):
@@ -22,3 +24,96 @@ def test_get_me_not_found(client, mock_db):
 
     response = client.get("/auth/me")
     assert response.status_code == 404
+
+
+def _build_person_lookup_db(stored_email_ciphertext: str):
+    """Build a mock driver whose first session.run → GET_PERSON_BY_USER_ID
+    returns a person row with the given encrypted email, and whose
+    subsequent runs return an empty result. Returns (db, session_mock)."""
+    db = MagicMock()
+    session_mock = AsyncMock()
+    db.session.return_value.__aenter__.return_value = session_mock
+
+    person_record = {
+        "p": {
+            "user_id": "google-123",
+            "email": stored_email_ciphertext,
+            "is_admin": False,
+            "signup_code": "open-registration",
+            "gdpr_consent": True,
+            "profile_image": "",
+        }
+    }
+    person_result = MagicMock()
+    person_result.single = AsyncMock(return_value=person_record)
+
+    empty_result = MagicMock()
+    empty_result.single = AsyncMock(return_value=None)
+
+    session_mock.run = AsyncMock(
+        side_effect=[person_result, empty_result, empty_result]
+    )
+    return db, session_mock
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_person_heals_drifted_email():
+    """Regression guard for #394: if :Person.email drifted away from the
+    OAuth email (e.g. an older session confirmed a CV that overwrote it
+    before the fix), the next OAuth login must rewrite it back to the
+    authoritative value from the provider."""
+    from app.auth.router import _get_or_create_person
+    from app.graph.encryption import decrypt_value, encrypt_value
+
+    stale = encrypt_value("cv-parsed@example.com")
+    db, session_mock = _build_person_lookup_db(stale)
+
+    with patch(
+        "app.auth.router.is_invite_code_required", AsyncMock(return_value=False)
+    ):
+        await _get_or_create_person(
+            db,
+            user_id="google-123",
+            email="oauth@example.com",
+            name="Test",
+            picture="",
+            provider="google",
+        )
+
+    # Two session.run calls: the initial GET_PERSON_BY_USER_ID and a
+    # follow-up UPDATE_PERSON that writes the fresh encrypted email.
+    assert session_mock.run.await_count >= 2
+    second_call = session_mock.run.await_args_list[1]
+    args, kwargs = second_call
+    # UPDATE_PERSON template + user_id / properties kwargs
+    assert "p += $properties" in args[0]
+    assert kwargs["user_id"] == "google-123"
+    props = kwargs["properties"]
+    assert "email" in props
+    assert decrypt_value(props["email"]) == "oauth@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_person_skips_update_when_email_matches():
+    """No spurious write when the stored email already matches the OAuth
+    email — avoids churning updated_at on every login."""
+    from app.auth.router import _get_or_create_person
+    from app.graph.encryption import encrypt_value
+
+    stored = encrypt_value("oauth@example.com")
+    db, session_mock = _build_person_lookup_db(stored)
+
+    with patch(
+        "app.auth.router.is_invite_code_required", AsyncMock(return_value=False)
+    ):
+        await _get_or_create_person(
+            db,
+            user_id="google-123",
+            email="oauth@example.com",
+            name="Test",
+            picture="",
+            provider="google",
+        )
+
+    # Only the initial lookup — no UPDATE_PERSON follow-up.
+    assert session_mock.run.await_count == 1

--- a/backend/tests/unit/test_cv_router.py
+++ b/backend/tests/unit/test_cv_router.py
@@ -215,3 +215,49 @@ def test_confirm_cv_invalid_node_type(client, mock_db):
     response = client.post("/cv/confirm", json=payload)
     assert response.status_code == 200
     assert response.json()["created"] == 0
+
+
+def test_build_person_updates_drops_cv_parsed_email():
+    """Regression guard for #394: email extracted from a CV must never
+    overwrite :Person.email (which is the OAuth sign-up address and the
+    only trusted contact channel). The CV-parsed email is unverified and
+    may belong to a third party on a shared/outdated CV."""
+    from app.cv.models import ConfirmRequest, ExtractedProfile
+    from app.cv.router import _build_person_updates
+
+    data = ConfirmRequest(
+        nodes=[],
+        profile=ExtractedProfile(
+            email="cv-parsed@example.com",
+            phone="+1-555-0100",
+            headline="Staff Engineer",
+            linkedin_url="https://linkedin.com/in/x",
+        ),
+    )
+
+    updates = _build_person_updates(data)
+
+    assert "email" not in updates, (
+        "CV-parsed email leaked into Person.email update — this would "
+        "overwrite the OAuth sign-up address and reroute all transactional "
+        "email to the CV-parsed address."
+    )
+    # Non-identity fields should still flow through so the profile stays useful.
+    assert updates.get("headline") == "Staff Engineer"
+    assert updates.get("linkedin_url") == "https://linkedin.com/in/x"
+
+
+def test_build_person_updates_whitelist_rejects_unknown_fields():
+    """Only known safe profile fields are merged. An unexpected key (even
+    if Pydantic ever allowed one through) must not reach the Cypher writer."""
+    from app.cv.models import ConfirmRequest, ExtractedProfile
+    from app.cv.router import _build_person_updates
+
+    data = ConfirmRequest(
+        nodes=[],
+        profile=ExtractedProfile(headline="x", location="Berlin"),
+    )
+    updates = _build_person_updates(data)
+    # email/phone/role injection guard: caller cannot add arbitrary props
+    for forbidden in ("email", "is_admin", "signup_code", "orb_id", "user_id"):
+        assert forbidden not in updates

--- a/backend/tests/unit/test_jobs_router.py
+++ b/backend/tests/unit/test_jobs_router.py
@@ -188,3 +188,84 @@ def test_process_job_skips_non_queued(mock_get_job):
 
     assert response.status_code == 200
     assert response.json()["status"] == "skipped"
+
+
+# ── CV completion emails (#394 acceptance coverage) ──
+
+
+def _make_db_returning_encrypted_email(ciphertext: str | None):
+    """Build a mock AsyncDriver whose session.run().single() yields a
+    Person row with the given (encrypted) email column."""
+    from unittest.mock import MagicMock
+
+    db = MagicMock()
+    session_mock = AsyncMock()
+    db.session.return_value.__aenter__.return_value = session_mock
+    result_mock = MagicMock()
+    if ciphertext is None:
+        result_mock.single = AsyncMock(return_value=None)
+    else:
+        result_mock.single = AsyncMock(return_value={"email": ciphertext})
+    session_mock.run = AsyncMock(return_value=result_mock)
+    return db
+
+
+async def test_send_success_email_uses_decrypted_person_email():
+    """On job success the email must go to the sign-up address stored on
+    :Person.email (decrypted). This is the acceptance criterion from #394:
+    'receives a CV ready email at the sign-up address'."""
+    from app.cv.jobs_router import _send_success_email
+    from app.graph.encryption import encrypt_value
+
+    db = _make_db_returning_encrypted_email(encrypt_value("oauth@example.com"))
+    with patch(
+        "app.email.service.send_cv_ready_email", new_callable=AsyncMock
+    ) as mock_send:
+        await _send_success_email(
+            user_id="google-123",
+            db=db,
+            job_id="job-abc",
+            node_count=7,
+            edge_count=3,
+        )
+
+    mock_send.assert_awaited_once()
+    kwargs = mock_send.await_args.kwargs
+    assert kwargs["to"] == "oauth@example.com"
+    assert kwargs["job_id"] == "job-abc"
+    assert kwargs["node_count"] == 7
+    assert kwargs["edge_count"] == 3
+
+
+async def test_send_success_email_skips_when_no_email():
+    """If the Person row has no email, nothing is sent (no crash)."""
+    from app.cv.jobs_router import _send_success_email
+
+    db = _make_db_returning_encrypted_email(None)
+    with patch(
+        "app.email.service.send_cv_ready_email", new_callable=AsyncMock
+    ) as mock_send:
+        await _send_success_email(
+            user_id="google-123",
+            db=db,
+            job_id="job-abc",
+            node_count=0,
+            edge_count=0,
+        )
+    mock_send.assert_not_awaited()
+
+
+async def test_send_failure_email_uses_decrypted_person_email():
+    """On job failure the user still gets a notification (they're otherwise
+    stuck on a polling spinner)."""
+    from app.cv.jobs_router import _send_failure_email
+    from app.graph.encryption import encrypt_value
+
+    db = _make_db_returning_encrypted_email(encrypt_value("oauth@example.com"))
+    with patch(
+        "app.email.service.send_cv_failed_email", new_callable=AsyncMock
+    ) as mock_send:
+        await _send_failure_email(user_id="google-123", db=db)
+
+    mock_send.assert_awaited_once()
+    assert mock_send.await_args.kwargs["to"] == "oauth@example.com"

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,7 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | Method | Path | Auth | Rate Limit | Description |
 |--------|------|------|------------|-------------|
 | GET | `/orbs/me` | JWT | — | Full orb: person + nodes + links |
-| PUT | `/orbs/me` | JWT | — | Update Person profile fields |
+| PUT | `/orbs/me` | JWT | — | Update Person profile fields. `email` is **not** in the accepted schema — it is the OAuth sign-up address and can only be changed by re-authenticating with a different provider account (#394). |
 | PUT | `/orbs/me/orb-id` | JWT | — | Claim/update public orb_id (409 if taken) |
 | POST | `/orbs/me/profile-image` | JWT | — | Upload profile image as base64 (max 2MB) |
 | DELETE | `/orbs/me/profile-image` | JWT | — | Clear profile image |
@@ -94,7 +94,7 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/cv/upload` | JWT | Upload PDF (max 10MB). Requires GDPR consent. Stores document, dispatches Cloud Task, returns `{job_id, status: "queued"}` immediately. |
-| POST | `/cv/confirm` | JWT | Persist confirmed nodes to Neo4j. Wipes existing graph first. Accepts `document_id` to track metadata. |
+| POST | `/cv/confirm` | JWT | Persist confirmed nodes to Neo4j. Wipes existing graph first. Accepts `document_id` to track metadata. The `profile.email` field in the payload is **dropped server-side** (allowlist in `_CV_PROFILE_WRITABLE_FIELDS`) so the CV-parsed address never overwrites `:Person.email` — see #394. |
 | POST | `/cv/import` | JWT | Import supplementary document (PDF, DOCX, TXT). Stores document, dispatches Cloud Task, returns `{job_id, status: "queued"}` immediately. |
 | POST | `/cv/import-confirm` | JWT | Merge imported nodes into existing orb (no wipe). Accepts `document_id` to track metadata. |
 | GET | `/cv/documents` | JWT | List document metadata for current user (up to 3, ordered by date desc). |
@@ -115,6 +115,8 @@ All endpoints require `is_admin = true` on the authenticated Person.
 ```
 
 The client should poll `GET /cv/job/{job_id}` until `status` is `succeeded` or `failed`. On success the response includes a `result` field with the extracted nodes.
+
+On the `succeeded` / `failed` transition the worker also dispatches a best-effort transactional email (`send_cv_ready_email` / `send_cv_failed_email`) to the address stored on `:Person.email` — i.e. the OAuth sign-up address (#394). Email delivery is decoupled from job status; a Resend failure is logged but does not re-queue the job.
 
 ### Confirm Request Body
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,10 @@ Stage 6: User Review + Confirm
 
 Text input is capped at 12,000 characters. The LLM provider is controlled by `LLM_PROVIDER` and `LLM_FALLBACK_CHAIN` config settings.
 
+**CV profile fields vs. identity fields.** The LLM-extracted profile block (email, phone, headline, social URLs, …) is merged onto `:Person` by `POST /cv/confirm` through a strict allowlist in `backend/app/cv/router.py::_CV_PROFILE_WRITABLE_FIELDS`. `email` is deliberately **not** on that list — `:Person.email` is the OAuth sign-up address and the sole destination for every transactional email (activation, CV-ready/failed, access grants). Letting an LLM reading an arbitrary PDF rewrite it would silently reroute all notifications and, when the CV belongs to a third party, also exposes that third party's address to admins (#394).
+
+**CV completion notifications.** When the background job transitions to `succeeded` or `failed`, `app.cv.jobs_router._send_success_email` / `_send_failure_email` read `:Person.email`, decrypt it, and dispatch `send_cv_ready_email` / `send_cv_failed_email` (templates in `backend/app/email/templates.py`). Delivery is best-effort: a send failure is logged but does not flip the job status.
+
 ### Authentication Flow
 
 ```
@@ -110,8 +114,11 @@ POST /auth/google or /auth/linkedin
     ├─ Exchange OAuth code for user info
     ├─ Lookup user by provider ID in Neo4j
     ├─ If not found: CREATE Person node
+    ├─ If found and p.email ≠ provider email: heal p.email to the provider value (#394)
     └─ Return JWT (HS256, short-lived) + set HttpOnly refresh token cookie
 ```
+
+The heal step exists because older sessions could allow `POST /cv/confirm` to overwrite `:Person.email` with the CV-parsed address. OAuth is the identity of record, so every login snaps the stored email back to whatever the provider claims.
 
 JWT validation on protected endpoints via `HTTPBearer` scheme. Refresh tokens support token rotation — each refresh revokes the old token and issues a new pair. In production, the refresh token cookie uses `SameSite=None; Secure` and is scoped to `path=/`.
 


### PR DESCRIPTION
Closes #394.

## Summary
- **Bug 1** — `POST /cv/confirm` no longer merges `profile.email` onto `:Person.email`. `backend/app/cv/router.py::_build_person_updates` now uses an explicit `_CV_PROFILE_WRITABLE_FIELDS` allowlist (`headline`, `location`, `phone`, `linkedin_url`, `github_url`, `twitter_url`, `instagram_url`, `scholar_url`, `website_url`, `open_to_work`).
- **Migration** — `backend/app/auth/router.py::_get_or_create_person` heals drifted emails on every OAuth login: if the stored `:Person.email` doesn't match the provider claim, it is rewritten to the OAuth value. This backfills users whose email was corrupted before the fix, per the issue's suggested approach.
- **Bug 2** — Admin Users tab already reads `:Person.email` (decrypted) via `admin.service.list_users`. Once Bug 1 is fixed and the heal step runs, the column shows the OAuth sign-up address automatically. No frontend change needed; `cv_email` is intentionally not stored (closes the third-party PII exposure called out in the issue's security note).
- **Completion email** — the `send_cv_ready_email` / `send_cv_failed_email` path was already wired in `jobs_router._send_success_email` / `_send_failure_email`. Added regression tests asserting both helpers read `:Person.email`, decrypt it, and deliver to the OAuth address — satisfies the acceptance criterion.

## Test plan
- [x] New unit tests pass:
  - `test_build_person_updates_drops_cv_parsed_email`
  - `test_build_person_updates_whitelist_rejects_unknown_fields`
  - `test_get_or_create_person_heals_drifted_email`
  - `test_get_or_create_person_skips_update_when_email_matches`
  - `test_send_success_email_uses_decrypted_person_email`
  - `test_send_success_email_skips_when_no_email`
  - `test_send_failure_email_uses_decrypted_person_email`
- [x] `uv run ruff check .` + `uv run ruff format --check .` — all clean.
- [x] Affected test files pass together: `test_cv_router.py`, `test_auth_router.py`, `test_jobs_router.py`, `test_orbs_router.py`, `test_admin_users.py`, `test_email_service.py`, `test_invitation_system.py` → 125 passed.
- [ ] Manual smoke: upload a CV whose text contains an `Email: cv-parsed@foo.com` line, confirm, then check `MATCH (p:Person {user_id: …}) RETURN p.email` decrypts back to the OAuth address.
- [ ] Manual smoke: log out, change the Person.email manually in Neo4j to a different value, log back in via Google/LinkedIn — the value should be healed back on the next session.

## Documentation
- `docs/api.md` — noted that `PUT /orbs/me` does not accept `email` and that `POST /cv/confirm` drops `profile.email`; documented the CV completion email flow on the job status section.
- `docs/architecture.md` — added the CV profile allowlist explanation, the OAuth email heal step, and the completion-email helper references.

## Notes
- Pre-existing suite-level flakiness (~8 failures / ~56 errors when running the entire unit suite together) was present before this change on `main` and is unaffected by this PR.
- `frontend/src/api/orbs.ts` has a local `TEMP MOCK` dev change that predates this branch — intentionally left out of this commit.