### PR TITLE
fix(timeline): keep Skill visible if a linked dated node is in range

### DIFF
--- a/frontend/src/stores/dateFilterStore.test.ts
+++ b/frontend/src/stores/dateFilterStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getNodeDates } from './dateFilterStore';
+import { getNodeDates, computeDateFilteredNodeIds } from './dateFilterStore';
 
 describe('getNodeDates', () => {
   it('extracts YYYY-MM from ISO dates', () => {
@@ -26,5 +26,140 @@ describe('getNodeDates', () => {
 
   it('returns empty for nodes with no date fields', () => {
     expect(getNodeDates({ name: 'Python' })).toHaveLength(0);
+  });
+});
+
+describe('computeDateFilteredNodeIds — dateless neighbor logic', () => {
+  const person = { uid: 'p', _labels: ['Person'] };
+
+  it('returns empty set when range is null', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [person, { uid: 'w1', _labels: ['WorkExperience'], start_date: '2020' }],
+      [],
+      null,
+      null,
+    );
+    expect(filtered.size).toBe(0);
+  });
+
+  it('returns empty set when range covers full bounds', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [{ uid: 'w1', _labels: ['WorkExperience'], start_date: '2020-01' }],
+      [],
+      '2019-01',
+      '2025-12',
+      '2020-01',
+      '2024-01',
+    );
+    expect(filtered.size).toBe(0);
+  });
+
+  it('never filters the Person node', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [person],
+      [],
+      '2020-01',
+      '2020-12',
+    );
+    expect(filtered.has('p')).toBe(false);
+  });
+
+  it('filters dated nodes that are out of range', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w1', _labels: ['WorkExperience'], start_date: '2018-01', end_date: '2019-06' },
+        { uid: 'w2', _labels: ['WorkExperience'], start_date: '2022-01', end_date: '2023-06' },
+      ],
+      [],
+      '2022-01',
+      '2022-12',
+    );
+    expect(filtered.has('w1')).toBe(true);
+    expect(filtered.has('w2')).toBe(false);
+  });
+
+  it('keeps Skill visible when ONE of two linked WorkExperiences is in range', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w_old', _labels: ['WorkExperience'], start_date: '2015-01', end_date: '2016-06' },
+        { uid: 'w_new', _labels: ['WorkExperience'], start_date: '2023-01', end_date: '2024-06' },
+        { uid: 's', _labels: ['Skill'], name: 'Python' },
+      ],
+      [
+        { source: 'w_old', target: 's' },
+        { source: 'w_new', target: 's' },
+      ],
+      '2023-01',
+      '2024-01',
+    );
+    expect(filtered.has('w_old')).toBe(true);
+    expect(filtered.has('w_new')).toBe(false);
+    expect(filtered.has('s')).toBe(false); // kept visible because w_new overlaps
+  });
+
+  it('hides Skill when ALL linked dated nodes are out of range', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w_old1', _labels: ['WorkExperience'], start_date: '2010-01', end_date: '2011-06' },
+        { uid: 'w_old2', _labels: ['WorkExperience'], start_date: '2012-01', end_date: '2013-06' },
+        { uid: 's', _labels: ['Skill'], name: 'COBOL' },
+      ],
+      [
+        { source: 'w_old1', target: 's' },
+        { source: 'w_old2', target: 's' },
+      ],
+      '2023-01',
+      '2024-01',
+    );
+    expect(filtered.has('s')).toBe(true);
+  });
+
+  it('hides Skill with no links at all', () => {
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w', _labels: ['WorkExperience'], start_date: '2023-01' },
+        { uid: 's', _labels: ['Skill'], name: 'Orphan' },
+      ],
+      [], // no edges
+      '2023-01',
+      '2024-01',
+    );
+    expect(filtered.has('s')).toBe(true);
+  });
+
+  it('one-hop only: Skill linked only to another dateless node stays hidden', () => {
+    // Skill A → Skill B (both dateless). Neither has a dated neighbor, so
+    // both are hidden — no transitive rescue.
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w', _labels: ['WorkExperience'], start_date: '2023-01' },
+        { uid: 'sA', _labels: ['Skill'], name: 'A' },
+        { uid: 'sB', _labels: ['Skill'], name: 'B' },
+      ],
+      [
+        { source: 'sA', target: 'sB' },
+        { source: 'w', target: 'sB' }, // sB is rescued by w, but sA is not transitively rescued through sB
+      ],
+      '2023-01',
+      '2024-01',
+    );
+    expect(filtered.has('sB')).toBe(false); // directly linked to w_new → kept
+    expect(filtered.has('sA')).toBe(true);  // only linked to another dateless → hidden
+  });
+
+  it('link direction does not matter (undirected traversal)', () => {
+    // The input is directed (source/target), but a Skill linked via
+    // "Skill -> WorkExperience" should still be rescued the same as
+    // "WorkExperience -> Skill".
+    const filtered = computeDateFilteredNodeIds(
+      [
+        { uid: 'w', _labels: ['WorkExperience'], start_date: '2023-01' },
+        { uid: 's', _labels: ['Skill'] },
+      ],
+      [{ source: 's', target: 'w' }], // flipped direction
+      '2023-01',
+      '2024-01',
+    );
+    expect(filtered.has('s')).toBe(false);
   });
 });

--- a/frontend/src/stores/dateFilterStore.ts
+++ b/frontend/src/stores/dateFilterStore.ts
@@ -82,12 +82,17 @@ function nodeIsInRange(
  * Logic:
  * 1. If range is null, return empty set (no filtering).
  * 2. Dated nodes outside the range → filtered.
- * 3. Dateless nodes (Skill, Language) are always visible.
+ * 3. Dateless nodes (Skill, Language, etc.) are visible iff at least one
+ *    directly-linked dated neighbor overlaps the range. A dateless node
+ *    with zero dated neighbors — or whose dated neighbors are all out of
+ *    range — is filtered. Link walk is one-hop only (a dateless neighbor
+ *    is never considered "reachable"), which keeps the computation O(N+E)
+ *    and matches the "the skill is active in this timeframe" intuition.
  * 4. Person node is never filtered.
  */
 export function computeDateFilteredNodeIds(
   nodes: Array<Record<string, unknown>>,
-  _links: Array<{ source: string; target: string }>,
+  links: Array<{ source: string; target: string }>,
   rangeStart: string | null,
   rangeEnd: string | null,
   boundsMin?: string | null,
@@ -98,7 +103,11 @@ export function computeDateFilteredNodeIds(
   if (boundsMin && boundsMax && rangeStart <= boundsMin && rangeEnd >= boundsMax) return new Set();
 
   const outOfRangeIds = new Set<string>();
+  const datelessIds: string[] = [];
+  const datedInRangeIds = new Set<string>();
 
+  // First pass — dated nodes. Dateless nodes are deferred to the second pass
+  // once we know which dated nodes are in range.
   for (const node of nodes) {
     const uid = node.uid as string;
     const labels = node._labels as string[] | undefined;
@@ -107,13 +116,42 @@ export function computeDateFilteredNodeIds(
     if (labels?.[0] === 'Person') continue;
 
     const dates = getNodeDates(node);
-    // Dateless nodes are hidden when slider is not at full range
     if (dates.length === 0) {
-      outOfRangeIds.add(uid);
+      datelessIds.push(uid);
       continue;
     }
 
-    if (!nodeIsInRange(node, rangeStart, rangeEnd)) {
+    if (nodeIsInRange(node, rangeStart, rangeEnd)) {
+      datedInRangeIds.add(uid);
+    } else {
+      outOfRangeIds.add(uid);
+    }
+  }
+
+  if (datelessIds.length === 0) return outOfRangeIds;
+
+  // Second pass — for each dateless node, check if any one-hop neighbor is
+  // a dated node that's in range. If yes, keep it visible; otherwise filter.
+  const neighborsByUid = new Map<string, string[]>();
+  for (const { source, target } of links) {
+    let outA = neighborsByUid.get(source);
+    if (!outA) {
+      outA = [];
+      neighborsByUid.set(source, outA);
+    }
+    outA.push(target);
+    let outB = neighborsByUid.get(target);
+    if (!outB) {
+      outB = [];
+      neighborsByUid.set(target, outB);
+    }
+    outB.push(source);
+  }
+
+  for (const uid of datelessIds) {
+    const neighbors = neighborsByUid.get(uid);
+    const hasVisibleDatedNeighbor = neighbors?.some((nb) => datedInRangeIds.has(nb)) ?? false;
+    if (!hasVisibleDatedNeighbor) {
       outOfRangeIds.add(uid);
     }
   }


### PR DESCRIPTION
Closes #407

## Summary

`computeDateFilteredNodeIds` unconditionally hid dateless nodes (Skill, Language) whenever the timeline slider was narrower than the full bounds. This contradicted the docstring ("dateless nodes are always visible") and produced surprising UX: narrowing the slider to the timeframe you worked on Python would hide the Python Skill node itself.

**New behavior:** a dateless node is visible iff at least one of its one-hop dated neighbors overlaps the selected range. Walk is one-hop only — no transitive rescue through other dateless nodes — keeping the algorithm O(N + E).

## Test plan

9 new cases in `frontend/src/stores/dateFilterStore.test.ts`:

- [x] Null range → empty filter set
- [x] Range covers full bounds → empty filter set
- [x] Person node never filtered
- [x] Dated nodes outside range are filtered
- [x] **Skill with one in-range + one out-of-range WorkExperience → visible** (the core fix)
- [x] Skill with all out-of-range WorkExperiences → hidden
- [x] Skill with zero links → hidden
- [x] Skill linked only to another dateless Skill → hidden (no transitive rescue)
- [x] Link direction does not matter (undirected walk)

All 14 tests in the file pass (5 pre-existing + 9 new). Build + lint clean.

## Documentation

No doc changes needed — the function's docstring was updated in-place to reflect the new logic, and the behavior change is invisible outside the store (same signature, same callers in `OrbViewPage.tsx` and `SharedOrbPage.tsx`).