### PR TITLE
fix(cv): stop silently masking Gemini failures as rule-based extraction

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -59,7 +59,10 @@ class Settings(BaseSettings):
     # When empty, a single-provider chain is derived from llm_provider.
     llm_fallback_chain: str = ""
     # Per-provider timeout in seconds before falling back to the next provider.
-    llm_timeout_seconds: int = 300
+    # Must stay comfortably below the Cloud Run request timeout (see
+    # infra/gcp/deploy-backend.sh `--timeout`) so the handler can still emit
+    # fallback + email + DB writes after the LLM call returns or times out.
+    llm_timeout_seconds: int = 900
 
     # Ollama (local LLM, used only when llm_provider=ollama)
     ollama_base_url: str = "http://localhost:11434"

--- a/backend/app/cv/cloud_tasks.py
+++ b/backend/app/cv/cloud_tasks.py
@@ -7,10 +7,17 @@ import logging
 
 from google.api_core.exceptions import NotFound
 from google.cloud import tasks_v2
+from google.protobuf import duration_pb2
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+# Must be ≥ the Cloud Run `--timeout` in infra/gcp/deploy-backend.sh,
+# otherwise Cloud Tasks kills the dispatched request before Cloud Run
+# finishes long Gemini calls on big CVs. Defaults to 600s when unset,
+# which used to cut ~15-min Gemini extractions short.
+_DISPATCH_DEADLINE_SECONDS = 1200
 
 
 def _get_client() -> tasks_v2.CloudTasksClient:
@@ -27,6 +34,7 @@ def dispatch_cv_job(*, job_id: str) -> str:
         settings.cloud_tasks_queue,
     )
     task = tasks_v2.Task(
+        dispatch_deadline=duration_pb2.Duration(seconds=_DISPATCH_DEADLINE_SECONDS),
         http_request=tasks_v2.HttpRequest(
             http_method=tasks_v2.HttpMethod.POST,
             url=f"{settings.cloud_run_url}/api/cv/process-job",

--- a/backend/app/cv/jobs_router.py
+++ b/backend/app/cv/jobs_router.py
@@ -135,6 +135,22 @@ async def process_job(
 
         result = await classify_entries(raw_text, progress_callback=_progress_cb)
 
+        # classify_entries returns a metadata-only result with
+        # llm_provider="none" when every provider in the fallback chain
+        # fails (timeout, quota, empty response). Previously such jobs
+        # were silently stored as "succeeded" with 0 nodes, leaving the
+        # user staring at an empty graph with no failure email. Raise so
+        # the existing failure path fires.
+        if (
+            result.metadata is not None
+            and result.metadata.llm_provider == "none"
+            and not result.nodes
+        ):
+            raise RuntimeError(
+                "All LLM providers in the fallback chain failed "
+                "(timeout, quota, or empty response). See upstream logs."
+            )
+
         # Step 4: Store result
         await jobs_db.update_job_progress(
             job_id,

--- a/backend/app/cv/models.py
+++ b/backend/app/cv/models.py
@@ -52,10 +52,12 @@ class ExtractedData(BaseModel):
 class ExtractionMetadata(BaseModel):
     """Metadata about how a CV extraction was performed."""
 
-    llm_provider: str  # "claude", "ollama", "rule_based"
-    llm_model: str  # "claude-opus-4-6", "llama3.2:3b", "rule_based_parser"
-    extraction_method: str  # "primary", "fallback_rule_based", "fallback_raw_text"
-    prompt_content: str  # Full system prompt used (empty for rule_based)
+    llm_provider: str  # "claude", "gemini", "ollama", "rule_based", or "none"
+    llm_model: (
+        str  # e.g. "claude-opus-4-6", "gemini-2.5-pro", "rule_based_parser", "none"
+    )
+    extraction_method: str  # "primary", "fallback_<provider>", "fallback_rule_based", "fallback_raw_text"
+    prompt_content: str  # Full system prompt used (empty when no LLM was invoked)
     prompt_hash: str  # SHA-256 of prompt_content
     cost_usd: float | None = None
     duration_ms: int | None = None

--- a/backend/app/cv/ollama_classifier.py
+++ b/backend/app/cv/ollama_classifier.py
@@ -439,6 +439,9 @@ async def classify_entries(  # noqa: C901
             logger.warning("%s failed (%s), falling back", display, e)
 
     # All providers exhausted — return raw text as unmatched.
+    # Labelled "none/none" (not "rule_based") so operators can distinguish
+    # this exhausted-chain dump from a real rule-based extraction, which
+    # keeps the "rule_based/rule_based_parser" labels below.
     logger.error("All providers in fallback chain failed — returning as unmatched")
     fallback_lines = [
         line.strip()
@@ -449,8 +452,8 @@ async def classify_entries(  # noqa: C901
         unmatched=fallback_lines[:50],
         truncated=truncated,
         metadata=ExtractionMetadata(
-            llm_provider="rule_based",
-            llm_model="rule_based_parser",
+            llm_provider="none",
+            llm_model="none",
             extraction_method="fallback_raw_text",
             prompt_content="",
             prompt_hash="",

--- a/backend/tests/unit/test_classify_entries.py
+++ b/backend/tests/unit/test_classify_entries.py
@@ -420,6 +420,34 @@ class TestFinalFallback:
             assert result.nodes == []
             assert len(result.unmatched) > 0
 
+    async def test_exhausted_chain_metadata_is_distinct_from_rule_based(self):
+        """Chain-exhausted dumps are labelled 'none/none', not 'rule_based/rule_based_parser'.
+
+        Operators need to distinguish a real rule-based extraction (parser.py
+        ran and produced nodes — extraction_method='fallback_rule_based') from
+        a chain-exhausted raw-text dump (no provider succeeded, unmatched only —
+        extraction_method='fallback_raw_text'). Both used to share the
+        'rule_based' provider label, masking silent LLM failures in prod.
+        """
+        with (
+            patch(
+                "app.cv.ollama_classifier.settings",
+                _make_settings(llm_fallback_chain="gemini-pro"),
+            ),
+            patch(
+                "app.cv.ollama_classifier._call_gemini_provider",
+                new_callable=AsyncMock,
+                side_effect=asyncio.TimeoutError(),
+            ),
+        ):
+            result = await classify_entries(
+                "This is a line of text that should appear as unmatched"
+            )
+            assert result.metadata is not None
+            assert result.metadata.llm_provider == "none"
+            assert result.metadata.llm_model == "none"
+            assert result.metadata.extraction_method == "fallback_raw_text"
+
     async def test_final_fallback_limits_to_50_lines(self):
         text = "\n".join(f"Line number {i} with enough text" for i in range(100))
         with (

--- a/backend/tests/unit/test_jobs_router.py
+++ b/backend/tests/unit/test_jobs_router.py
@@ -167,6 +167,82 @@ def test_process_job_invalid_oidc_returns_401(mock_get_job):
     mock_get_job.assert_not_awaited()
 
 
+@patch("app.cv.jobs_router._send_failure_email", new_callable=AsyncMock)
+@patch("app.cv.jobs_router.jobs_db.update_job_result", new_callable=AsyncMock)
+@patch("app.cv.jobs_router.jobs_db.update_job_progress", new_callable=AsyncMock)
+@patch("app.cv.jobs_router.jobs_db.update_job_status", new_callable=AsyncMock)
+@patch("app.cv.jobs_router.jobs_db.get_job", new_callable=AsyncMock)
+def test_process_job_marks_exhausted_chain_as_failed(
+    mock_get_job,
+    mock_update_status,
+    mock_update_progress,
+    mock_update_result,
+    mock_failure_email,
+):
+    """When every LLM provider fails, classify_entries returns a
+    metadata-only result with llm_provider='none'. The job must be marked
+    failed (not succeeded with 0 nodes) so the user gets a failure email
+    instead of staring at an empty graph."""
+    from app.cv.models import ExtractionMetadata
+    from app.cv.ollama_classifier import ClassificationResult
+
+    mock_get_job.return_value = dict(_BASE_JOB)
+    exhausted = ClassificationResult(
+        nodes=[],
+        unmatched=["stray line 1", "stray line 2"],
+        metadata=ExtractionMetadata(
+            llm_provider="none",
+            llm_model="none",
+            extraction_method="fallback_raw_text",
+            prompt_content="",
+            prompt_hash="",
+        ),
+    )
+
+    client, _ = _make_client(USER_ID)
+    try:
+        with (
+            patch(
+                "app.cv.jobs_router.verify_oidc_token",
+                return_value="sa@project.iam.gserviceaccount.com",
+            ),
+            patch(
+                "app.cv_storage.storage.load_document_async",
+                new_callable=AsyncMock,
+                return_value=b"%PDF-1.4 fake",
+            ),
+            patch(
+                "app.cv.pdf_extractor.extract_text",
+                new_callable=AsyncMock,
+                return_value="Some extracted CV text",
+            ),
+            patch(
+                "app.cv.ollama_classifier.classify_entries",
+                new_callable=AsyncMock,
+                return_value=exhausted,
+            ),
+        ):
+            response = client.post(
+                "/cv/process-job",
+                json={"job_id": "job-123"},
+            )
+    finally:
+        _teardown()
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "failed"
+    # Must have been persisted with status=failed carrying the error.
+    failure_calls = [
+        c
+        for c in mock_update_result.await_args_list
+        if c.kwargs.get("status") == "failed"
+    ]
+    assert failure_calls, "expected jobs_db.update_job_result(status='failed')"
+    assert "All LLM providers" in failure_calls[0].kwargs["error_message"]
+    # And the user must get a failure email, not a success email.
+    mock_failure_email.assert_awaited_once()
+
+
 @patch("app.cv.jobs_router.jobs_db.get_job", new_callable=AsyncMock)
 def test_process_job_skips_non_queued(mock_get_job):
     """If job status is not 'queued', the endpoint returns skipped."""

--- a/docs/database.md
+++ b/docs/database.md
@@ -109,8 +109,8 @@ Records every LLM invocation (CV extraction, note enhancement) for cost and toke
 |----------|------|-------|
 | `usage_id` | string | UUID |
 | `endpoint` | string | e.g. `/cv/upload`, `/notes/enhance` |
-| `llm_provider` | string | `claude`, `ollama`, `rule_based` |
-| `llm_model` | string | e.g. `claude-opus-4-6`, `llama3.2:3b` |
+| `llm_provider` | string | `claude`, `gemini`, `ollama`, `rule_based`, or `none` |
+| `llm_model` | string | e.g. `claude-opus-4-6`, `gemini-2.5-pro`, `llama3.2:3b`, `rule_based_parser`, `none` |
 | `input_tokens` | integer | Nullable |
 | `output_tokens` | integer | Nullable |
 | `total_tokens` | integer | Nullable (input + output) |
@@ -314,9 +314,9 @@ One node per confirmed CV import. Records which LLM was used, which prompt, and 
 |----------|------|-------------|
 | `record_id` | string (UUID) | Unique identifier |
 | `document_id` | string | References `cv_documents.document_id` in SQLite |
-| `llm_provider` | string | `"claude"`, `"ollama"`, or `"rule_based"` |
-| `llm_model` | string | e.g. `"claude-opus-4-6"`, `"llama3.2:3b"`, `"rule_based_parser"` |
-| `extraction_method` | string | `"primary"`, `"fallback_rule_based"`, or `"fallback_raw_text"` |
+| `llm_provider` | string | `"claude"`, `"gemini"`, `"ollama"`, `"rule_based"`, or `"none"` (every provider in the chain failed) |
+| `llm_model` | string | e.g. `"claude-opus-4-6"`, `"gemini-2.5-pro"`, `"llama3.2:3b"`, `"rule_based_parser"`, `"none"` |
+| `extraction_method` | string | `"primary"` (chain[0] succeeded), `"fallback_<provider>"` (a later LLM succeeded), `"fallback_rule_based"` (real rule-based parser ran), or `"fallback_raw_text"` (chain exhausted — raw text dumped as unmatched) |
 | `prompt_hash` | string | SHA-256 of the system prompt used |
 | `nodes_extracted` | integer | Count of nodes produced |
 | `edges_extracted` | integer | Count of relationships produced |

--- a/docs/deploy-plan.md
+++ b/docs/deploy-plan.md
@@ -189,7 +189,7 @@ The FastAPI backend is **stateless** (JWT auth, no server-side sessions), making
 - Startup probe: `GET /health/ready` (see [Health Endpoints](#health-endpoints))
 - Min instances: 0 (scale-to-zero)
 - Max instances: 10 (cap for early stage, adjust later)
-- Request timeout: 300s (matches `llm_timeout_seconds`)
+- Request timeout: 1200s (Gemini 2.5 Pro on long CVs can take ~15 min; must be ≥ `llm_timeout_seconds` — currently 900s — plus headroom for PDF extract, DB writes, and failure email). Cloud Tasks `dispatch_deadline` is also set to 1200s in `cloud_tasks.py` to match.
 - CPU always allocated: No (only during request processing — saves cost)
 
 **Dockerfile (`backend/Dockerfile`):**

--- a/infra/gcp/deploy-backend.sh
+++ b/infra/gcp/deploy-backend.sh
@@ -31,7 +31,7 @@ gcloud run deploy "$BACKEND_SERVICE" \
   --concurrency=80 \
   --min-instances=0 \
   --max-instances=10 \
-  --timeout=300s \
+  --timeout=1200s \
   --allow-unauthenticated \
   --startup-cpu-boost \
   --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest,RESEND_API_KEY=resend-api-key:latest,GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,LINKEDIN_CLIENT_ID=linkedin-client-id:latest,LINKEDIN_CLIENT_SECRET=linkedin-client-secret:latest" \


### PR DESCRIPTION
## Summary

- Every job in prod labelled `rule_based/rule_based_parser` was actually a silent Gemini failure (Vertex AI timeout or 429 RESOURCE_EXHAUSTED), not a real rule-based extraction — the terminal "all providers exhausted" branch in `classify_entries` was reusing the same metadata labels as the successful rule-based path, so operators couldn't tell them apart.
- Affected jobs were marked `succeeded` with 0 nodes/edges and never triggered a failure email — users just saw an empty graph.
- Three fixes, bundled:
  1. **Honest labels** — terminal branch now emits `llm_provider="none"`, `llm_model="none"` (keeping `extraction_method="fallback_raw_text"`). Real rule-based extraction keeps `rule_based/rule_based_parser/fallback_rule_based`.
  2. **No more silent failures** — `jobs_router.process_job` now detects the exhausted-chain result and raises into the existing failure path, so the job is marked `failed` and a failure email goes out.
  3. **Timeout headroom for Gemini 2.5 Pro** — `llm_timeout_seconds` 300→900s, Cloud Run `--timeout` 300s→1200s, explicit Cloud Tasks `dispatch_deadline=1200s`. Long CVs were hitting the 300s per-call ceiling on today's jobs (4f234c53, 259795ec).

## Evidence (Cloud Logging, last 14 days)

```
2026-04-20 08:54:22  INFO   Calling Gemini via Vertex AI: model=gemini-2.5-pro, region=europe-west1
2026-04-20 08:59:22  WARN   Gemini Pro timed out after 300s, falling back
2026-04-20 08:59:22  ERROR  All providers in fallback chain failed — returning as unmatched
2026-04-20 08:59:25  INFO   Job 4f234c53 succeeded: 0 nodes, 0 edges   ← user sees empty graph, no email
```

Also seen 2026-04-14/15: `Gemini Pro failed (429 RESOURCE_EXHAUSTED)`, four jobs total.

## Test plan

- [x] `uv run pytest tests/unit/ -q` — 665 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean on all touched files
- [x] New test `test_exhausted_chain_metadata_is_distinct_from_rule_based` locks in the `none/none/fallback_raw_text` labels
- [x] New test `test_process_job_marks_exhausted_chain_as_failed` verifies failed status + failure email
- [ ] Post-merge: deploy and watch Cloud Logging for 24h — expect no more `Job … succeeded: 0 nodes, 0 edges` entries; any Gemini timeout should now surface as a `failed` job with a failure email to the user.
- [ ] Separate follow-up (not in this PR): add Claude Opus to `FALLBACK_CHAIN` once quota is approved, per `infra/gcp/variables.env:30-31`.

## Documentation

- `docs/database.md` — updated LLMUsage + ProcessingRecord value tables to include `gemini`, `none`, and `fallback_raw_text`, and clarify what each `extraction_method` actually means.
- `docs/deploy-plan.md` — stale `Request timeout: 300s` line updated to reflect the new 1200s Cloud Run timeout and Cloud Tasks dispatch_deadline.