### PR TITLE
fix(gift-invite): collapse to icon on mobile, inside search bar

### DIFF
--- a/frontend/src/components/GiftInviteButton.tsx
+++ b/frontend/src/components/GiftInviteButton.tsx
@@ -1,12 +1,20 @@
 // Gift invitation surface on /myorbis (#385).
 //
 // Each activated user gets a lifetime quota of 3 invite codes to share with
-// friends. The button sits at the bottom-left of the OrbView and shows the
-// remaining count ("3/3", "2/3", "1/3", "0/3" — decrementing as friends
-// redeem codes). Clicking opens a modal that lets the user generate a new
-// code (up to the quota) and copy an activation URL to share.
+// friends. On desktop the trigger is a bottom-left pill showing the remaining
+// count ("3/3", "2/3", ...). On mobile — where that pill would overlap the
+// ChatBox search bar — the trigger collapses to a compact circular icon
+// rendered inside the chat bar, level with the other action circles.
 
-import { useCallback, useEffect, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -28,7 +36,20 @@ function GiftIcon({ className = 'w-4 h-4' }: { className?: string }) {
   );
 }
 
-export default function GiftInviteButton() {
+interface GiftInviteController {
+  state: GiftInvitesState | null;
+  loading: boolean;
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  generating: boolean;
+  copiedCode: string | null;
+  handleGenerate: () => Promise<void>;
+  handleCopy: (code: string) => Promise<void>;
+}
+
+const GiftInviteContext = createContext<GiftInviteController | null>(null);
+
+function useGiftInviteController(): GiftInviteController {
   const [state, setState] = useState<GiftInvitesState | null>(null);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
@@ -61,7 +82,7 @@ export default function GiftInviteButton() {
     return () => document.removeEventListener('keydown', handleKey);
   }, [open, refresh]);
 
-  const handleGenerate = async () => {
+  const handleGenerate = useCallback(async () => {
     if (!state) return;
     if (state.total_issued >= state.quota) return;
     setGenerating(true);
@@ -73,9 +94,9 @@ export default function GiftInviteButton() {
     } finally {
       setGenerating(false);
     }
-  };
+  }, [state, refresh, addToast]);
 
-  const handleCopy = async (code: string) => {
+  const handleCopy = useCallback(async (code: string) => {
     try {
       await navigator.clipboard.writeText(code);
       setCopiedCode(code);
@@ -84,135 +105,174 @@ export default function GiftInviteButton() {
     } catch {
       addToast('Copy failed', 'error');
     }
-  };
+  }, [addToast]);
 
-  if (loading || !state) {
-    return null;
-  }
+  return useMemo(
+    () => ({ state, loading, open, setOpen, generating, copiedCode, handleGenerate, handleCopy }),
+    [state, loading, open, generating, copiedCode, handleGenerate, handleCopy],
+  );
+}
 
-  const remaining = state.remaining;
-  const quota = state.quota;
+function useGiftInvite(): GiftInviteController | null {
+  return useContext(GiftInviteContext);
+}
 
+export function GiftInviteProvider({ children }: { children: ReactNode }) {
+  const controller = useGiftInviteController();
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        aria-label={`Gift Invitation ${remaining} of ${quota} remaining`}
-        className="fixed bottom-4 left-4 z-[45] inline-flex items-center gap-2 rounded-full px-3.5 py-2 text-xs font-semibold text-white shadow-lg shadow-red-900/40 border border-red-400/50 bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 transition-all cursor-pointer"
-      >
-        <GiftIcon className="w-4 h-4" />
-        <span>Gift Invitation</span>
-        <span className="inline-flex items-center justify-center rounded-full bg-white/20 border border-white/30 px-1.5 text-[10px] font-bold leading-none py-0.5">
-          {remaining}/{quota}
-        </span>
-      </button>
+    <GiftInviteContext.Provider value={controller}>
+      {children}
+      <GiftInviteModal />
+    </GiftInviteContext.Provider>
+  );
+}
 
-      {createPortal(
-        <AnimatePresence>
-          {open && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center p-2 sm:p-4"
-            >
-              <div
-                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                onClick={() => setOpen(false)}
-                aria-hidden="true"
-              />
-              <motion.div
-                initial={{ opacity: 0, scale: 0.94, y: 24 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.94, y: 24 }}
-                transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-                className="relative w-full max-w-md bg-neutral-950 border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="gift-invite-title"
-              >
-                <div className="px-5 pt-5 pb-3 border-b border-white/5">
-                  <div className="flex items-start gap-3">
-                    <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-rose-500 to-red-700 flex items-center justify-center shrink-0 shadow-lg shadow-red-900/40">
-                      <GiftIcon className="w-5 h-5 text-white" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <h2 id="gift-invite-title" className="text-white text-base font-semibold leading-tight">
-                        Invite friends to OpenOrbis
-                      </h2>
-                      <p className="text-white/50 text-xs mt-1 leading-relaxed">
-                        You can invite up to <strong className="text-white/80">{quota}</strong> friends. Generate a code, copy the activation link, and share it — the counter decrements as friends join.
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => setOpen(false)}
-                      aria-label="Close"
-                      className="-mr-1 -mt-1 h-8 w-8 rounded-lg text-white/40 hover:text-white hover:bg-white/10 flex items-center justify-center shrink-0 cursor-pointer"
-                    >
-                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
+export default function GiftInviteButton() {
+  const ctrl = useGiftInvite();
+  if (!ctrl || ctrl.loading || !ctrl.state) return null;
+  const { remaining, quota } = ctrl.state;
+  return (
+    <button
+      type="button"
+      onClick={() => ctrl.setOpen(true)}
+      aria-label={`Gift Invitation ${remaining} of ${quota} remaining`}
+      className="hidden sm:inline-flex fixed bottom-4 left-4 z-[45] items-center gap-2 rounded-full px-3.5 py-2 text-xs font-semibold text-white shadow-lg shadow-red-900/40 border border-red-400/50 bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 transition-all cursor-pointer"
+    >
+      <GiftIcon className="w-4 h-4" />
+      <span>Gift Invitation</span>
+      <span className="inline-flex items-center justify-center rounded-full bg-white/20 border border-white/30 px-1.5 text-[10px] font-bold leading-none py-0.5">
+        {remaining}/{quota}
+      </span>
+    </button>
+  );
+}
+
+export function GiftInviteIconButton() {
+  const ctrl = useGiftInvite();
+  if (!ctrl || ctrl.loading || !ctrl.state) return null;
+  const { remaining, quota } = ctrl.state;
+  return (
+    <button
+      type="button"
+      onClick={() => ctrl.setOpen(true)}
+      aria-label={`Gift Invitation ${remaining} of ${quota} remaining`}
+      title={`Gift Invitation · ${remaining}/${quota}`}
+      className="w-8 h-8 rounded-full flex items-center justify-center border border-red-400/50 text-white shadow-lg shadow-red-900/40 bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 transition-all flex-shrink-0 cursor-pointer"
+    >
+      <GiftIcon className="w-4 h-4" />
+    </button>
+  );
+}
+
+function GiftInviteModal() {
+  const ctrl = useGiftInvite();
+  if (!ctrl || !ctrl.state) return null;
+  const { state, open, setOpen, generating, copiedCode, handleGenerate, handleCopy } = ctrl;
+  const { remaining, quota } = state;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center p-2 sm:p-4"
+        >
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 24 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 24 }}
+            transition={{ type: 'spring', damping: 28, stiffness: 320 }}
+            className="relative w-full max-w-md bg-neutral-950 border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="gift-invite-title"
+          >
+            <div className="px-5 pt-5 pb-3 border-b border-white/5">
+              <div className="flex items-start gap-3">
+                <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-rose-500 to-red-700 flex items-center justify-center shrink-0 shadow-lg shadow-red-900/40">
+                  <GiftIcon className="w-5 h-5 text-white" />
                 </div>
-
-                <div className="px-5 py-4 space-y-3 max-h-[60vh] overflow-y-auto">
-                  <div className="flex items-center justify-between">
-                    <span className="text-[10px] uppercase tracking-[0.15em] text-white/40 font-semibold">Your codes</span>
-                    <span className="text-[11px] text-white/50">
-                      {remaining} / {quota} remaining
-                    </span>
-                  </div>
-
-                  {state.codes.length === 0 ? (
-                    <p className="text-white/40 text-sm italic text-center py-3">
-                      No codes yet — generate your first one below.
-                    </p>
-                  ) : (
-                    <ul className="space-y-2">
-                      {state.codes.map((c) => (
-                        <CodeRow
-                          key={c.code}
-                          code={c}
-                          onCopy={handleCopy}
-                          copied={copiedCode === c.code}
-                        />
-                      ))}
-                    </ul>
-                  )}
-
-                  {state.total_issued < state.quota && (
-                    <button
-                      type="button"
-                      onClick={handleGenerate}
-                      disabled={generating}
-                      className="w-full inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-white bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 disabled:opacity-60 disabled:cursor-wait border border-red-400/50 shadow-lg shadow-red-900/30 transition-all cursor-pointer"
-                    >
-                      <GiftIcon className="w-4 h-4" />
-                      {generating ? 'Generating…' : `Generate new code (${state.quota - state.total_issued} left)`}
-                    </button>
-                  )}
-                  {state.total_issued >= state.quota && remaining > 0 && (
-                    <p className="text-[11px] text-white/40 text-center">
-                      All {quota} codes issued. Share the ones above.
-                    </p>
-                  )}
-                  {remaining === 0 && state.total_issued >= state.quota && (
-                    <p className="text-[11px] text-emerald-300/80 text-center">
-                      All your friends joined — thanks for bringing them on board.
-                    </p>
-                  )}
+                <div className="flex-1 min-w-0">
+                  <h2 id="gift-invite-title" className="text-white text-base font-semibold leading-tight">
+                    Invite friends to OpenOrbis
+                  </h2>
+                  <p className="text-white/50 text-xs mt-1 leading-relaxed">
+                    You can invite up to <strong className="text-white/80">{quota}</strong> friends. Generate a code, copy the activation link, and share it — the counter decrements as friends join.
+                  </p>
                 </div>
-              </motion.div>
-            </motion.div>
-          )}
-        </AnimatePresence>,
-        document.body,
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  aria-label="Close"
+                  className="-mr-1 -mt-1 h-8 w-8 rounded-lg text-white/40 hover:text-white hover:bg-white/10 flex items-center justify-center shrink-0 cursor-pointer"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <div className="px-5 py-4 space-y-3 max-h-[60vh] overflow-y-auto">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-[0.15em] text-white/40 font-semibold">Your codes</span>
+                <span className="text-[11px] text-white/50">
+                  {remaining} / {quota} remaining
+                </span>
+              </div>
+
+              {state.codes.length === 0 ? (
+                <p className="text-white/40 text-sm italic text-center py-3">
+                  No codes yet — generate your first one below.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {state.codes.map((c) => (
+                    <CodeRow
+                      key={c.code}
+                      code={c}
+                      onCopy={handleCopy}
+                      copied={copiedCode === c.code}
+                    />
+                  ))}
+                </ul>
+              )}
+
+              {state.total_issued < state.quota && (
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={generating}
+                  className="w-full inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold text-white bg-gradient-to-br from-rose-500 via-red-600 to-red-700 hover:brightness-110 disabled:opacity-60 disabled:cursor-wait border border-red-400/50 shadow-lg shadow-red-900/30 transition-all cursor-pointer"
+                >
+                  <GiftIcon className="w-4 h-4" />
+                  {generating ? 'Generating…' : `Generate new code (${state.quota - state.total_issued} left)`}
+                </button>
+              )}
+              {state.total_issued >= state.quota && remaining > 0 && (
+                <p className="text-[11px] text-white/40 text-center">
+                  All {quota} codes issued. Share the ones above.
+                </p>
+              )}
+              {remaining === 0 && state.total_issued >= state.quota && (
+                <p className="text-[11px] text-emerald-300/80 text-center">
+                  All your friends joined — thanks for bringing them on board.
+                </p>
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
       )}
-    </>
+    </AnimatePresence>,
+    document.body,
   );
 }
 

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef, useCallback } from 'react';
+import { useEffect, useMemo, useState, useRef, useCallback, type ReactNode } from 'react';
 import { textSearch } from '../../api/orbs';
 import type { OrbNode, OrbVisibility } from '../../api/orbs';
 import { NODE_TYPE_COLORS } from '../graph/NodeColors';
@@ -26,6 +26,11 @@ interface ChatBoxProps {
   interactionHint?: string;
   onRecenter?: () => void;
   visibility?: OrbVisibility;
+  // Rendered on mobile only, at the left of the bar row (same level as the
+  // action circles on the right). Used for compact triggers that would
+  // otherwise overlap the search bar if floated separately (e.g. the gift
+  // invite icon on /myorbis — #385).
+  mobileLeftSlot?: ReactNode;
 }
 
 export type { ChatMessage };
@@ -94,6 +99,7 @@ export default function ChatBox({
   interactionHint = 'Zoom: mouse wheel · Pan: right-drag · Rotate: left-drag',
   onRecenter,
   visibility = 'public',
+  mobileLeftSlot,
 }: ChatBoxProps) {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -412,6 +418,11 @@ export default function ChatBox({
 
       {/* Bottom bar — discover + recenter + chat input + action buttons */}
       <div className="flex items-center gap-1.5 sm:gap-2">
+        {mobileLeftSlot && (
+          <div className="sm:hidden flex items-center flex-shrink-0">
+            {mobileLeftSlot}
+          </div>
+        )}
         {onDiscover && (
           <button
             type="button"

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -26,7 +26,7 @@ import { loadDraftNotes, loadDraftNotesAsync } from '../components/drafts/DraftN
 import ProcessingCounter from '../components/cv/ProcessingCounter';
 import KeywordFilterDropdown from '../components/cv/KeywordFilterDropdown';
 import UserMenu from '../components/UserMenu';
-import GiftInviteButton from '../components/GiftInviteButton';
+import GiftInviteButton, { GiftInviteProvider, GiftInviteIconButton } from '../components/GiftInviteButton';
 import { useToastStore } from '../stores/toastStore';
 import { useUndoStore } from '../stores/undoStore';
 import { getDocuments, confirmImport, getJob } from '../api/cv';
@@ -599,6 +599,7 @@ export default function OrbViewPage() {
   }
 
   return (
+    <GiftInviteProvider>
     <div className="min-h-screen bg-black relative">
       {/* ── Deletion countdown banner ── */}
       {isPendingDeletion && (
@@ -1034,6 +1035,7 @@ export default function OrbViewPage() {
         highlightAdd={data.nodes.length === 0 && !showInput}
         onRecenter={() => handleFocusNode(personNodeId)}
         visibility={((data?.person?.visibility as OrbVisibility) || 'public')}
+        mobileLeftSlot={<GiftInviteIconButton />}
       />}
 
       {/* ── Draft Notes ── */}
@@ -1167,5 +1169,6 @@ export default function OrbViewPage() {
       {/* ── Guided Tour ── */}
       <GuidedTour run={tourRunning} onFinish={() => setTourRunning(false)} />
     </div>
+    </GiftInviteProvider>
   );
 }


### PR DESCRIPTION
## Summary
- On mobile the bottom-left **Gift Invitation** pill overlapped the ChatBox search bar. It now collapses to a compact circular icon rendered **inside** the bar row on the left, vertically aligned with the Share/Add circles.
- Desktop behaviour is unchanged — the pill with the remaining/quota badge still sits at `bottom-4 left-4`.
- Added a `GiftInviteProvider` context so the two triggers (desktop pill + mobile icon) share state and mount a single modal.

## Changes
- `components/GiftInviteButton.tsx`: extracted state into a provider + controller hook; default export (pill) is now `hidden sm:inline-flex`; new `GiftInviteIconButton` export for the mobile trigger.
- `components/chat/ChatBox.tsx`: new optional `mobileLeftSlot` prop, rendered `sm:hidden` as the first child of the bar row.
- `pages/OrbViewPage.tsx`: page wrapped in `GiftInviteProvider`; `<GiftInviteIconButton />` passed to ChatBox as `mobileLeftSlot`.

## Test plan
- [ ] Desktop (≥ sm): pill still appears bottom-left with the `N/3` badge and opens the modal.
- [ ] Mobile (< sm): pill is hidden; gift icon appears inside the chat bar on the left, same height as Share/Add; tapping it opens the same modal.
- [ ] Modal open/close, code generation, and copy-to-clipboard still work on both breakpoints.
- [ ] `npm run build` passes (TS type-check + Vite bundle).

## Documentation
No doc changes needed — purely a responsive tweak to an existing feature; no new routes, modals, or API changes.