### PR TITLE
fix(infra): actually route traffic to new revision on deploy

### DIFF
--- a/infra/gcp/deploy-backend.sh
+++ b/infra/gcp/deploy-backend.sh
@@ -34,10 +34,21 @@ gcloud run deploy "$BACKEND_SERVICE" \
   --timeout=1200s \
   --allow-unauthenticated \
   --cpu-boost \
-  --to-latest \
   --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest,RESEND_API_KEY=resend-api-key:latest,GOOGLE_CLIENT_ID=google-client-id:latest,GOOGLE_CLIENT_SECRET=google-client-secret:latest,LINKEDIN_CLIENT_ID=linkedin-client-id:latest,LINKEDIN_CLIENT_SECRET=linkedin-client-secret:latest" \
   --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,LLM_PROVIDER=vertex,LLM_FALLBACK_CHAIN=$FALLBACK_CHAIN,GEMINI_MODEL=gemini-2.5-pro,GCP_PROJECT_ID=$PROJECT_ID,VERTEX_REGION=$REGION,CV_STORAGE_BUCKET=$GCS_BUCKET,FRONTEND_URL=https://open-orbis.com,COOKIE_DOMAIN=.open-orbis.com,LINKEDIN_REDIRECT_URI=https://open-orbis.com/auth/linkedin/callback,CLOUD_TASKS_QUEUE=orbis-cv-queue,CLOUD_TASKS_LOCATION=$REGION,CLOUD_RUN_URL=https://orbis-api-o5zg3whvrq-ew.a.run.app,CLOUD_RUN_SERVICE_ACCOUNT=$SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com"
 
+# Route 100% traffic to the freshly created revision. `gcloud run deploy`
+# does NOT do this automatically when the service's traffic spec is pinned
+# to specific revision names (as opposed to LATEST), which is the mode
+# this service is currently in — revisions 00053 (Apr 18) and 00054 (today)
+# were both created by past deploys but never served traffic until this
+# post-deploy update-traffic call was added. See #401.
+echo "--- Routing traffic to latest revision ---"
+gcloud run services update-traffic "$BACKEND_SERVICE" \
+  --region="$REGION" \
+  --project="$PROJECT_ID" \
+  --to-latest
+
 echo ""
 echo "=== Backend deployed ==="
-gcloud run services describe "$BACKEND_SERVICE" --region="$REGION" --format="value(status.url)"
+gcloud run services describe "$BACKEND_SERVICE" --region="$REGION" --format="value(status.url,status.traffic[0].revisionName)"


### PR DESCRIPTION
## Summary

PR #401 added `--to-latest` to `gcloud run deploy`, but that flag only exists on `gcloud run services update-traffic`. Today's deploy attempt failed with:

```
ERROR: (gcloud.run.deploy) unrecognized arguments: --to-latest (did you mean '--labels'?)
```

Correct fix: remove `--to-latest` from the `deploy` step and add an explicit post-deploy `gcloud run services update-traffic --to-latest` step, which **is** the documented way to force traffic onto the newest revision when the service is in "specific revision" traffic mode (which ours is — see #401 for the 00053/00054 evidence). Also extends the final `describe` to print the serving revision name for operator confirmation.

## Test plan

- [x] `gcloud run services update-traffic --help | grep to-latest` — confirmed flag exists on the `update-traffic` subcommand.
- [ ] Run `infra/gcp/deploy-backend.sh` after merge — expect build + deploy + traffic routing all to succeed, with the final `describe` line showing the newly created revision name.

## Documentation

No doc changes needed — single-script infra change.