### PR TITLE
hotfix(cv): drop Gemini response_schema — Vertex returns empty on unsupported fields

### DIFF
--- a/backend/app/cv/gemini_classifier.py
+++ b/backend/app/cv/gemini_classifier.py
@@ -31,7 +31,6 @@ async def call_gemini(
     from google.genai.types import GenerateContentConfig
 
     from app.config import settings
-    from app.cv.models import GeminiExtractionOutput
 
     if timeout is None:
         timeout = settings.llm_timeout_seconds
@@ -44,24 +43,28 @@ async def call_gemini(
         location=settings.vertex_region,
     )
 
-    # CV extraction is a structured classification task. We lean on three
-    # Gemini 2.5 Pro knobs to maximise extraction quality + determinism:
+    # CV extraction is a structured classification task. Three knobs,
+    # all safe under Vertex AI's response-config restrictions:
     #   - temperature=0.0: variance hurts the extraction-quality benchmark.
-    #   - response_mime_type + response_schema: force Vertex to emit JSON
-    #     matching the GeminiExtractionOutput contract — eliminates the
-    #     "Gemini wrapped the JSON in ```json fences" parse failures.
-    #   - seed: with temperature=0, pinning seed makes repeat runs on the
-    #     same input bit-identical. Useful for A/B testing prompt edits.
-    # max_output_tokens is tightened from 65k (model ceiling) to 16k —
-    # dense CVs peak around 8-12k tokens; 16k keeps headroom without
-    # letting a pathological loop burn the full ceiling.
+    #   - seed=42: with temperature=0, pinning seed makes repeat runs on
+    #     the same input bit-identical. Useful for A/B testing prompts.
+    #   - max_output_tokens=16384: dense CVs peak around 8-12k tokens;
+    #     16k keeps headroom without letting a pathological loop burn
+    #     the full 65k ceiling.
+    # NOTE: we intentionally do NOT set response_mime_type or
+    # response_schema. Vertex AI's response_schema has a restricted
+    # JSON Schema subset that does not support additionalProperties=true
+    # (needed by our ExtractedNode.properties: dict field). Enabling
+    # response_schema causes Vertex to silently return empty text
+    # despite an HTTP 200 — see v0.1.0-alpha.13 incident. The existing
+    # prompt-based JSON instructions in ollama_classifier.SYSTEM_PROMPT
+    # are sufficient; the downstream parser already handles markdown
+    # fences via json.JSONDecoder.raw_decode().
     config = GenerateContentConfig(
         system_instruction=system_prompt,
         max_output_tokens=16384,
         temperature=0.0,
         seed=42,
-        response_mime_type="application/json",
-        response_schema=GeminiExtractionOutput,
     )
 
     logger.info(

--- a/backend/app/cv/models.py
+++ b/backend/app/cv/models.py
@@ -49,32 +49,6 @@ class ExtractedData(BaseModel):
     prompt_hash: str | None = None
 
 
-class GeminiExtractionOutput(BaseModel):
-    """LLM output contract for CV extraction — used as `response_schema`
-    on the Gemini 2.5 Pro Vertex AI call to enforce structured output.
-
-    Mirrors the top-level JSON shape documented in
-    `ollama_classifier.SYSTEM_PROMPT`. Intentionally distinct from
-    `ExtractedData`: this is what the LLM must produce (profile fields
-    flat at the top level, no provenance metadata), not what Orbis
-    stores internally.
-    """
-
-    cv_owner_name: str | None = None
-    headline: str | None = None
-    location: str | None = None
-    email: str | None = None
-    phone: str | None = None
-    linkedin_url: str | None = None
-    github_url: str | None = None
-    twitter_url: str | None = None
-    website_url: str | None = None
-    scholar_url: str | None = None
-    nodes: list[ExtractedNode] = []
-    relationships: list[ExtractedRelationship] = []
-    unmatched: list[str] = []
-
-
 class ExtractionMetadata(BaseModel):
     """Metadata about how a CV extraction was performed."""
 


### PR DESCRIPTION
## Incident

v0.1.0-alpha.13 enabled \`response_schema=GeminiExtractionOutput\` on the Vertex AI Gemini call. In prod, this caused every CV upload via the Gemini path to fail with an empty response, falling through to Claude → rule-based → eventual job failure.

Example failure: job \`aad1c482-27df-48be-8192-0c570bd60364\` at \`2026-04-22T15:32:18\` in \`orbis-api\`. Log trail:
\`\`\`
15:30:08  Calling Gemini via Vertex AI: model=gemini-2.5-pro
15:32:18  HTTP Request: POST gemini-2.5-pro:generateContent "HTTP/1.1 200 OK"
15:32:18  ERROR: All providers in fallback chain failed — returning as unmatched
15:32:18  ERROR: Job ... failed (RuntimeError)
\`\`\`

HTTP 200 but empty \`response.text\` — Vertex AI's telltale response when the \`response_schema\` contains unsupported JSON Schema features.

## Root cause

Vertex AI's \`response_schema\` has a restricted JSON Schema subset. It does **not** support \`additionalProperties=true\`, which Pydantic emits for any \`dict\`-typed field. Our schema:

\`\`\`python
class GeminiExtractionOutput(BaseModel):
    nodes: list[ExtractedNode]  # ExtractedNode.properties: dict  ← problem
    ...
\`\`\`

The \`ExtractedNode.properties: dict\` serializes to \`{"type": "object", "additionalProperties": true}\`. Vertex silently returns empty text in this case — no 400, no warning in logs.

## Fix

Drop \`response_schema\` and \`response_mime_type\` from the \`GenerateContentConfig\`. Keep the three safe knobs from the same PR:

- \`temperature=0.0\` — deterministic extraction
- \`seed=42\` — cross-run reproducibility with temp=0
- \`max_output_tokens=16384\` — tighter cap than the 65k ceiling

Also remove the now-unused \`GeminiExtractionOutput\` Pydantic model from \`app/cv/models.py\`.

The existing prompt-based JSON instructions in \`ollama_classifier.SYSTEM_PROMPT\` + downstream \`json.JSONDecoder.raw_decode()\` in the parser already handle markdown-fenced output robustly.

## Documentation

No doc changes needed — this is a strict subset revert of alpha.13's config change.

## Release

Cut v0.1.0-alpha.14 immediately on merge — prod CV ingest is broken.