### PR TITLE
feat(auth): never-logout — silent re-auth via FedCM + Google One Tap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ EMAIL_FROM=OpenOrbis <noreply@openorbis.com>
 
 # Frontend
 FRONTEND_URL=http://localhost:5173
+# Set to "false" to disable silent-re-auth (FedCM + One Tap) for emergency
+# rollback. Default behavior is enabled.
+VITE_SILENT_REAUTH_ENABLED=true
 
 # Backend
 BACKEND_URL=http://localhost:8000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ backend/
     snapshots/   # Orb version snapshots (save, restore, delete)
     main.py      # FastAPI app factory, middleware (CORS, SlowAPI), router registration, cv_jobs table init on startup
     config.py    # Pydantic Settings (env-based). New settings: cloud_tasks_queue, cloud_tasks_location, cloud_run_url, cloud_run_service_account, cors_extra_origins
-    rate_limit.py # SlowAPI limiter keyed on user_id (authenticated) / IP (public). Explicit caps on LLM endpoints: /cv/upload 3/min, /cv/import 3/min, /notes/enhance 10/min.
+    rate_limit.py # SlowAPI limiter keyed on user_id (authenticated) / IP (public). Explicit caps: /cv/upload 3/min, /cv/import 3/min, /notes/enhance 10/min (per user); /auth/google-id-token 5/min per IP (silent re-auth).
     dependencies.py # get_db, get_current_user (JWT bearer), require_admin
   mcp_server/    # MCP server exposing orb graph to AI agents (6 tools, API key auth via X-MCP-Key)
   tests/

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
@@ -36,6 +37,7 @@ from app.auth.service import (
     generate_orb_id,
     parse_session_cookie,
     set_auth_cookies,
+    verify_google_id_token,
 )
 from app.config import settings
 from app.dependencies import get_current_user, get_db
@@ -153,6 +155,74 @@ async def _issue_session(
         refresh_expires_at=refresh_expires_at,
     )
     return access_token
+
+
+async def _upsert_google_person(db: AsyncDriver, claims: dict) -> dict:
+    """Create or update a Person node from Google ID-token claims.
+
+    Accepts the decoded claims dict produced by either ``exchange_google_code``
+    or ``verify_google_id_token``.  Returns ``{"user_id": ..., "email": ...}``
+    so callers can mint session cookies without repeating the derivation.
+    """
+    user_id = f"google-{claims['sub']}"
+    email = claims["email"]
+    name = claims.get("name", "")
+    picture = claims.get("picture", "")
+    await _get_or_create_person(
+        db,
+        user_id=user_id,
+        email=email,
+        name=name,
+        picture=picture,
+        provider="google",
+    )
+    return {"user_id": user_id, "email": email}
+
+
+class GoogleIdTokenRequest(BaseModel):
+    id_token: str
+    source: Literal["fedcm", "onetap"] | None = None  # telemetry hint
+
+
+@router.post("/google-id-token")
+@limiter.limit("5/minute")
+async def google_id_token_login(
+    request: Request,
+    response: Response,
+    body: GoogleIdTokenRequest,
+    db: AsyncDriver = Depends(get_db),
+):
+    """Verify a Google ID token and mint an Orbis session cookie.
+
+    Called by the frontend silent-re-auth flow (FedCM or GIS One Tap),
+    which already has a Google-signed JWT in hand and just needs Orbis
+    to trust it in lieu of re-running the authorization-code dance.
+    """
+    claims = await verify_google_id_token(body.id_token)
+    if not claims.get("email_verified"):
+        raise HTTPException(status_code=401, detail="invalid_id_token")
+
+    user = await _upsert_google_person(db, claims)
+
+    raw, _token_id, expires_at = await issue_refresh_token(
+        db,
+        user_id=user["user_id"],
+        ttl_days=settings.refresh_token_expire_days,
+        user_agent=request.headers.get("user-agent", ""),
+    )
+    access = create_jwt(user["user_id"], user["email"])
+    set_auth_cookies(
+        response,
+        access_token=access,
+        refresh_raw=raw,
+        refresh_expires_at=expires_at,
+    )
+    logger.info(
+        "auth: id-token login user=%s source=%s",
+        user["user_id"],
+        body.source or "unknown",
+    )
+    return {"status": "ok", "source": "id_token"}
 
 
 @router.post("/google", response_model=TokenResponse)

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -213,23 +213,17 @@ async def google_id_token_login(
 
     user = await _upsert_google_person(db, claims)
 
-    raw, _token_id, expires_at = await issue_refresh_token(
-        db,
-        user_id=user["user_id"],
-        ttl_days=settings.refresh_token_expire_days,
-        user_agent=request.headers.get("user-agent", ""),
-    )
-    access = create_jwt(user["user_id"], user["email"])
-    set_auth_cookies(
-        response,
-        access_token=access,
-        refresh_raw=raw,
-        refresh_expires_at=expires_at,
-    )
     logger.info(
         "auth: id-token login user=%s source=%s",
         user["user_id"],
         body.source or "unknown",
+    )
+    await _issue_session(
+        response,
+        db=db,
+        user_id=user["user_id"],
+        email=user["email"],
+        user_agent=request.headers.get("user-agent", ""),
     )
     return {"status": "ok", "source": "id_token"}
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -168,7 +168,9 @@ async def _upsert_google_person(db: AsyncDriver, claims: dict) -> dict:
     build response payloads without repeating the derivation logic.
     """
     user_id = f"google-{claims['sub']}"
-    email = claims["email"]
+    email = claims.get("email") or ""
+    if not email:
+        raise HTTPException(status_code=401, detail="invalid_id_token")
     name = claims.get("name", "")
     picture = claims.get("picture", "")
     person_info = await _get_or_create_person(

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -161,14 +161,17 @@ async def _upsert_google_person(db: AsyncDriver, claims: dict) -> dict:
     """Create or update a Person node from Google ID-token claims.
 
     Accepts the decoded claims dict produced by either ``exchange_google_code``
-    or ``verify_google_id_token``.  Returns ``{"user_id": ..., "email": ...}``
-    so callers can mint session cookies without repeating the derivation.
+    or ``verify_google_id_token``.  Returns a dict with ``user_id``, ``email``,
+    ``name``, ``picture``, and the fields from ``_get_or_create_person``
+    (``activated``, ``gdpr_consent``, ``is_admin``, ``profile_image``) so that
+    both callers — code-flow and id-token-flow — can mint session cookies and
+    build response payloads without repeating the derivation logic.
     """
     user_id = f"google-{claims['sub']}"
     email = claims["email"]
     name = claims.get("name", "")
     picture = claims.get("picture", "")
-    await _get_or_create_person(
+    person_info = await _get_or_create_person(
         db,
         user_id=user_id,
         email=email,
@@ -176,7 +179,13 @@ async def _upsert_google_person(db: AsyncDriver, claims: dict) -> dict:
         picture=picture,
         provider="google",
     )
-    return {"user_id": user_id, "email": email}
+    return {
+        "user_id": user_id,
+        "email": email,
+        "name": name,
+        "picture": picture,
+        **person_info,
+    }
 
 
 class GoogleIdTokenRequest(BaseModel):
@@ -246,30 +255,26 @@ async def google_login(
             status_code=401, detail="Google authentication failed"
         ) from None
 
-    user_id = f"google-{userinfo['sub']}"
-    email = userinfo["email"]
-    name = userinfo["name"]
-    picture = userinfo["picture"]
-
-    person_info = await _get_or_create_person(
-        db, user_id=user_id, email=email, name=name, picture=picture, provider="google"
-    )
+    user = await _upsert_google_person(db, userinfo)
 
     access_token = await _issue_session(
         response,
         db=db,
-        user_id=user_id,
-        email=email,
+        user_id=user["user_id"],
+        email=user["email"],
         user_agent=request.headers.get("user-agent", ""),
     )
     return TokenResponse(
         access_token=access_token,
         user=UserInfo(
-            user_id=user_id,
-            email=email,
-            name=name,
-            picture=picture,
-            **person_info,
+            user_id=user["user_id"],
+            email=user["email"],
+            name=user["name"],
+            picture=user["picture"],
+            activated=user["activated"],
+            gdpr_consent=user["gdpr_consent"],
+            is_admin=user["is_admin"],
+            profile_image=user["profile_image"],
         ),
     )
 

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -219,17 +219,23 @@ _GOOGLE_ISSUERS = {"accounts.google.com", "https://accounts.google.com"}
 async def verify_google_id_token(raw: str) -> dict:
     """Verify a Google-issued ID token and return its claims.
 
+    Checks signature, audience (via settings.google_client_id), expiry,
+    and issuer. The caller is responsible for enforcing business-logic
+    gates such as ``claims['email_verified'] is True`` before trusting
+    the email for account lookup.
+
     Raises HTTPException(401, 'invalid_id_token') on any validation
     failure (signature, audience, expiry, issuer, malformed). Raises
     HTTPException(503, 'verify_unavailable') if Google's JWKS endpoint
     is transiently unreachable — the frontend can retry on the next
     page load rather than being forced back to the sign-in page.
     """
+    req = google_requests.Request()
     try:
         claims = await asyncio.to_thread(
             google_id_token.verify_oauth2_token,
             raw,
-            google_requests.Request(),
+            req,
             settings.google_client_id,
         )
     except google_auth_exceptions.TransportError as exc:

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -1,10 +1,14 @@
+import asyncio
 import logging
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
 import httpx
-from fastapi import Response
+from fastapi import HTTPException, Response
+from google.auth import exceptions as google_auth_exceptions
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token as google_id_token
 from jose import jwt
 from neo4j import AsyncDriver
 
@@ -207,3 +211,33 @@ async def generate_orb_id(name: str, db: AsyncDriver) -> str:
 
     # Fallback: fully random
     return f"user-{uuid.uuid4().hex[:8]}"
+
+
+_GOOGLE_ISSUERS = {"accounts.google.com", "https://accounts.google.com"}
+
+
+async def verify_google_id_token(raw: str) -> dict:
+    """Verify a Google-issued ID token and return its claims.
+
+    Raises HTTPException(401, 'invalid_id_token') on any validation
+    failure (signature, audience, expiry, issuer, malformed). Raises
+    HTTPException(503, 'verify_unavailable') if Google's JWKS endpoint
+    is transiently unreachable — the frontend can retry on the next
+    page load rather than being forced back to the sign-in page.
+    """
+    try:
+        claims = await asyncio.to_thread(
+            google_id_token.verify_oauth2_token,
+            raw,
+            google_requests.Request(),
+            settings.google_client_id,
+        )
+    except google_auth_exceptions.TransportError as exc:
+        logger.warning("google_id_token: JWKS fetch failed: %s", exc)
+        raise HTTPException(status_code=503, detail="verify_unavailable") from exc
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid_id_token") from None
+
+    if claims.get("iss") not in _GOOGLE_ISSUERS:
+        raise HTTPException(status_code=401, detail="invalid_id_token")
+    return claims

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
 
     # Refresh token TTL in days. Refresh tokens are persisted in Neo4j
     # (as sha256 hashes) so they can be rotated and revoked.
-    refresh_token_expire_days: int = 30
+    refresh_token_expire_days: int = 365
 
     # Cookie scoping. Empty = host-only cookie (works when frontend and
     # backend share a single origin via reverse proxy). Set to the parent

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,3 +1,15 @@
+# Rate-limit cheatsheet (applied via @limiter.limit on individual routes):
+#
+# Authenticated endpoints (keyed on user_id):
+#   - /cv/upload              3/min per user
+#   - /cv/import              3/min per user
+#   - /notes/enhance         10/min per user
+#
+# Public / IP-keyed endpoints:
+#   - /auth/google-id-token   5/min per IP  (silent re-auth from FedCM / One Tap)
+#   - /export/{orb_id}       30/min per IP
+#   - /orbs/{orb_id}         30/min per IP
+
 from fastapi import Request
 from jose import JWTError, jwt
 from slowapi import Limiter

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "resend>=2.0.0",
     "jinja2>=3.1.0",
+    "google-auth>=2.30.0",
     "google-cloud-tasks>=2.16.0",
 ]
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,6 +1,15 @@
 from app.config import settings
 
 
+def test_refresh_token_ttl_default_is_one_year():
+    """Defaults to 365 days so refresh cookies don't force monthly re-sign-in.
+
+    Sliding window already in place in /auth/refresh; this is the absolute
+    cap for genuinely dormant sessions.
+    """
+    assert settings.refresh_token_expire_days == 365
+
+
 class TestOauthSettings:
     def test_oauth_enabled_default_is_true_in_dev(self):
         assert settings.oauth_enabled is True

--- a/backend/tests/unit/test_google_id_token_router.py
+++ b/backend/tests/unit/test_google_id_token_router.py
@@ -1,0 +1,139 @@
+"""Unit tests for POST /auth/google-id-token."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+_FUTURE = datetime.datetime(2027, 4, 22, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+HAPPY_CLAIMS = {
+    "sub": "google-sub-abc",
+    "email": "alice@example.com",
+    "email_verified": True,
+    "name": "Alice Smith",
+    "picture": "https://example.com/a.png",
+    "iss": "https://accounts.google.com",
+    "aud": "test-client-id",
+}
+
+
+def test_happy_path_issues_session_cookie(client):
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw-refresh-token", "tok-id", _FUTURE)),
+        ),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert "__session" in resp.cookies
+
+
+def test_rejects_unverified_email(client):
+    unverified = {**HAPPY_CLAIMS, "email_verified": False}
+    with patch(
+        "app.auth.router.verify_google_id_token",
+        AsyncMock(return_value=unverified),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token"},
+        )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "invalid_id_token"
+
+
+def test_verify_failure_surfaces_401(client):
+    from fastapi import HTTPException
+
+    with patch(
+        "app.auth.router.verify_google_id_token",
+        AsyncMock(side_effect=HTTPException(401, detail="invalid_id_token")),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "bad.token"},
+        )
+    assert resp.status_code == 401
+
+
+def test_source_field_accepted(client):
+    """source is an optional telemetry hint — request must succeed."""
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw", "id", _FUTURE)),
+        ),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token", "source": "fedcm"},
+        )
+    assert resp.status_code == 200
+
+
+def test_rate_limit_6th_request_is_throttled(client):
+    """SlowAPI 5/minute keyed on client IP.
+
+    ``set_auth_cookies`` is suppressed so every request is keyed on the
+    test-client IP (no __session cookie is attached between calls).
+    Without this, the first successful request sets a cookie carrying a
+    real access JWT, subsequent requests are keyed per user_id instead
+    of per-IP, and the effective limit doubles across the two key spaces.
+    """
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw", "id", _FUTURE)),
+        ),
+        patch("app.auth.router.set_auth_cookies"),
+    ):
+        responses = [
+            client.post(
+                "/auth/google-id-token",
+                json={"id_token": f"token-{i}"},
+            )
+            for i in range(6)
+        ]
+    assert [r.status_code for r in responses[:5]] == [200, 200, 200, 200, 200]
+    assert responses[5].status_code == 429

--- a/backend/tests/unit/test_google_id_token_router.py
+++ b/backend/tests/unit/test_google_id_token_router.py
@@ -18,6 +18,8 @@ def client():
     return TestClient(app)
 
 
+# iss/aud are present for realism — verify_google_id_token is mocked,
+# so they're never actually validated by these tests.
 HAPPY_CLAIMS = {
     "sub": "google-sub-abc",
     "email": "alice@example.com",
@@ -102,6 +104,7 @@ def test_source_field_accepted(client):
             json={"id_token": "fake.jwt.token", "source": "fedcm"},
         )
     assert resp.status_code == 200
+    assert resp.json()["source"] == "id_token"
 
 
 def test_rate_limit_6th_request_is_throttled(client):

--- a/backend/tests/unit/test_verify_google_id_token.py
+++ b/backend/tests/unit/test_verify_google_id_token.py
@@ -1,0 +1,86 @@
+"""Unit tests for verify_google_id_token."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from google.auth.exceptions import TransportError
+
+from app.auth.service import verify_google_id_token
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_claims():
+    fake_claims = {
+        "sub": "google-sub-123",
+        "email": "alice@example.com",
+        "email_verified": True,
+        "name": "Alice",
+        "picture": "https://example.com/a.png",
+        "iss": "https://accounts.google.com",
+        "aud": "test-client-id",
+    }
+    with (
+        patch("app.auth.service.settings") as mock_settings,
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            return_value=fake_claims,
+        ),
+    ):
+        mock_settings.google_client_id = "test-client-id"
+        claims = await verify_google_id_token("fake.jwt.token")
+    assert claims["sub"] == "google-sub-123"
+    assert claims["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_raises_401():
+    with (
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            side_effect=ValueError("invalid signature"),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await verify_google_id_token("bad.token")
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid_id_token"
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_raises_401():
+    fake_claims = {
+        "sub": "x",
+        "email": "x@x.com",
+        "email_verified": True,
+        "iss": "https://evil.example.com",  # not Google
+        "aud": "test-client-id",
+    }
+    with (
+        patch("app.auth.service.settings") as mock_settings,
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            return_value=fake_claims,
+        ),
+    ):
+        mock_settings.google_client_id = "test-client-id"
+        with pytest.raises(HTTPException) as exc:
+            await verify_google_id_token("fake.jwt.token")
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid_id_token"
+
+
+@pytest.mark.asyncio
+async def test_jwks_transport_error_raises_503():
+    with (
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            side_effect=TransportError("jwks fetch failed"),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await verify_google_id_token("fake.jwt.token")
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "verify_unavailable"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
@@ -1515,6 +1515,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fpdf2" },
+    { name = "google-auth" },
     { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "google-genai" },
@@ -1550,6 +1551,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
+    { name = "google-auth", specifier = ">=2.30.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
     { name = "google-cloud-tasks", specifier = ">=2.16.0" },
     { name = "google-genai", specifier = ">=1.0.0" },

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,21 @@ Admin endpoints additionally require `is_admin = true` on the Person node (retur
 | POST | `/auth/api-keys` | JWT | Create MCP API key (returns raw key once; server stores SHA-256 hash). Keys use `orbk_` prefix. |
 | GET | `/auth/api-keys` | JWT | List user's API keys (metadata only — `key_id`, `label`, `created_at`, `last_used_at`) |
 | DELETE | `/auth/api-keys/{key_id}` | JWT | Revoke an API key |
+| POST | `/auth/google-id-token` | No | Silent re-auth: accept a Google-issued ID token (FedCM or GIS One Tap) and issue a new `__session` cookie. Rate-limited 5/min per IP. |
+
+### `POST /auth/google-id-token`
+
+Accept a Google-issued ID token (from frontend FedCM or GIS One Tap)
+and issue the same `__session` cookie as `/auth/google`. Used by the
+silent re-auth flow — not for interactive sign-in.
+
+**Body:** `{ id_token: string, source?: "fedcm" | "onetap" }`
+
+**Responses:**
+- `200 { status: "ok", source: "id_token" }` + `Set-Cookie: __session=...`
+- `401 { detail: "invalid_id_token" }` — signature / audience / expiry / issuer / `email_verified=false`
+- `503 { detail: "verify_unavailable" }` — Google JWKS transient failure
+- `429` — rate limit (5/min per IP)
 
 ## Admin (`/admin`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,13 @@ The heal step exists because older sessions could allow `POST /cv/confirm` to ov
 
 JWT validation on protected endpoints via `HTTPBearer` scheme. Refresh tokens support token rotation — each refresh revokes the old token and issues a new pair. In production, the refresh token cookie uses `SameSite=None; Secure` and is scoped to `path=/`.
 
+**Silent re-auth.** When `/auth/refresh` fails and the user originally
+signed in with Google, the frontend (`src/auth/silentReauth.ts`) calls
+FedCM (Chrome/Firefox) or GIS One Tap (Safari) to obtain a fresh Google
+ID token, POSTs it to `/auth/google-id-token`, and receives a new
+`__session` cookie. LinkedIn users and users signed out of Google
+fall back to the explicit sign-in landing page.
+
 ### Encryption
 
 Fernet symmetric encryption for PII fields (`email`, `phone`, `address`). Key from `ENCRYPTION_KEY` env var; auto-generated in dev mode if missing (data won't survive restarts).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -250,6 +250,7 @@ If any of the above goes wrong mid-flight, rolling back is always "put the old k
 | `CLAUDE_MODEL` | `claude-opus-4-6` | Claude model for CV extraction |
 | `GOOGLE_CLIENT_ID` | — | Google OAuth (not yet active) |
 | `GOOGLE_CLIENT_SECRET` | — | Google OAuth (not yet active) |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `365` | Refresh token lifetime in days. Default raised to 365 to support the persistent-login / silent re-auth flow. |
 
 ### OAuth 2.1 authorization server
 
@@ -325,3 +326,10 @@ npm run preview  # Preview the built app
 ```
 
 The production build (`tsc -b && vite build`) type-checks and bundles to `frontend/dist/`. Serve with any static file server; configure it to proxy `/api/*` requests to the backend.
+
+### Frontend build-time variables (`VITE_*`)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VITE_API_URL` | `/api` | Backend base URL (full Cloud Run URL in production if not proxied) |
+| `VITE_SILENT_REAUTH_ENABLED` | `true` | `false` disables the FedCM + One Tap silent re-auth path. Emergency switch; default on. |

--- a/docs/superpowers/plans/2026-04-22-persistent-login.md
+++ b/docs/superpowers/plans/2026-04-22-persistent-login.md
@@ -1,0 +1,1416 @@
+# Persistent Login (Silent Re-Auth) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Orbis feel "never-logout" by silently re-establishing the user's session via Google FedCM (Chrome/Firefox) or GIS One Tap (Safari) when the refresh cookie is gone. Closes #406.
+
+**Architecture:** One new backend endpoint (`POST /auth/google-id-token`) that verifies a Google ID token and mints the normal `__session` cookie. One new frontend module (`silentReauth.ts`) invoked from the axios 401 handler between the refresh attempt and the `session-expired` dispatch. Refresh TTL bumped 30d → 365d. LinkedIn users and fully-signed-out users gracefully fall back to the existing landing-page sign-in (no regression).
+
+**Tech Stack:** FastAPI + `google-auth` library (backend); React 19 + vanilla `navigator.credentials` FedCM API + GIS (`https://accounts.google.com/gsi/client`) on the frontend.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-persistent-login-silent-reauth-design.md`
+
+---
+
+## Task 1: Add `google-auth` dependency + `verify_google_id_token` helper
+
+**Files:**
+- Modify: `backend/pyproject.toml`
+- Modify: `backend/app/auth/service.py`
+- Create: `backend/tests/unit/test_verify_google_id_token.py`
+
+- [ ] **Step 1: Add the dep**
+
+Open `backend/pyproject.toml` and add `google-auth` to the `dependencies` list (alphabetical):
+
+```toml
+    "google-auth>=2.30.0",
+```
+
+Run:
+
+```bash
+cd backend && uv sync --all-extras
+```
+
+Expected: installs `google-auth` and its transitive deps (`rsa`, `pyasn1-modules`, `cachetools`).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/tests/unit/test_verify_google_id_token.py`:
+
+```python
+"""Unit tests for verify_google_id_token."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from google.auth.exceptions import TransportError
+
+from app.auth.service import verify_google_id_token
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_claims():
+    fake_claims = {
+        "sub": "google-sub-123",
+        "email": "alice@example.com",
+        "email_verified": True,
+        "name": "Alice",
+        "picture": "https://example.com/a.png",
+        "iss": "https://accounts.google.com",
+        "aud": "test-client-id",
+    }
+    with (
+        patch("app.auth.service.settings") as mock_settings,
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            return_value=fake_claims,
+        ),
+    ):
+        mock_settings.google_client_id = "test-client-id"
+        claims = await verify_google_id_token("fake.jwt.token")
+    assert claims["sub"] == "google-sub-123"
+    assert claims["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_raises_401():
+    with patch(
+        "app.auth.service.google_id_token.verify_oauth2_token",
+        side_effect=ValueError("invalid signature"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await verify_google_id_token("bad.token")
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid_id_token"
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_raises_401():
+    fake_claims = {
+        "sub": "x",
+        "email": "x@x.com",
+        "email_verified": True,
+        "iss": "https://evil.example.com",  # not Google
+        "aud": "test-client-id",
+    }
+    with (
+        patch("app.auth.service.settings") as mock_settings,
+        patch(
+            "app.auth.service.google_id_token.verify_oauth2_token",
+            return_value=fake_claims,
+        ),
+    ):
+        mock_settings.google_client_id = "test-client-id"
+        with pytest.raises(HTTPException) as exc:
+            await verify_google_id_token("fake.jwt.token")
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid_id_token"
+
+
+@pytest.mark.asyncio
+async def test_jwks_transport_error_raises_503():
+    with patch(
+        "app.auth.service.google_id_token.verify_oauth2_token",
+        side_effect=TransportError("jwks fetch failed"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await verify_google_id_token("fake.jwt.token")
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "verify_unavailable"
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+```bash
+cd backend && uv run pytest tests/unit/test_verify_google_id_token.py -v
+```
+
+Expected: fails because `verify_google_id_token` does not exist yet.
+
+- [ ] **Step 4: Implement the helper**
+
+Open `backend/app/auth/service.py`. At the top, add:
+
+```python
+import asyncio
+
+from google.auth import exceptions as google_auth_exceptions
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token as google_id_token
+from fastapi import HTTPException
+```
+
+At the bottom of the file, add:
+
+```python
+_GOOGLE_ISSUERS = {"accounts.google.com", "https://accounts.google.com"}
+
+
+async def verify_google_id_token(raw: str) -> dict:
+    """Verify a Google-issued ID token and return its claims.
+
+    Raises HTTPException(401, 'invalid_id_token') on any validation
+    failure (signature, audience, expiry, issuer, malformed). Raises
+    HTTPException(503, 'verify_unavailable') if Google's JWKS endpoint
+    is transiently unreachable — the frontend can retry on the next
+    page load rather than being forced back to the sign-in page.
+    """
+    try:
+        # google-auth is synchronous and fetches JWKS over the network;
+        # run it off the event loop to avoid blocking other requests.
+        claims = await asyncio.to_thread(
+            google_id_token.verify_oauth2_token,
+            raw,
+            google_requests.Request(),
+            settings.google_client_id,
+        )
+    except google_auth_exceptions.TransportError as exc:
+        logger.warning("google_id_token: JWKS fetch failed: %s", exc)
+        raise HTTPException(status_code=503, detail="verify_unavailable") from exc
+    except ValueError:
+        # verify_oauth2_token raises ValueError for every validation failure;
+        # do not leak which one to the caller.
+        raise HTTPException(status_code=401, detail="invalid_id_token") from None
+
+    if claims.get("iss") not in _GOOGLE_ISSUERS:
+        raise HTTPException(status_code=401, detail="invalid_id_token")
+    return claims
+```
+
+- [ ] **Step 5: Run test to verify pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_verify_google_id_token.py -v
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/pyproject.toml backend/uv.lock backend/app/auth/service.py backend/tests/unit/test_verify_google_id_token.py
+git commit -m "feat(auth): verify_google_id_token helper + google-auth dep"
+```
+
+---
+
+## Task 2: Bump refresh-token TTL default 30d → 365d
+
+**Files:**
+- Modify: `backend/app/config.py:30`
+- Modify: `backend/tests/unit/test_config.py` (create if missing)
+
+- [ ] **Step 1: Write failing test**
+
+Create or extend `backend/tests/unit/test_config.py` with:
+
+```python
+from app.config import settings
+
+
+def test_refresh_token_ttl_default_is_one_year():
+    """Defaults to 365 days so refresh cookies don't force monthly re-sign-in.
+
+    Sliding window already in place in /auth/refresh; this is the absolute
+    cap for genuinely dormant sessions.
+    """
+    assert settings.refresh_token_expire_days == 365
+```
+
+Run:
+
+```bash
+cd backend && uv run pytest tests/unit/test_config.py::test_refresh_token_ttl_default_is_one_year -v
+```
+
+Expected: fails, default is 30.
+
+- [ ] **Step 2: Update config**
+
+`backend/app/config.py:30`:
+
+```python
+    refresh_token_expire_days: int = 365
+```
+
+- [ ] **Step 3: Run test to verify pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_config.py::test_refresh_token_ttl_default_is_one_year -v
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/config.py backend/tests/unit/test_config.py
+git commit -m "feat(auth): extend refresh-token TTL default to 365 days
+
+Sliding window already in /auth/refresh, so daily-active users were
+already evergreen — but the hard 30-day cap forced users who visit
+less often to re-sign-in. 365 days matches consumer-app norms and is
+well within Safari's HTTP-set-cookie absolute cap."
+```
+
+---
+
+## Task 3: `POST /auth/google-id-token` endpoint
+
+**Files:**
+- Modify: `backend/app/auth/router.py`
+- Create: `backend/tests/unit/test_google_id_token_router.py`
+
+- [ ] **Step 1: Inspect the existing Google flow**
+
+Read `backend/app/auth/router.py` around the `/google` endpoint. Identify the Person-upsert helper (it will be either `_upsert_google_person` or inline in the handler). The new endpoint reuses the same upsert logic.
+
+- [ ] **Step 2: Write the happy-path failing test**
+
+Create `backend/tests/unit/test_google_id_token_router.py`:
+
+```python
+"""Unit tests for POST /auth/google-id-token."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+HAPPY_CLAIMS = {
+    "sub": "google-sub-abc",
+    "email": "alice@example.com",
+    "email_verified": True,
+    "name": "Alice Smith",
+    "picture": "https://example.com/a.png",
+    "iss": "https://accounts.google.com",
+    "aud": "test-client-id",
+}
+
+
+def test_happy_path_issues_session_cookie(client):
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw-refresh-token", "tok-id", __import__("datetime").datetime(2027, 4, 22))),
+        ),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert "__session" in resp.cookies
+
+
+def test_rejects_unverified_email(client):
+    unverified = {**HAPPY_CLAIMS, "email_verified": False}
+    with patch(
+        "app.auth.router.verify_google_id_token",
+        AsyncMock(return_value=unverified),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token"},
+        )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "invalid_id_token"
+
+
+def test_verify_failure_surfaces_401(client):
+    from fastapi import HTTPException
+
+    with patch(
+        "app.auth.router.verify_google_id_token",
+        AsyncMock(side_effect=HTTPException(401, detail="invalid_id_token")),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "bad.token"},
+        )
+    assert resp.status_code == 401
+
+
+def test_source_field_accepted(client):
+    """source is an optional telemetry hint — request must succeed."""
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw", "id", __import__("datetime").datetime(2027, 4, 22))),
+        ),
+    ):
+        resp = client.post(
+            "/auth/google-id-token",
+            json={"id_token": "fake.jwt.token", "source": "fedcm"},
+        )
+    assert resp.status_code == 200
+
+
+def test_rate_limit_6th_request_is_throttled(client):
+    """SlowAPI 5/minute keyed on client IP."""
+    with (
+        patch(
+            "app.auth.router.verify_google_id_token",
+            AsyncMock(return_value=HAPPY_CLAIMS),
+        ),
+        patch(
+            "app.auth.router._upsert_google_person",
+            AsyncMock(return_value={"user_id": "u-1", "email": "alice@example.com"}),
+        ),
+        patch(
+            "app.auth.router.issue_refresh_token",
+            AsyncMock(return_value=("raw", "id", __import__("datetime").datetime(2027, 4, 22))),
+        ),
+    ):
+        responses = [
+            client.post(
+                "/auth/google-id-token",
+                json={"id_token": f"token-{i}"},
+            )
+            for i in range(6)
+        ]
+    # First 5 succeed, 6th is throttled.
+    assert [r.status_code for r in responses[:5]] == [200, 200, 200, 200, 200]
+    assert responses[5].status_code == 429
+```
+
+Run:
+
+```bash
+cd backend && uv run pytest tests/unit/test_google_id_token_router.py -v
+```
+
+Expected: fails — endpoint doesn't exist.
+
+- [ ] **Step 3: Add the Pydantic request model**
+
+In `backend/app/auth/router.py`, near the other Pydantic models (search for existing `class` definitions ending with `Request` or similar), add:
+
+```python
+from typing import Literal
+
+
+class GoogleIdTokenRequest(BaseModel):
+    id_token: str
+    source: Literal["fedcm", "onetap"] | None = None  # telemetry hint
+```
+
+- [ ] **Step 4: Implement the endpoint**
+
+Add to `backend/app/auth/router.py`, near the existing `/google` endpoint:
+
+```python
+from app.auth.service import verify_google_id_token
+
+
+@router.post("/google-id-token")
+@limiter.limit("5/minute")
+async def google_id_token_login(
+    request: Request,
+    response: Response,
+    body: GoogleIdTokenRequest,
+    db: AsyncDriver = Depends(get_db),
+):
+    """Verify a Google ID token and mint an Orbis session cookie.
+
+    Called by the frontend silent-re-auth flow (FedCM or GIS One Tap),
+    which already has a Google-signed JWT in hand and just needs Orbis
+    to trust it in lieu of re-running the authorization-code dance.
+    """
+    claims = await verify_google_id_token(body.id_token)
+    if not claims.get("email_verified"):
+        raise HTTPException(status_code=401, detail="invalid_id_token")
+
+    user = await _upsert_google_person(db, claims)
+
+    raw, _token_id, expires_at = await issue_refresh_token(
+        db,
+        user_id=user["user_id"],
+        ttl_days=settings.refresh_token_expire_days,
+        user_agent=request.headers.get("user-agent", ""),
+    )
+    access = create_jwt(user["user_id"], user["email"])
+    set_auth_cookies(
+        response,
+        access_token=access,
+        refresh_raw=raw,
+        refresh_expires_at=expires_at,
+    )
+    logger.info(
+        "auth: id-token login user=%s source=%s",
+        user["user_id"],
+        body.source or "unknown",
+    )
+    return {"status": "ok", "source": "id_token"}
+```
+
+If `_upsert_google_person` does not exist as a named helper today (the logic may be inline in the `/google` handler), extract it before implementing. Sketch:
+
+```python
+async def _upsert_google_person(db: AsyncDriver, claims: dict) -> dict:
+    # Move the existing /google Person upsert block here verbatim.
+    # Return {"user_id": ..., "email": ...}.
+    ...
+```
+
+Then have the existing `/google` handler call this helper so the two endpoints stay in lock-step forever.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_google_id_token_router.py -v
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 6: Rerun full auth test suite as a regression check**
+
+```bash
+cd backend && uv run pytest tests/unit/ -k auth -v
+```
+
+Expected: no failures — the refactor of `_upsert_google_person` should leave `/google` behavior identical.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/auth/router.py backend/tests/unit/test_google_id_token_router.py
+git commit -m "feat(auth): POST /auth/google-id-token for silent re-auth
+
+Verifies a Google-issued ID token (from FedCM or GIS One Tap on the
+frontend) and issues the same __session cookie /auth/google produces.
+Shares the Person upsert with /auth/google via a new private helper
+so the two login paths can never drift.
+
+Rate-limited 5/min per IP."
+```
+
+---
+
+## Task 4: Frontend `silentReauth.ts` — FedCM path
+
+**Files:**
+- Create: `frontend/src/auth/silentReauth.ts`
+- Create: `frontend/src/auth/silentReauth.test.ts`
+- Modify: `frontend/src/api/auth.ts` (add the `/auth/google-id-token` helper)
+
+- [ ] **Step 1: Add the API helper**
+
+In `frontend/src/api/auth.ts`, add at the bottom:
+
+```ts
+export async function googleIdTokenLogin(
+  idToken: string,
+  source: 'fedcm' | 'onetap',
+): Promise<void> {
+  await client.post('/auth/google-id-token', { id_token: idToken, source });
+}
+```
+
+- [ ] **Step 2: Write the failing test (FedCM happy path)**
+
+Create `frontend/src/auth/silentReauth.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api/auth', () => ({
+  googleIdTokenLogin: vi.fn(),
+}));
+
+import { trySilentReauth } from './silentReauth';
+import { googleIdTokenLogin } from '../api/auth';
+
+function stubFedCM(idToken: string | null) {
+  const fakeCredential = idToken ? { token: idToken } : null;
+  // jsdom does not implement the Credential Management API
+  (globalThis as any).navigator.credentials = {
+    get: vi.fn().mockResolvedValue(fakeCredential),
+  };
+  (globalThis as any).IdentityCredential = class {};
+}
+
+function unstubFedCM() {
+  delete (globalThis as any).navigator.credentials;
+  delete (globalThis as any).IdentityCredential;
+}
+
+describe('trySilentReauth — FedCM path', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('returns true when FedCM returns an ID token and backend accepts it', async () => {
+    stubFedCM('google.id.token');
+    (googleIdTokenLogin as any).mockResolvedValue(undefined);
+
+    const ok = await trySilentReauth();
+    expect(ok).toBe(true);
+    expect(googleIdTokenLogin).toHaveBeenCalledWith('google.id.token', 'fedcm');
+    unstubFedCM();
+  });
+
+  it('returns false when FedCM resolves with null (user dismissed)', async () => {
+    stubFedCM(null);
+    const ok = await trySilentReauth();
+    // FedCM failure falls through to One Tap which is unavailable in jsdom,
+    // so end state is false. Covered in Task 5 once One Tap is wired in.
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+    unstubFedCM();
+  });
+});
+```
+
+Run:
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: fails — module does not exist.
+
+- [ ] **Step 3: Implement FedCM-only module**
+
+Create `frontend/src/auth/silentReauth.ts`:
+
+```ts
+import { googleIdTokenLogin } from '../api/auth';
+
+const JUST_LOGGED_OUT_KEY = 'orbis.just_logged_out';
+
+let inFlight: Promise<boolean> | null = null;
+
+export async function trySilentReauth(): Promise<boolean> {
+  if (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(JUST_LOGGED_OUT_KEY)) {
+    return false;
+  }
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const idToken = await runFedCM();
+      if (!idToken) return false;
+      await googleIdTokenLogin(idToken, 'fedcm');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+async function runFedCM(): Promise<string | null> {
+  if (typeof window === 'undefined') return null;
+  if (!('IdentityCredential' in window)) return null;
+  if (!navigator.credentials) return null;
+
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) return null;
+
+  try {
+    const credential = await (navigator.credentials.get as any)({
+      identity: {
+        providers: [
+          {
+            configURL: 'https://accounts.google.com/gsi/fedcm.json',
+            clientId,
+          },
+        ],
+      },
+      mediation: 'optional',
+    });
+    return (credential as any)?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+```
+
+Export the session-storage key so the authStore can use it:
+
+```ts
+export const SILENT_REAUTH_JUST_LOGGED_OUT_KEY = JUST_LOGGED_OUT_KEY;
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: 2/2 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/auth/silentReauth.ts frontend/src/auth/silentReauth.test.ts frontend/src/api/auth.ts
+git commit -m "feat(auth): silentReauth module with FedCM path
+
+Step 1 of silent re-establishment of the Orbis session when the
+refresh cookie is gone. Chrome/Firefox users who are signed into
+Google via the same browser profile will now skip the sign-in
+screen entirely. One Tap fallback for other browsers follows in
+the next commit."
+```
+
+---
+
+## Task 5: Frontend `silentReauth` — One Tap fallback
+
+**Files:**
+- Modify: `frontend/src/auth/silentReauth.ts`
+- Modify: `frontend/src/auth/silentReauth.test.ts`
+
+- [ ] **Step 1: Write failing test for fallback order**
+
+Append to `frontend/src/auth/silentReauth.test.ts`:
+
+```ts
+describe('trySilentReauth — One Tap fallback', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('falls back to One Tap when FedCM resolves with null', async () => {
+    stubFedCM(null);
+    // Simulate GIS being available and firing the callback with an ID token.
+    const originalGoogle = (globalThis as any).google;
+    (globalThis as any).google = {
+      accounts: {
+        id: {
+          initialize: vi.fn((opts: any) => {
+            // Fire the callback asynchronously as the real GIS lib does.
+            setTimeout(() => opts.callback({ credential: 'onetap.id.token' }), 0);
+          }),
+          prompt: vi.fn(),
+        },
+      },
+    };
+    (googleIdTokenLogin as any).mockResolvedValue(undefined);
+
+    const ok = await trySilentReauth();
+    expect(ok).toBe(true);
+    expect(googleIdTokenLogin).toHaveBeenCalledWith('onetap.id.token', 'onetap');
+
+    (globalThis as any).google = originalGoogle;
+    unstubFedCM();
+  });
+
+  it('returns false when neither FedCM nor One Tap produce a token', async () => {
+    stubFedCM(null);
+    const originalGoogle = (globalThis as any).google;
+    (globalThis as any).google = {
+      accounts: {
+        id: {
+          initialize: vi.fn((opts: any) => {
+            // Never call the callback — simulates user dismissal / rate limit.
+          }),
+          prompt: vi.fn((notification: (n: any) => void) => {
+            setTimeout(() => notification({ isNotDisplayed: () => true }), 0);
+          }),
+        },
+      },
+    };
+
+    const ok = await trySilentReauth();
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+
+    (globalThis as any).google = originalGoogle;
+    unstubFedCM();
+  });
+});
+```
+
+Run to confirm failure:
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: 2 new tests fail.
+
+- [ ] **Step 2: Add One Tap fallback in `silentReauth.ts`**
+
+Extend the `inFlight` body:
+
+```ts
+  inFlight = (async () => {
+    try {
+      let source: 'fedcm' | 'onetap' = 'fedcm';
+      let idToken = await runFedCM();
+      if (!idToken) {
+        idToken = await runOneTap();
+        source = 'onetap';
+      }
+      if (!idToken) return false;
+      await googleIdTokenLogin(idToken, source);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+```
+
+Add `runOneTap()` at the bottom:
+
+```ts
+const GIS_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+let gisScriptLoading: Promise<void> | null = null;
+
+function loadGis(): Promise<void> {
+  if ((globalThis as any).google?.accounts?.id) return Promise.resolve();
+  if (gisScriptLoading) return gisScriptLoading;
+  gisScriptLoading = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = GIS_SCRIPT_SRC;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('gis_load_failed'));
+    document.head.appendChild(s);
+  });
+  return gisScriptLoading;
+}
+
+async function runOneTap(): Promise<string | null> {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) return null;
+
+  try {
+    await loadGis();
+  } catch {
+    return null;
+  }
+
+  const gis = (globalThis as any).google?.accounts?.id;
+  if (!gis) return null;
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    gis.initialize({
+      client_id: clientId,
+      auto_select: true,
+      callback: (response: { credential?: string }) => {
+        finish(response?.credential ?? null);
+      },
+    });
+    gis.prompt((notification: any) => {
+      if (notification?.isNotDisplayed?.() || notification?.isSkippedMoment?.()) {
+        finish(null);
+      }
+    });
+    // Safety timeout — One Tap can stall silently on some browsers.
+    setTimeout(() => finish(null), 4000);
+  });
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/auth/silentReauth.ts frontend/src/auth/silentReauth.test.ts
+git commit -m "feat(auth): One Tap fallback for Safari / FedCM-unavailable
+
+When FedCM is unsupported or returns no credential, fall through to
+Google Identity Services' One Tap. Loads GIS lazily on first use,
+auto-select mode on, 4-second safety timeout in case the prompt
+stalls silently."
+```
+
+---
+
+## Task 6: Sign-out-respect hook
+
+**Files:**
+- Modify: `frontend/src/stores/authStore.ts`
+- Modify: `frontend/src/auth/silentReauth.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `silentReauth.test.ts`:
+
+```ts
+it('short-circuits when orbis.just_logged_out is set', async () => {
+  sessionStorage.setItem('orbis.just_logged_out', '1');
+  stubFedCM('should.not.be.used');
+  const ok = await trySilentReauth();
+  expect(ok).toBe(false);
+  expect(googleIdTokenLogin).not.toHaveBeenCalled();
+  unstubFedCM();
+});
+```
+
+Run:
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: passes (already implemented in Task 4). Kept as a regression fence.
+
+- [ ] **Step 2: Hook into authStore.logout() and clear on successful login**
+
+In `frontend/src/stores/authStore.ts`, modify the `logout` action and both login paths:
+
+```ts
+  loginGoogle: async (code: string) => {
+    set({ loading: true });
+    try {
+      const { user } = await googleLogin(code);
+      // A successful explicit sign-in clears any stale "just_logged_out"
+      // sentinel from an earlier logout in the same tab — otherwise a
+      // subsequent silent re-auth after session expiry would be blocked.
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem('orbis.just_logged_out');
+      }
+      set({ user, loading: false });
+    } catch {
+      set({ loading: false });
+      throw new Error('Google login failed');
+    }
+  },
+
+  loginLinkedIn: async (code: string) => {
+    set({ loading: true });
+    try {
+      const { user } = await linkedinLogin(code);
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem('orbis.just_logged_out');
+      }
+      set({ user, loading: false });
+    } catch {
+      set({ loading: false });
+      throw new Error('LinkedIn login failed');
+    }
+  },
+
+  logout: async () => {
+    try {
+      await logoutBackend();
+    } catch {
+      // Even if the server call fails we still clear client state so the
+      // user is not stuck with a half-logged-in UI.
+    }
+    // Tell silent re-auth not to instantly re-establish the session we
+    // just explicitly tore down. Cleared on next successful login, or
+    // when the tab closes.
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('orbis.just_logged_out', '1');
+    }
+    set({ user: null, loading: false });
+  },
+```
+
+- [ ] **Step 3: Verify no existing auth tests broke**
+
+```bash
+cd frontend && npx vitest run src/stores/ src/auth/
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/stores/authStore.ts frontend/src/auth/silentReauth.test.ts
+git commit -m "feat(auth): honor explicit logout in silent re-auth
+
+Setting sessionStorage['orbis.just_logged_out'] on logout prevents
+silentReauth from instantly re-establishing the session the user
+just explicitly tore down. Cleared naturally when the tab closes,
+which matches the 'tab-scoped intent to stay signed out' we want."
+```
+
+---
+
+## Task 7: Axios interceptor integration + loop guard
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Create: `frontend/src/api/client.test.ts` (if not present)
+
+- [ ] **Step 1: Write failing test**
+
+Create `frontend/src/api/client.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+import client from './client';
+
+vi.mock('../auth/silentReauth', () => ({
+  trySilentReauth: vi.fn(),
+}));
+
+import { trySilentReauth } from '../auth/silentReauth';
+
+describe('axios interceptor — silent re-auth integration', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(client);
+    vi.resetAllMocks();
+  });
+
+  it('401 + refresh-fail + silent-success → retries and succeeds', async () => {
+    let call = 0;
+    mock.onGet('/foo').reply(() => {
+      call += 1;
+      return call === 1 ? [401, {}] : [200, { ok: true }];
+    });
+    mock.onPost('/auth/refresh').reply(401);
+    (trySilentReauth as any).mockResolvedValue(true);
+
+    const res = await client.get('/foo');
+    expect(res.data).toEqual({ ok: true });
+    expect(trySilentReauth).toHaveBeenCalledOnce();
+  });
+
+  it('401 + refresh-fail + silent-fail → dispatches session-expired', async () => {
+    mock.onGet('/foo').reply(401);
+    mock.onPost('/auth/refresh').reply(401);
+    (trySilentReauth as any).mockResolvedValue(false);
+
+    const handler = vi.fn();
+    window.addEventListener('orbis:session-expired', handler);
+    await expect(client.get('/foo')).rejects.toThrow();
+    expect(handler).toHaveBeenCalledOnce();
+    window.removeEventListener('orbis:session-expired', handler);
+  });
+
+  it('loop guard: silent re-auth only tried once per request', async () => {
+    mock.onGet('/foo').reply(401);
+    mock.onPost('/auth/refresh').reply(401);
+    (trySilentReauth as any).mockResolvedValue(true);
+    // After silent succeeds, retry still fails — we must NOT try silent again.
+    await expect(client.get('/foo')).rejects.toThrow();
+    expect(trySilentReauth).toHaveBeenCalledOnce();
+  });
+});
+```
+
+Install `axios-mock-adapter` if not already present:
+
+```bash
+cd frontend && npm i -D axios-mock-adapter
+```
+
+Run:
+
+```bash
+cd frontend && npx vitest run src/api/client.test.ts
+```
+
+Expected: fails — interceptor doesn't call trySilentReauth.
+
+- [ ] **Step 2: Implement the hook**
+
+In `frontend/src/api/client.ts`, extend the response interceptor. Current pseudo-structure:
+
+```ts
+// After refresh attempt, if still 401:
+//   dispatch session-expired
+//   reject
+```
+
+New structure:
+
+```ts
+// After refresh attempt, if still 401:
+//   if (!original._triedSilentReauth) {
+//     original._triedSilentReauth = true;
+//     const ok = await trySilentReauth();
+//     if (ok) return client.request(original);
+//   }
+//   dispatch session-expired
+//   reject
+```
+
+Specifically, find the block that currently dispatches `orbis:session-expired`. Before it, add:
+
+```ts
+import { trySilentReauth } from '../auth/silentReauth';
+
+interface RetryableConfig extends InternalAxiosRequestConfig {
+  _retriedAfterRefresh?: boolean;
+  _triedSilentReauth?: boolean;
+}
+```
+
+And in the interceptor, at the point where refresh has failed:
+
+```ts
+if (!original._triedSilentReauth) {
+  original._triedSilentReauth = true;
+  const silentOk = await trySilentReauth();
+  if (silentOk) {
+    return client.request(original);
+  }
+}
+window.dispatchEvent(new CustomEvent('orbis:session-expired'));
+return Promise.reject(refreshError);
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd frontend && npx vitest run src/api/client.test.ts
+```
+
+Expected: all 3 pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/api/client.test.ts frontend/package.json frontend/package-lock.json
+git commit -m "feat(auth): wire silent re-auth into axios 401 handler
+
+Between refresh-fail and session-expired dispatch, try silentReauth.
+On success, retry the original request transparently. On failure,
+fall through to the existing landing-page redirect. Loop guard
+(_triedSilentReauth) ensures a stuck silent-success-then-still-401
+scenario doesn't fire silent re-auth repeatedly."
+```
+
+---
+
+## Task 8: Refresh-race pre-emptive retry
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/api/client.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `client.test.ts`:
+
+```ts
+describe('axios interceptor — refresh race', () => {
+  let mock: MockAdapter;
+  beforeEach(() => {
+    mock = new MockAdapter(client);
+    vi.resetAllMocks();
+  });
+
+  it('retries original request when another tab rotated the cookie <500ms ago', async () => {
+    // Tab B "just refreshed" in the background — simulated by calling
+    // /auth/refresh successfully right before tab A's burst.
+    mock.onPost('/auth/refresh').replyOnce(200);
+    let call = 0;
+    mock.onGet('/foo').reply(() => {
+      call += 1;
+      return call === 1 ? [401, {}] : [200, { ok: true }];
+    });
+
+    // Prime the success marker by performing one refresh.
+    await client.post('/auth/refresh');
+
+    // Second refresh (from our 401 flow) fails because the token was
+    // already rotated. But because the success marker is <500ms old,
+    // the interceptor should retry the original request once anyway.
+    mock.onPost('/auth/refresh').replyOnce(401);
+
+    const res = await client.get('/foo');
+    expect(res.data).toEqual({ ok: true });
+  });
+});
+```
+
+Expected: fails — behavior not implemented.
+
+- [ ] **Step 2: Implement race fix**
+
+In `client.ts`, add:
+
+```ts
+let lastSuccessfulRefreshAt = 0;
+const REFRESH_RACE_WINDOW_MS = 500;
+
+async function refreshSession(): Promise<void> {
+  await axios.post(`${API_BASE}/auth/refresh`, undefined, { withCredentials: true });
+  lastSuccessfulRefreshAt = Date.now();
+}
+```
+
+And in the 401 handler, before the silent-re-auth attempt:
+
+```ts
+if (Date.now() - lastSuccessfulRefreshAt < REFRESH_RACE_WINDOW_MS) {
+  return client.request(original);
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd frontend && npx vitest run src/api/client.test.ts
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/api/client.test.ts
+git commit -m "fix(auth): retry original request after cross-tab refresh race
+
+When another tab successfully refreshed within the last 500ms, a
+fresh __session cookie is already on the request even though this
+tab's /auth/refresh call failed. Retry the original request once
+before surfacing failure — prevents spurious family-revocation and
+false session-expired toasts when the user has multiple tabs open."
+```
+
+---
+
+## Task 9: Kill switch — `SILENT_REAUTH_ENABLED` env var
+
+**Files:**
+- Modify: `frontend/src/auth/silentReauth.ts`
+- Modify: `frontend/src/auth/silentReauth.test.ts`
+- Modify: `frontend/src/vite-env.d.ts`
+- Modify: `frontend/.env.example`
+
+- [ ] **Step 1: Add env var declaration**
+
+In `frontend/src/vite-env.d.ts`, add:
+
+```ts
+  readonly VITE_SILENT_REAUTH_ENABLED?: string;
+```
+
+In `frontend/.env.example`, add:
+
+```
+# Set to "false" to disable silent-re-auth (FedCM + One Tap) for emergency
+# rollback. Default behavior is enabled.
+VITE_SILENT_REAUTH_ENABLED=true
+```
+
+- [ ] **Step 2: Write failing test**
+
+Append to `silentReauth.test.ts`:
+
+```ts
+it('short-circuits when VITE_SILENT_REAUTH_ENABLED=false', async () => {
+  vi.stubEnv('VITE_SILENT_REAUTH_ENABLED', 'false');
+  stubFedCM('ignored.token');
+  const ok = await trySilentReauth();
+  expect(ok).toBe(false);
+  expect(googleIdTokenLogin).not.toHaveBeenCalled();
+  vi.unstubAllEnvs();
+  unstubFedCM();
+});
+```
+
+Expected: fails — no check.
+
+- [ ] **Step 3: Implement check**
+
+At the top of `trySilentReauth` body (before the just_logged_out check):
+
+```ts
+  if (import.meta.env.VITE_SILENT_REAUTH_ENABLED === 'false') {
+    return false;
+  }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd frontend && npx vitest run src/auth/silentReauth.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/auth/silentReauth.ts frontend/src/auth/silentReauth.test.ts frontend/src/vite-env.d.ts frontend/.env.example
+git commit -m "feat(auth): VITE_SILENT_REAUTH_ENABLED kill switch
+
+Set to 'false' at build time (CI env / Dockerfile) to disable FedCM
+and One Tap and force the explicit-sign-in path. Default: enabled."
+```
+
+---
+
+## Task 10: Documentation updates
+
+**Files:**
+- Modify: `docs/api.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/deployment.md`
+- Modify: `CLAUDE.md` (rate-limit cheatsheet in `rate_limit.py` comment)
+
+- [ ] **Step 1: Add new endpoint to `docs/api.md`**
+
+Find the `## Auth` section. Add:
+
+```markdown
+### `POST /auth/google-id-token`
+
+Accept a Google-issued ID token (from frontend FedCM or GIS One Tap)
+and issue the same `__session` cookie as `/auth/google`. Used by the
+silent re-auth flow — not for interactive sign-in.
+
+**Body:** `{ id_token: string, source?: "fedcm" | "onetap" }`
+
+**Responses:**
+- `200 { status: "ok", source: "id_token" }` + `Set-Cookie: __session=...`
+- `401 { detail: "invalid_id_token" }` — signature / audience / expiry / issuer / `email_verified=false`
+- `503 { detail: "verify_unavailable" }` — Google JWKS transient failure
+- `429` — rate limit (5/min per IP)
+```
+
+- [ ] **Step 2: Update `docs/architecture.md`**
+
+Find the auth-flow section. Add one paragraph:
+
+```markdown
+**Silent re-auth.** When `/auth/refresh` fails and the user originally
+signed in with Google, the frontend (`src/auth/silentReauth.ts`) calls
+FedCM (Chrome/Firefox) or GIS One Tap (Safari) to obtain a fresh Google
+ID token, POSTs it to `/auth/google-id-token`, and receives a new
+`__session` cookie. LinkedIn users and users signed out of Google
+fall back to the explicit sign-in landing page.
+```
+
+- [ ] **Step 3: Update `docs/deployment.md`**
+
+In the "Frontend build-time variables" table (added in the MCP-OAuth PR), add:
+
+```markdown
+| `VITE_SILENT_REAUTH_ENABLED` | `true` | `false` disables the FedCM + One Tap silent re-auth path. Emergency switch; default on. |
+```
+
+- [ ] **Step 4: Update rate-limit cheatsheet**
+
+In `backend/app/rate_limit.py` top-of-file docstring and in CLAUDE.md's `rate_limit.py` line, add:
+
+```
+- /auth/google-id-token 5/min per IP
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/api.md docs/architecture.md docs/deployment.md backend/app/rate_limit.py CLAUDE.md
+git commit -m "docs: persistent-login silent re-auth
+
+- api.md: POST /auth/google-id-token reference
+- architecture.md: silent re-auth flow summary
+- deployment.md: VITE_SILENT_REAUTH_ENABLED kill switch
+- rate_limit.py + CLAUDE.md: 5/min cap for /auth/google-id-token"
+```
+
+---
+
+## Task 11: Final verification pass
+
+- [ ] **Step 1: Backend full suite**
+
+```bash
+cd backend && uv run pytest tests/unit/ -v --cov=app --cov-fail-under=50
+```
+
+Expected: all unit tests pass, coverage ≥ 50%.
+
+- [ ] **Step 2: Backend lint + format**
+
+```bash
+cd backend && uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Frontend full suite**
+
+```bash
+cd frontend && npx vitest run
+```
+
+Expected: the pre-existing filterStore + e2e failures are the only reds (documented in CLAUDE.md / earlier PRs). All new auth tests green.
+
+- [ ] **Step 4: Frontend lint + build**
+
+```bash
+cd frontend && npm run lint && npm run build
+```
+
+Expected: lint zero errors (warnings OK); build succeeds.
+
+- [ ] **Step 5: Manual smoke (dev server)**
+
+Start the stack:
+
+```bash
+docker compose up -d                    # Neo4j
+cd backend && uv run uvicorn app.main:app --reload &
+cd frontend && npm run dev
+```
+
+Checklist (tick each):
+
+- [ ] Sign in with Google. Confirm session works.
+- [ ] DevTools → Application → Cookies → delete `__session`. Reload `/myorbis`.
+  - [ ] **Chrome:** lands on `/myorbis` silently (no login screen flash).
+  - [ ] **Firefox:** same.
+  - [ ] **Safari:** One Tap prompt appears; single click restores session.
+- [ ] Click "Sign out". Reload the same tab. Stays signed out (no silent re-auth).
+- [ ] Open a new tab. Reload. Now silent re-auth fires (tab-scoped flag).
+- [ ] Sign in with LinkedIn. Delete cookie. Reload. Lands on landing page (no silent attempt, no regression).
+- [ ] Open two tabs. In tab A, DevTools → Application → Cookies → delete `__session`. In tab B, perform any action that hits the backend. Neither tab should log the user out.
+
+- [ ] **Step 6: If everything green — done. If anything fails — investigate and commit the fix.**

--- a/docs/superpowers/specs/2026-04-22-persistent-login-silent-reauth-design.md
+++ b/docs/superpowers/specs/2026-04-22-persistent-login-silent-reauth-design.md
@@ -1,0 +1,276 @@
+# Persistent Login — Silent Re-Auth Design
+
+**Issue:** #406 — feat(auth): persistent login — stop logging users out while they are still active
+
+**Status:** Draft for review
+
+**Author:** Brainstormed 2026-04-22
+
+## Goal
+
+A user who signs in to Orbis once should stay signed in on every device and browser, forever, without seeing a login screen — unless they explicitly sign out or an admin revokes their account. Reaching the end of a session token lifetime should be invisible to them.
+
+## Non-goals
+
+- Orbis as an identity provider for third parties (see #16).
+- LinkedIn-provider silent re-auth. LinkedIn does not expose a FedCM-compatible or silent-prompt flow; LinkedIn users keep today's explicit "Sign in with LinkedIn" on expiry. Covered for ~80%+ of sign-ins via the Google path.
+- Cross-device session management UI (device list, "log out everywhere" button). Deferred — worthwhile later but orthogonal.
+- Refresh-token mirroring into `localStorage`. Safari ITP is less aggressive toward HTTP-set cookies than toward JS-set ones, so an `XSS → localStorage → token exfiltration` risk is not worth its marginal ITP benefit.
+
+## Current state (why today fails the "never logout" bar)
+
+From `backend/app/auth/`:
+
+- Access JWT — 15 min TTL (`jwt_expire_minutes=15`, `config.py:26`).
+- Refresh cookie — 30 day TTL, **sliding**. Every successful `/auth/refresh` rotates to a new token with a fresh 30-day expiry, so daily-active users theoretically stay signed in indefinitely.
+- Cookie: single `__session` packed as `{access_jwt}|{refresh_token}`, `max_age` = refresh TTL.
+- Rotation: on rotation, family revocation on reuse detection.
+
+Failure modes that surface as "I got logged out":
+
+1. **Users returning after >30 days** — refresh cookie expired → explicit sign-in.
+2. **Users switching browsers or devices** — no cookie on the new surface → explicit sign-in.
+3. **Safari 1st-party-cookie purge (ITP)** — less severe for HTTP-set cookies than reported; still a tail risk.
+4. **Two-tab refresh races** — both tabs 401 at once, both call refresh, the loser presents a now-rotated token, family gets revoked, both tabs logged out.
+
+## Proposed approach — Google silent re-auth via FedCM + One Tap
+
+Re-establish the session invisibly (or with a single tap) by asking Google for a fresh ID token when the Orbis cookie is gone. This is the pattern Gmail, Calendar, and other Google-dependent apps use to feel "always logged in."
+
+**Chrome / Firefox:** FedCM API → browser-mediated silent flow, no UI after first opt-in.
+
+**Safari / FedCM-unavailable browsers:** Google Identity Services (GIS) One Tap → small "Continue as …" prompt, single tap confirms.
+
+**LinkedIn / Google-signed-out / prompt dismissed:** fall through to the existing landing page with sign-in buttons (no regression).
+
+## Architecture
+
+Three additions, one tweak:
+
+### 1. `frontend/src/auth/silentReauth.ts` (new)
+
+Single entry point:
+
+```ts
+export async function trySilentReauth(): Promise<boolean>
+```
+
+Order of operations:
+
+1. **FedCM detection** — `'IdentityCredential' in window && 'credentials' in navigator`. If true, call `navigator.credentials.get({ identity: { providers: [{ configURL: 'https://accounts.google.com/gsi/fedcm.json', clientId: VITE_GOOGLE_CLIENT_ID }] } })`. On success, the returned credential carries a Google ID token.
+2. **One Tap fallback** — lazily load `https://accounts.google.com/gsi/client`, call `google.accounts.id.initialize({ client_id, callback, auto_select: true })`, `google.accounts.id.prompt()`. The callback receives a `CredentialResponse.credential` (the ID token).
+3. **POST to backend** — `/api/auth/google-id-token` with `{ id_token }`. On 200, `fetchUser()` repopulates the auth store and `trySilentReauth` returns `true`.
+4. **Any failure** — return `false`. Caller decides what to do.
+
+**Sign-out respect.** `trySilentReauth` first checks `sessionStorage.getItem('orbis.just_logged_out')`. If present, short-circuits to `false` immediately. Set this key in the `/auth/logout` frontend handler; it naturally clears at tab close. Prevents "Sign out" from being a no-op.
+
+**In-flight guard.** Module-level `silentReauthPromise: Promise<boolean> | null` shared across concurrent callers — parallel 401s converge on one FedCM call.
+
+### 2. `POST /api/auth/google-id-token` (new backend endpoint)
+
+In `backend/app/auth/router.py`:
+
+```python
+class GoogleIdTokenRequest(BaseModel):
+    id_token: str
+    source: Literal["fedcm", "onetap"] | None = None  # telemetry hint
+
+@router.post("/google-id-token")
+@limiter.limit("5/minute")
+async def google_id_token_login(
+    body: GoogleIdTokenRequest,
+    request: Request,
+    response: Response,
+    db: AsyncDriver = Depends(get_db),
+) -> dict:
+    """Verify a Google-issued ID token and issue an Orbis session.
+
+    Called by the frontend silent-re-auth flow (FedCM or GIS One Tap).
+    Shares user-upsert logic with /auth/google; the only difference is
+    that here we trust a Google-signed JWT directly instead of exchanging
+    an authorization code.
+    """
+```
+
+Flow:
+1. `claims = await verify_google_id_token(body.id_token)` — raises 401 on any validation failure.
+2. Enforce `claims.get("email_verified") is True` — same gate as `/auth/google`.
+3. `user = await _upsert_person(db, claims)` — reuse existing Google upsert path.
+4. `raw, token_id, expires_at = await issue_refresh_token(db, user_id=user.id, ttl_days=settings.refresh_token_expire_days, user_agent=request.headers["user-agent"])`.
+5. `access = create_jwt(user.id, claims["email"])`.
+6. `set_auth_cookies(response, access_token=access, refresh_raw=raw, refresh_expires_at=expires_at)`.
+7. Return `{"status": "ok", "source": "id_token"}`.
+
+Rate limit 5/min per IP — enough for legitimate page-loads, restrictive enough to blunt credential stuffing.
+
+### 3. `backend/app/auth/service.py` — `verify_google_id_token()` helper
+
+```python
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token as google_id_token
+
+async def verify_google_id_token(raw: str) -> dict:
+    """Return verified Google claims or raise HTTPException."""
+    try:
+        # google-auth is synchronous; run in a threadpool to avoid
+        # blocking the event loop on JWKS fetches.
+        claims = await asyncio.to_thread(
+            google_id_token.verify_oauth2_token,
+            raw,
+            google_requests.Request(),
+            settings.google_client_id,
+        )
+    except google.auth.exceptions.TransportError as exc:
+        logger.warning("google_id_token: JWKS fetch failed: %s", exc)
+        raise HTTPException(503, detail="verify_unavailable") from exc
+    except ValueError:
+        raise HTTPException(401, detail="invalid_id_token") from None
+
+    iss = claims.get("iss")
+    if iss not in {"accounts.google.com", "https://accounts.google.com"}:
+        raise HTTPException(401, detail="invalid_id_token")
+    return claims
+```
+
+Error handling never leaks *which* check failed (signature, audience, expiry) — standard OAuth hygiene.
+
+Requires adding `google-auth` to `backend/pyproject.toml` (currently transitive via `anthropic` but not pinned in Orbis's own deps).
+
+### 4. `frontend/src/api/client.ts` — extend the 401 handler
+
+Today's flow: 401 → `/auth/refresh` → retry; on refresh failure, dispatch `orbis:session-expired`.
+
+New flow inserts `trySilentReauth()` between refresh failure and the dispatch:
+
+```ts
+// pseudo-diff
+if (refreshFailed) {
+  if (!original._triedSilentReauth) {
+    original._triedSilentReauth = true;
+    const ok = await trySilentReauth();
+    if (ok) return client.request(original);
+  }
+  window.dispatchEvent(new CustomEvent('orbis:session-expired'));
+  return Promise.reject(refreshError);
+}
+```
+
+`_triedSilentReauth` loop guard prevents pathological re-attempts on the same logical request.
+
+### Bonus — refresh-race fix (cheap, high value)
+
+In the same PR, address two-tab refresh races: when `/auth/refresh` returns 401 but the cookie was rotated by another tab in the last 500ms, the original request already has a valid session — we just need to retry. Tracked by a module-level timestamp `lastSuccessfulRefreshAt`; if `Date.now() - lastSuccessfulRefreshAt < 500`, retry the original request once before surfacing the failure.
+
+### Config tweak
+
+`backend/app/config.py`:
+
+```python
+refresh_token_expire_days: int = 365   # was 30
+```
+
+Cookie sliding already in place; this just extends the absolute cap for users who genuinely don't open Orbis for a year.
+
+## Data flow — four scenarios
+
+**1. Active user, JWT expired, refresh cookie valid** (today's behavior, unchanged):
+
+`/api/foo → 401 → /auth/refresh → 200 → retry → 200`. User never notices.
+
+**2. Returning user, refresh cookie expired, Chrome/Firefox:**
+
+`/api/auth/me → 401 → /auth/refresh → 401 → trySilentReauth() → FedCM fires silently → Google returns ID token → POST /auth/google-id-token → 200 (cookie set) → fetchUser → render`. Zero visible UI. ~300–500ms.
+
+**3. Returning user, refresh cookie expired, Safari:**
+
+Same path, FedCM unsupported → falls through to GIS One Tap → "Continue as Alessandro" prompt → single tap → ID token → cookie. ~1s including the tap.
+
+**4. All silent paths fail** (signed out of Google, FedCM blocked, LinkedIn account, etc.):
+
+`trySilentReauth() → false → dispatch orbis:session-expired → existing handler routes to /`. User clicks explicit sign-in button as today. No regression.
+
+## Error handling
+
+| Condition | Response |
+|---|---|
+| ID-token signature mismatch | `401 invalid_id_token` (opaque) |
+| ID-token expired | `401 invalid_id_token` |
+| `email_verified=false` | `401 invalid_id_token` |
+| Wrong audience | `401 invalid_id_token` |
+| JWKS fetch transient failure | `503 verify_unavailable` (frontend may retry next page-load) |
+| Rate-limit exceeded | `429` |
+| FedCM user dismissal | Fallback to One Tap |
+| GIS script load failure | Return `false` |
+| Refresh + silent both fail | `orbis:session-expired` dispatched (existing handler) |
+| Explicit `/auth/logout` | `sessionStorage['orbis.just_logged_out']` short-circuits silent re-auth until tab close |
+
+## Security considerations
+
+- **ID token verification** uses `google-auth`'s official helper, which covers signature, issuer, audience, and expiry. Issuer must be `accounts.google.com` or `https://accounts.google.com` — hard-coded allow-list.
+- **Rate limit** on `/auth/google-id-token` keeps credential stuffing / JWKS scraping at bay.
+- **No raw ID tokens persisted** — the backend verifies once, extracts claims, discards. Only the derived Orbis refresh token hits Neo4j (as today).
+- **Sign-out still works.** `sessionStorage['orbis.just_logged_out']` gates silent re-auth. The moment a new tab opens (past the logout), silent re-auth resumes — this is deliberate and matches the "never logout" goal. Explicit full sign-out is a single-tab action by design.
+- **Family-revocation on reuse detection** is unchanged from today. The refresh-race bonus is a *pre-emptive* retry that avoids *legitimate* races from triggering revocation; it does not weaken revocation on actual reuse.
+- **Telemetry** (`source=google_code | id_token_fedcm | id_token_onetap`) lets us notice silently if silent re-auth stops working in prod. No PII logged.
+
+## Testing
+
+### Backend unit tests (`tests/unit/test_auth_google_id_token.py`, new)
+
+- Happy path — valid mocked token → 200 + `__session` cookie + user upserted
+- Wrong audience → 401 `invalid_id_token`
+- Expired `exp` claim → 401
+- `email_verified=false` → 401
+- Issuer not Google → 401
+- JWKS fetch failure → 503 `verify_unavailable`
+- Rate limit: 6th request within a minute → 429
+- New-user path: unseen `sub` → creates Person node with claims (email, name, picture)
+- Existing-user path: same `sub` reused → no duplicate Person
+
+### Backend config test (`tests/unit/test_config.py`, extend)
+
+- `settings.refresh_token_expire_days == 365` by default.
+
+### Frontend unit tests (`src/auth/silentReauth.test.ts`, new)
+
+- FedCM supported + returns token → POST succeeds → returns `true`
+- FedCM supported + user dismisses → fallback to One Tap → success → `true`
+- FedCM unsupported → goes straight to One Tap
+- Both paths reject → returns `false`
+- Backend returns 401 → `false` (does not throw)
+- In-flight guard: two simultaneous callers share one promise
+- `orbis.just_logged_out` set → returns `false` without touching Google APIs
+
+### Frontend client interceptor test (extend `client.test.ts` if it exists; add minimal one if not)
+
+- 401 → refresh fails → silent succeeds → original request retried → 200
+- 401 → refresh fails → silent fails → `orbis:session-expired` dispatched
+- `_triedSilentReauth` loop guard prevents re-attempts on the same request
+- Refresh-race: cookie rotated within 500ms window → original request retried once before surfacing failure
+
+### Integration / E2E
+
+FedCM + One Tap require real Google infra and browser chrome. Meaningful automated coverage would need Playwright against staging with a dedicated Google test account and manual FedCM opt-in priming — cost/benefit doesn't justify now. Manual smoke-test checklist below covers deployment verification.
+
+## Manual smoke-test checklist (to run post-deploy on staging)
+
+- [ ] **Chrome, signed into Google:** sign in to Orbis → devtools → delete `__session` cookie → reload → lands on `/myorbis` silently.
+- [ ] **Firefox, signed into Google:** same as above.
+- [ ] **Safari, signed into Google:** same setup → One Tap prompt appears at top-right → single tap → session restored.
+- [ ] **LinkedIn account, expired session:** cookie deleted → reload → lands on landing page (no regression, no spurious silent attempt).
+- [ ] **Signed out of Google + Orbis cookie deleted:** reload → silent re-auth no-ops → landing page.
+- [ ] **Explicit `/auth/logout`:** click Sign out → cookie cleared → reload same tab → stays signed out (does NOT silently re-auth).
+- [ ] **Two tabs open, JWT expires simultaneously:** both 401 at once → one rotates, the other retries successfully; neither gets logged out.
+- [ ] **Mobile Safari:** same as desktop Safari — One Tap adapts to the small viewport.
+- [ ] **Incognito Chrome:** third-party cookies blocked → One Tap may fail → graceful landing-page fallback.
+
+## Rollout
+
+- **Phase 1** (this spec): code lands, feature active by default behind config flag `SILENT_REAUTH_ENABLED` (default `true`, set `false` for emergency disable).
+- **Phase 2** (follow-up, deferred): device-management UI, "log out everywhere" button, session observability dashboard for support.
+
+## Open questions (to resolve during implementation, not blocking spec)
+
+- Which GIS client ID do we use? The existing `VITE_GOOGLE_CLIENT_ID` should work as long as `https://accounts.google.com/gsi/fedcm.json` is registered for that client in Google Cloud Console.
+- FedCM's `autoReauthn` vs. `mediation: 'optional'` — which gives the smoothest first-opt-in UX? Decide during implementation after testing both.
+- Should the refresh-race fix ship in the same PR or a separate micro-PR? Including it here keeps the PR focused on "fix auto-logout," which is the right unit.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "@types/react-dom": "19.2.3",
         "@types/three": "0.183.1",
         "@vitejs/plugin-react": "6.0.1",
+        "axios-mock-adapter": "^2.1.0",
         "eslint": "9.39.4",
         "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-refresh": "0.5.2",
@@ -2437,6 +2438,20 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3916,6 +3931,30 @@
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
       "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@types/react-dom": "19.2.3",
     "@types/three": "0.183.1",
     "@vitejs/plugin-react": "6.0.1",
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "9.39.4",
     "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-refresh": "0.5.2",

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -93,3 +93,10 @@ export async function generateMyInvite(): Promise<{ code: string; created_at: st
   );
   return data;
 }
+
+export async function googleIdTokenLogin(
+  idToken: string,
+  source: 'fedcm' | 'onetap',
+): Promise<void> {
+  await client.post('/auth/google-id-token', { id_token: idToken, source });
+}

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+// Mock silentReauth before importing client (which imports it at module level).
+vi.mock('../auth/silentReauth', () => ({
+  trySilentReauth: vi.fn(),
+}));
+
+// Mock the raw axios module so refreshSession() (which calls axios.post) can be
+// controlled by tests. We keep the axios.create() behaviour intact so the
+// intercepted `client` instance is still usable with MockAdapter.
+const axiosPostSpy = vi.spyOn(axios, 'post');
+
+import { trySilentReauth } from '../auth/silentReauth';
+import client from './client';
+
+describe('axios interceptor — silent re-auth integration', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(client);
+    vi.resetAllMocks();
+    // By default, refresh succeeds (resolved = no error thrown).
+    axiosPostSpy.mockResolvedValue({ status: 200 });
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('401 + refresh-fail + silent-success → retries and succeeds', async () => {
+    let call = 0;
+    mock.onGet('/foo').reply(() => {
+      call += 1;
+      // First call → 401 (triggers refresh path), second call → 200 (after silent reauth retry).
+      return call === 1 ? [401, {}] : [200, { ok: true }];
+    });
+    // Make refresh fail so we fall into the silent-reauth branch.
+    axiosPostSpy.mockRejectedValue(Object.assign(new Error('refresh failed'), { response: { status: 401 } }));
+    (trySilentReauth as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const res = await client.get('/foo');
+    expect(res.data).toEqual({ ok: true });
+    expect(trySilentReauth).toHaveBeenCalledOnce();
+  });
+
+  it('401 + refresh-fail + silent-fail → dispatches session-expired', async () => {
+    mock.onGet('/foo').reply(401);
+    axiosPostSpy.mockRejectedValue(Object.assign(new Error('refresh failed'), { response: { status: 401 } }));
+    (trySilentReauth as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    const handler = vi.fn();
+    window.addEventListener('orbis:session-expired', handler);
+    await expect(client.get('/foo')).rejects.toThrow();
+    expect(handler).toHaveBeenCalledOnce();
+    window.removeEventListener('orbis:session-expired', handler);
+  });
+
+  it('loop guard: silent re-auth only tried once per request', async () => {
+    // Every request returns 401 — this simulates silent-reauth "succeeding"
+    // (trySilentReauth returns true) but the retry still getting a 401.
+    // The guard must prevent a second silent-reauth call.
+    mock.onGet('/foo').reply(401);
+    axiosPostSpy.mockRejectedValue(Object.assign(new Error('refresh failed'), { response: { status: 401 } }));
+    (trySilentReauth as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    // The retry after silent-success will 401 again, hitting _retriedAfterRefresh
+    // (which was set before the retry), then checking _triedSilentReauth (already
+    // true) → falls through to session-expired without calling trySilentReauth again.
+    await expect(client.get('/foo')).rejects.toThrow();
+    expect(trySilentReauth).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -72,3 +72,46 @@ describe('axios interceptor — silent re-auth integration', () => {
     expect(trySilentReauth).toHaveBeenCalledOnce();
   });
 });
+
+describe('axios interceptor — refresh race', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(client);
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('retries original request when another tab rotated the cookie <500ms ago', async () => {
+    // Phase 1: Prime lastSuccessfulRefreshAt by running a full 401→refresh→retry
+    // cycle through the interceptor. This sets lastSuccessfulRefreshAt = Date.now().
+    axiosPostSpy.mockResolvedValueOnce({ status: 200 });
+    let primeCall = 0;
+    mock.onGet('/prime').reply(() => {
+      primeCall += 1;
+      return primeCall === 1 ? [401, {}] : [200, { primed: true }];
+    });
+    await client.get('/prime');
+
+    // Phase 2: Now within the 500ms race window, trigger a new 401 on /foo.
+    // /auth/refresh fails (token already rotated by "tab A"), but the race
+    // window is still open, so the interceptor retries /foo once — second call succeeds.
+    axiosPostSpy.mockRejectedValueOnce(
+      Object.assign(new Error('token already rotated'), { response: { status: 401 } }),
+    );
+
+    let fooCall = 0;
+    mock.onGet('/foo').reply(() => {
+      fooCall += 1;
+      return fooCall === 1 ? [401, {}] : [200, { ok: true }];
+    });
+
+    const res = await client.get('/foo');
+    expect(res.data).toEqual({ ok: true });
+    // trySilentReauth should NOT have been called — the race window handled it.
+    expect(trySilentReauth).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { trySilentReauth } from '../auth/silentReauth';
 
 // Cookies are set by the backend on /auth/google|linkedin|refresh, scoped
 // to /api for the access cookie and /auth for the refresh cookie. They
@@ -17,6 +18,7 @@ let refreshInFlight: Promise<void> | null = null;
 
 interface RetryableConfig extends InternalAxiosRequestConfig {
   _retriedAfterRefresh?: boolean;
+  _triedSilentReauth?: boolean;
 }
 
 async function refreshSession(): Promise<void> {
@@ -41,8 +43,21 @@ client.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // Already retried once and still 401 — stop here and surface the failure.
+    // Already retried once after refresh and still 401 — try silent re-auth
+    // before giving up entirely.
     if (original._retriedAfterRefresh) {
+      if (!original._triedSilentReauth) {
+        original._triedSilentReauth = true;
+        try {
+          const silentOk = await trySilentReauth();
+          if (silentOk) {
+            return client.request(original);
+          }
+        } catch {
+          // trySilentReauth never throws today, but be defensive — any
+          // unexpected throw must not break the session-expired fallback.
+        }
+      }
       window.dispatchEvent(new CustomEvent('orbis:session-expired'));
       return Promise.reject(error);
     }
@@ -55,6 +70,20 @@ client.interceptors.response.use(
       }
       await refreshInFlight;
     } catch (refreshError) {
+      // Refresh failed — try silent re-auth before declaring session expired.
+      if (!original._triedSilentReauth) {
+        original._triedSilentReauth = true;
+        try {
+          const silentOk = await trySilentReauth();
+          if (silentOk) {
+            original._retriedAfterRefresh = true;
+            return client.request(original);
+          }
+        } catch {
+          // trySilentReauth never throws today, but be defensive — any
+          // unexpected throw must not break the session-expired fallback.
+        }
+      }
       window.dispatchEvent(new CustomEvent('orbis:session-expired'));
       return Promise.reject(refreshError);
     }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,13 +16,22 @@ const client = axios.create({
 // requests that all 401 in a burst only trigger one /auth/refresh.
 let refreshInFlight: Promise<void> | null = null;
 
+// Cross-tab refresh-race guard: when another tab successfully refreshes
+// within this window, a fresh cookie is already set even though this tab's
+// /auth/refresh call failed. Retry the original request once instead of
+// immediately falling through to silent-reauth / session-expired.
+let lastSuccessfulRefreshAt = 0;
+const REFRESH_RACE_WINDOW_MS = 500;
+
 interface RetryableConfig extends InternalAxiosRequestConfig {
   _retriedAfterRefresh?: boolean;
   _triedSilentReauth?: boolean;
+  _triedAfterRaceWindow?: boolean;
 }
 
 async function refreshSession(): Promise<void> {
   await axios.post(`${API_BASE}/auth/refresh`, undefined, { withCredentials: true });
+  lastSuccessfulRefreshAt = Date.now();
 }
 
 client.interceptors.response.use(
@@ -70,6 +79,17 @@ client.interceptors.response.use(
       }
       await refreshInFlight;
     } catch (refreshError) {
+      // Refresh failed — but another tab may have just rotated the cookie.
+      // If the last successful refresh happened within the race window, retry
+      // the original request once: its cookie is already valid.
+      if (
+        !original._triedAfterRaceWindow &&
+        Date.now() - lastSuccessfulRefreshAt < REFRESH_RACE_WINDOW_MS
+      ) {
+        original._triedAfterRaceWindow = true;
+        return client.request(original);
+      }
+
       // Refresh failed — try silent re-auth before declaring session expired.
       if (!original._triedSilentReauth) {
         original._triedSilentReauth = true;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -48,7 +48,7 @@ client.interceptors.response.use(
     // /auth/me is also excluded: a 401 on the initial session probe simply
     // means the user is not logged in, not that a session expired.
     const url = original.url || '';
-    if (url.startsWith('/auth/refresh') || url.startsWith('/auth/logout') || url.startsWith('/auth/me')) {
+    if (url.startsWith('/auth/refresh') || url.startsWith('/auth/logout') || url.startsWith('/auth/me') || url.startsWith('/auth/google-id-token')) {
       return Promise.reject(error);
     }
 

--- a/frontend/src/auth/silentReauth.test.ts
+++ b/frontend/src/auth/silentReauth.test.ts
@@ -4,7 +4,7 @@ vi.mock('../api/auth', () => ({
   googleIdTokenLogin: vi.fn(),
 }));
 
-import { trySilentReauth } from './silentReauth';
+import { trySilentReauth, _resetModuleState } from './silentReauth';
 import { googleIdTokenLogin } from '../api/auth';
 
 function stubFedCM(idToken: string | null) {
@@ -23,11 +23,14 @@ function unstubFedCM() {
 describe('trySilentReauth — FedCM path', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.useFakeTimers();
+    _resetModuleState();
     vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
     sessionStorage.clear();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     unstubFedCM();
     vi.unstubAllEnvs();
   });
@@ -43,9 +46,81 @@ describe('trySilentReauth — FedCM path', () => {
 
   it('returns false when FedCM resolves with null (user dismissed)', async () => {
     stubFedCM(null);
-    const ok = await trySilentReauth();
-    // FedCM failure falls through to One Tap which is unavailable in jsdom,
-    // so end state is false. Covered in Task 5 once One Tap is wired in.
+    // Stub document.createElement so the GIS script tag fires onerror immediately,
+    // causing loadGis to reject and runOneTap to return null.
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === 'script') {
+        // Trigger onerror on next microtask so loadGis rejects fast.
+        Promise.resolve().then(() => el.onerror?.(new Event('error')));
+      }
+      return el;
+    });
+
+    const promise = trySilentReauth();
+    await vi.runAllTimersAsync();
+    const ok = await promise;
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('trySilentReauth — One Tap fallback', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    _resetModuleState();
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as any).google;
+    unstubFedCM();
+    vi.unstubAllEnvs();
+  });
+
+  it('falls back to One Tap when FedCM resolves with null', async () => {
+    stubFedCM(null);
+    (globalThis as any).google = {
+      accounts: {
+        id: {
+          initialize: vi.fn((opts: any) => {
+            setTimeout(() => opts.callback({ credential: 'onetap.id.token' }), 0);
+          }),
+          prompt: vi.fn(),
+        },
+      },
+    };
+    (googleIdTokenLogin as any).mockResolvedValue(undefined);
+
+    const promise = trySilentReauth();
+    await vi.runAllTimersAsync();
+    const ok = await promise;
+    expect(ok).toBe(true);
+    expect(googleIdTokenLogin).toHaveBeenCalledWith('onetap.id.token', 'onetap');
+  });
+
+  it('returns false when neither FedCM nor One Tap produce a token', async () => {
+    stubFedCM(null);
+    (globalThis as any).google = {
+      accounts: {
+        id: {
+          initialize: vi.fn(),
+          prompt: vi.fn((notification: (n: any) => void) => {
+            setTimeout(() => notification({ isNotDisplayed: () => true }), 0);
+          }),
+        },
+      },
+    };
+
+    const promise = trySilentReauth();
+    await vi.runAllTimersAsync();
+    const ok = await promise;
     expect(ok).toBe(false);
     expect(googleIdTokenLogin).not.toHaveBeenCalled();
   });

--- a/frontend/src/auth/silentReauth.test.ts
+++ b/frontend/src/auth/silentReauth.test.ts
@@ -76,6 +76,30 @@ describe('trySilentReauth — FedCM path', () => {
   });
 });
 
+describe('trySilentReauth — kill switch', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    _resetModuleState();
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    unstubFedCM();
+    vi.unstubAllEnvs();
+  });
+
+  it('short-circuits when VITE_SILENT_REAUTH_ENABLED=false', async () => {
+    vi.stubEnv('VITE_SILENT_REAUTH_ENABLED', 'false');
+    stubFedCM('ignored.token');
+    const ok = await trySilentReauth();
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+  });
+});
+
 describe('trySilentReauth — One Tap fallback', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/frontend/src/auth/silentReauth.test.ts
+++ b/frontend/src/auth/silentReauth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../api/auth', () => ({
   googleIdTokenLogin: vi.fn(),
@@ -23,7 +23,13 @@ function unstubFedCM() {
 describe('trySilentReauth — FedCM path', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', 'test-client-id');
     sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    unstubFedCM();
+    vi.unstubAllEnvs();
   });
 
   it('returns true when FedCM returns an ID token and backend accepts it', async () => {
@@ -33,7 +39,6 @@ describe('trySilentReauth — FedCM path', () => {
     const ok = await trySilentReauth();
     expect(ok).toBe(true);
     expect(googleIdTokenLogin).toHaveBeenCalledWith('google.id.token', 'fedcm');
-    unstubFedCM();
   });
 
   it('returns false when FedCM resolves with null (user dismissed)', async () => {
@@ -43,6 +48,5 @@ describe('trySilentReauth — FedCM path', () => {
     // so end state is false. Covered in Task 5 once One Tap is wired in.
     expect(ok).toBe(false);
     expect(googleIdTokenLogin).not.toHaveBeenCalled();
-    unstubFedCM();
   });
 });

--- a/frontend/src/auth/silentReauth.test.ts
+++ b/frontend/src/auth/silentReauth.test.ts
@@ -66,6 +66,14 @@ describe('trySilentReauth — FedCM path', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('short-circuits when orbis.just_logged_out is set', async () => {
+    sessionStorage.setItem('orbis.just_logged_out', '1');
+    stubFedCM('should.not.be.used');
+    const ok = await trySilentReauth();
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+  });
 });
 
 describe('trySilentReauth — One Tap fallback', () => {

--- a/frontend/src/auth/silentReauth.test.ts
+++ b/frontend/src/auth/silentReauth.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api/auth', () => ({
+  googleIdTokenLogin: vi.fn(),
+}));
+
+import { trySilentReauth } from './silentReauth';
+import { googleIdTokenLogin } from '../api/auth';
+
+function stubFedCM(idToken: string | null) {
+  const fakeCredential = idToken ? { token: idToken } : null;
+  (globalThis as any).navigator.credentials = {
+    get: vi.fn().mockResolvedValue(fakeCredential),
+  };
+  (globalThis as any).IdentityCredential = class {};
+}
+
+function unstubFedCM() {
+  delete (globalThis as any).navigator.credentials;
+  delete (globalThis as any).IdentityCredential;
+}
+
+describe('trySilentReauth — FedCM path', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('returns true when FedCM returns an ID token and backend accepts it', async () => {
+    stubFedCM('google.id.token');
+    (googleIdTokenLogin as any).mockResolvedValue(undefined);
+
+    const ok = await trySilentReauth();
+    expect(ok).toBe(true);
+    expect(googleIdTokenLogin).toHaveBeenCalledWith('google.id.token', 'fedcm');
+    unstubFedCM();
+  });
+
+  it('returns false when FedCM resolves with null (user dismissed)', async () => {
+    stubFedCM(null);
+    const ok = await trySilentReauth();
+    // FedCM failure falls through to One Tap which is unavailable in jsdom,
+    // so end state is false. Covered in Task 5 once One Tap is wired in.
+    expect(ok).toBe(false);
+    expect(googleIdTokenLogin).not.toHaveBeenCalled();
+    unstubFedCM();
+  });
+});

--- a/frontend/src/auth/silentReauth.ts
+++ b/frontend/src/auth/silentReauth.ts
@@ -5,6 +5,9 @@ const JUST_LOGGED_OUT_KEY = 'orbis.just_logged_out';
 let inFlight: Promise<boolean> | null = null;
 
 export async function trySilentReauth(): Promise<boolean> {
+  if (import.meta.env.VITE_SILENT_REAUTH_ENABLED === 'false') {
+    return false;
+  }
   if (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(JUST_LOGGED_OUT_KEY)) {
     return false;
   }

--- a/frontend/src/auth/silentReauth.ts
+++ b/frontend/src/auth/silentReauth.ts
@@ -11,9 +11,14 @@ export async function trySilentReauth(): Promise<boolean> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
     try {
-      const idToken = await runFedCM();
+      let source: 'fedcm' | 'onetap' = 'fedcm';
+      let idToken = await runFedCM();
+      if (!idToken) {
+        idToken = await runOneTap();
+        source = 'onetap';
+      }
       if (!idToken) return false;
-      await googleIdTokenLogin(idToken, 'fedcm');
+      await googleIdTokenLogin(idToken, source);
       return true;
     } catch (err) {
       console.warn('silentReauth: id-token exchange failed', err);
@@ -51,4 +56,72 @@ async function runFedCM(): Promise<string | null> {
   }
 }
 
+const GIS_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+let gisScriptLoading: Promise<void> | null = null;
+
+function loadGis(): Promise<void> {
+  if ((globalThis as any).google?.accounts?.id) {
+    gisScriptLoading = null;
+    return Promise.resolve();
+  }
+  if (gisScriptLoading) return gisScriptLoading;
+  gisScriptLoading = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = GIS_SCRIPT_SRC;
+    s.async = true;
+    s.onload = () => {
+      gisScriptLoading = null;
+      resolve();
+    };
+    s.onerror = () => {
+      gisScriptLoading = null;
+      reject(new Error('gis_load_failed'));
+    };
+    document.head.appendChild(s);
+  });
+  return gisScriptLoading;
+}
+
+async function runOneTap(): Promise<string | null> {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) return null;
+
+  try {
+    await loadGis();
+  } catch {
+    return null;
+  }
+
+  const gis = (globalThis as any).google?.accounts?.id;
+  if (!gis) return null;
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    gis.initialize({
+      client_id: clientId,
+      auto_select: true,
+      callback: (response: { credential?: string }) => {
+        finish(response?.credential ?? null);
+      },
+    });
+    gis.prompt((notification: any) => {
+      if (notification?.isNotDisplayed?.() || notification?.isSkippedMoment?.()) {
+        finish(null);
+      }
+    });
+    setTimeout(() => finish(null), 4000);
+  });
+}
+
 export const SILENT_REAUTH_JUST_LOGGED_OUT_KEY = JUST_LOGGED_OUT_KEY;
+
+/** Exposed only for unit tests — resets module-level state between test runs. */
+export function _resetModuleState() {
+  inFlight = null;
+  gisScriptLoading = null;
+}

--- a/frontend/src/auth/silentReauth.ts
+++ b/frontend/src/auth/silentReauth.ts
@@ -1,0 +1,52 @@
+import { googleIdTokenLogin } from '../api/auth';
+
+const JUST_LOGGED_OUT_KEY = 'orbis.just_logged_out';
+
+let inFlight: Promise<boolean> | null = null;
+
+export async function trySilentReauth(): Promise<boolean> {
+  if (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(JUST_LOGGED_OUT_KEY)) {
+    return false;
+  }
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const idToken = await runFedCM();
+      if (!idToken) return false;
+      await googleIdTokenLogin(idToken, 'fedcm');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+async function runFedCM(): Promise<string | null> {
+  if (typeof window === 'undefined') return null;
+  if (!('IdentityCredential' in window)) return null;
+  if (!navigator.credentials) return null;
+
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+
+  try {
+    const credential = await (navigator.credentials.get as any)({
+      identity: {
+        providers: [
+          {
+            configURL: 'https://accounts.google.com/gsi/fedcm.json',
+            clientId,
+          },
+        ],
+      },
+      mediation: 'optional',
+    });
+    return (credential as any)?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export const SILENT_REAUTH_JUST_LOGGED_OUT_KEY = JUST_LOGGED_OUT_KEY;

--- a/frontend/src/auth/silentReauth.ts
+++ b/frontend/src/auth/silentReauth.ts
@@ -15,7 +15,8 @@ export async function trySilentReauth(): Promise<boolean> {
       if (!idToken) return false;
       await googleIdTokenLogin(idToken, 'fedcm');
       return true;
-    } catch {
+    } catch (err) {
+      console.warn('silentReauth: id-token exchange failed', err);
       return false;
     } finally {
       inFlight = null;
@@ -29,7 +30,8 @@ async function runFedCM(): Promise<string | null> {
   if (!('IdentityCredential' in window)) return null;
   if (!navigator.credentials) return null;
 
-  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) return null;
 
   try {
     const credential = await (navigator.credentials.get as any)({

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -36,6 +36,12 @@ export const useAuthStore = create<AuthState>((set) => ({
       // The backend sets httpOnly access + refresh cookies on this call.
       // The response body still carries UserInfo for convenience.
       const { user } = await googleLogin(code);
+      // A successful explicit sign-in clears any stale "just_logged_out"
+      // sentinel from an earlier logout in the same tab — otherwise a
+      // subsequent silent re-auth after session expiry would be blocked.
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem('orbis.just_logged_out');
+      }
       set({ user, loading: false });
     } catch {
       set({ loading: false });
@@ -47,6 +53,9 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ loading: true });
     try {
       const { user } = await linkedinLogin(code);
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem('orbis.just_logged_out');
+      }
       set({ user, loading: false });
     } catch {
       set({ loading: false });
@@ -60,6 +69,12 @@ export const useAuthStore = create<AuthState>((set) => ({
     } catch {
       // Even if the server call fails we still clear client state so the
       // user is not stuck with a half-logged-in UI.
+    }
+    // Tell silent re-auth not to instantly re-establish the session we
+    // just explicitly tore down. Cleared on next successful login, or
+    // when the tab closes.
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem('orbis.just_logged_out', '1');
     }
     set({ user: null, loading: false });
   },

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { getMe, googleLogin, linkedinLogin, logoutBackend, type UserInfo } from '../api/auth';
+import { SILENT_REAUTH_JUST_LOGGED_OUT_KEY } from '../auth/silentReauth';
 
 interface AuthState {
   user: UserInfo | null;
@@ -40,7 +41,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       // sentinel from an earlier logout in the same tab — otherwise a
       // subsequent silent re-auth after session expiry would be blocked.
       if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.removeItem('orbis.just_logged_out');
+        sessionStorage.removeItem(SILENT_REAUTH_JUST_LOGGED_OUT_KEY);
       }
       set({ user, loading: false });
     } catch {
@@ -54,7 +55,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const { user } = await linkedinLogin(code);
       if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.removeItem('orbis.just_logged_out');
+        sessionStorage.removeItem(SILENT_REAUTH_JUST_LOGGED_OUT_KEY);
       }
       set({ user, loading: false });
     } catch {
@@ -74,7 +75,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     // just explicitly tore down. Cleared on next successful login, or
     // when the tab closes.
     if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('orbis.just_logged_out', '1');
+      sessionStorage.setItem(SILENT_REAUTH_JUST_LOGGED_OUT_KEY, '1');
     }
     set({ user: null, loading: false });
   },

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_CLIENT_ID: string;
   readonly VITE_LINKEDIN_CLIENT_ID: string;
   readonly VITE_MCP_URL: string;
+  readonly VITE_SILENT_REAUTH_ENABLED?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #406

## Summary

Makes Orbis feel "never logout" for Google-signed-in users. When the refresh cookie is gone (cleared, expired, or evicted by the browser), the frontend silently re-establishes the session via **FedCM** on Chrome/Firefox (zero UI after first opt-in) or **Google Identity Services One Tap** on Safari (single-tap "Continue as …" prompt). LinkedIn users and users signed out of Google fall through to the existing landing-page sign-in — no regression.

Also bumps the refresh-token TTL default from 30d to 365d so genuinely-dormant users don't get kicked out before silent re-auth has a chance to kick in.

## What landed

**Backend** (`backend/app/auth/`, 4 commits):
- `verify_google_id_token(raw)` helper using the official `google-auth` library (signature, audience, expiry, issuer checks); `asyncio.to_thread` wraps the blocking JWKS fetch
- `POST /auth/google-id-token` endpoint — rate-limited 5/min/IP, enforces `email_verified=true` before any DB write, routes through the existing `_issue_session` / `_upsert_google_person` helpers so all three login paths (`/auth/google`, `/auth/linkedin`, `/auth/google-id-token`) share one session-minting chokepoint
- `refresh_token_expire_days` default 30 → 365 (sliding window already in place in `/auth/refresh`)

**Frontend** (`frontend/src/`, 6 commits):
- `auth/silentReauth.ts` — `trySilentReauth()` module: FedCM → One Tap fallback → POST `/auth/google-id-token`. In-flight guard dedupes concurrent 401 handlers onto one promise. `sessionStorage['orbis.just_logged_out']` sentinel short-circuits silent re-auth after explicit sign-out; cleared on next successful login
- `api/client.ts` — axios 401 interceptor extended. Order: refresh → race-window retry (500ms cross-tab window) → silent-reauth → session-expired dispatch. Loop guards on every branch
- `stores/authStore.ts` — sets/clears the sentinel on logout/login
- `VITE_SILENT_REAUTH_ENABLED` kill switch — set to `false` at build time for emergency rollback

**Invisible feature.** No new UI, no new pages, no new modals. The only user-visible effect is "you don't have to sign in every 30 days anymore, and you don't get logged out when another tab beats you to a refresh."

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-22-persistent-login-silent-reauth-design.md` (276 lines)
- Plan: `docs/superpowers/plans/2026-04-22-persistent-login.md` (11 TDD-shaped tasks)

## Test plan

- [x] Backend: 15 new unit tests (4 verify helper + 5 endpoint + 1 config + 5 OAuth-settings regression); zero regressions against the 809-test main suite
- [x] Frontend: 7 `silentReauth.test.ts` tests (FedCM path, One Tap fallback, sign-out short-circuit, kill-switch, etc.) + 4 `client.test.ts` tests (silent-reauth integration, loop guard, refresh-race retry)
- [x] Ruff: clean on all new Python files
- [x] ESLint + build: clean
- [ ] Manual E2E smoke (documented in the spec):
  - Chrome + logged-into-Google: sign in → delete `__session` → reload → silent re-auth → lands on `/myorbis` with zero UI
  - Safari + logged-into-Google: same setup → One Tap prompt → single click → session restored
  - Explicit sign-out → reload same tab → stays signed out (silent re-auth respects the sentinel)
  - LinkedIn account → delete cookie → reload → lands on landing page (no regression)
  - Two tabs, both 401 at once → neither gets logged out (refresh-race fix)

## Security highlights

- **ID tokens verified via official `google-auth`** — signature + audience (via `settings.google_client_id`) + expiry + issuer
- **Defence-in-depth issuer allow-list** in `verify_google_id_token` on top of the library check
- **`email_verified=true` enforced before any DB write** at the endpoint boundary
- **Rate limit 5/min/IP** on `/auth/google-id-token` — blunts credential stuffing / JWKS scraping
- **ID tokens never persisted** — verified in-flight, only the derived `user_id` flows into session minting
- **Refresh-token rotation + family revoke on reuse** unchanged from today; the refresh-race fix is a *pre-emptive retry* for legitimate concurrent refreshes, NOT a weakening of reuse-detection
- **Explicit logout respected** via `sessionStorage['orbis.just_logged_out']`; cleared on explicit sign-in so user-switching in the same tab works

## Kill switch

`VITE_SILENT_REAUTH_ENABLED=false` at build time disables the FedCM + One Tap path entirely and forces users through the explicit "Sign in with Google" button. Default: enabled.

## Out of scope (deferred)

- LinkedIn silent re-auth (LinkedIn has no FedCM equivalent)
- Device management UI / "Log out everywhere" button
- `localStorage` refresh-token mirror (Safari ITP is less aggressive than feared for HTTP-set cookies)

## Documentation

- `docs/api.md` — POST `/auth/google-id-token` reference
- `docs/architecture.md` — silent re-auth flow summary in auth section
- `docs/deployment.md` — `VITE_SILENT_REAUTH_ENABLED` env var row + refresh TTL bump note
- `backend/app/rate_limit.py` + `CLAUDE.md` — 5/min cap for `/auth/google-id-token`