### PR TITLE
fix(infra): route traffic to new revision on deploy

### DIFF
--- a/infra/gcp/deploy-backend.sh
+++ b/infra/gcp/deploy-backend.sh
@@ -34,6 +34,7 @@ gcloud run deploy "$BACKEND_SERVICE" \
   --timeout=1200s \
   --allow-unauthenticated \
   --cpu-boost \
+  --to-latest \
   --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest,RESEND_API_KEY=resend-api-key:latest,GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,LINKEDIN_CLIENT_ID=linkedin-client-id:latest,LINKEDIN_CLIENT_SECRET=linkedin-client-secret:latest" \
   --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,LLM_PROVIDER=vertex,LLM_FALLBACK_CHAIN=$FALLBACK_CHAIN,GEMINI_MODEL=gemini-2.5-pro,GCP_PROJECT_ID=$PROJECT_ID,VERTEX_REGION=$REGION,CV_STORAGE_BUCKET=$GCS_BUCKET,FRONTEND_URL=https://open-orbis.com,COOKIE_DOMAIN=.open-orbis.com,LINKEDIN_REDIRECT_URI=https://open-orbis.com/auth/linkedin/callback,CLOUD_TASKS_QUEUE=orbis-cv-queue,CLOUD_TASKS_LOCATION=$REGION,CLOUD_RUN_URL=https://orbis-api-o5zg3whvrq-ew.a.run.app,CLOUD_RUN_SERVICE_ACCOUNT=$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com"
 


### PR DESCRIPTION
## Summary

Follow-up to #400. Without `--to-latest`, `gcloud run deploy` creates a new revision but leaves traffic pinned to whichever revision the service's traffic spec currently references.

**Evidence from today:** revision `00053-s2t` (Apr 18) and `00054-8r6` (today, deploy of #399) were both created but never received traffic. The 2-day-old `00052-r9h` kept serving until I noticed during the #399 deploy and shifted traffic manually with `gcloud run services update-traffic --to-revisions=orbis-api-00054-8r6=100`.

`--to-latest` makes the deploy route 100% traffic to the newly created revision automatically — which is what every past deploy silently assumed.

## Test plan

- [ ] On the next deploy after this lands, verify `gcloud run services describe orbis-api --region=europe-west1 --format='value(status.traffic[0].revisionName)'` returns the newly created revision without manual intervention.

## Documentation

No doc changes needed — single-flag change in `infra/gcp/deploy-backend.sh`.