### PR TITLE
hotfix(cv): restore Gemini max_output_tokens to 65536

### DIFF
--- a/backend/app/cv/gemini_classifier.py
+++ b/backend/app/cv/gemini_classifier.py
@@ -48,9 +48,12 @@ async def call_gemini(
     #   - temperature=0.0: variance hurts the extraction-quality benchmark.
     #   - seed=42: with temperature=0, pinning seed makes repeat runs on
     #     the same input bit-identical. Useful for A/B testing prompts.
-    #   - max_output_tokens=16384: dense CVs peak around 8-12k tokens;
-    #     16k keeps headroom without letting a pathological loop burn
-    #     the full 65k ceiling.
+    #   - max_output_tokens=65536: model ceiling. An earlier alpha.14
+    #     tried 16384 as a "pathological-loop guard" but dense academic
+    #     CVs (e.g. Riccardo Massidda, 16:09 UTC 2026-04-22) produce
+    #     >19k chars of JSON and get silently truncated mid-value,
+    #     leaving unparseable output. Restore the ceiling and let the
+    #     LLM timeout be the real safeguard.
     # NOTE: we intentionally do NOT set response_mime_type or
     # response_schema. Vertex AI's response_schema has a restricted
     # JSON Schema subset that does not support additionalProperties=true
@@ -62,7 +65,7 @@ async def call_gemini(
     # fences via json.JSONDecoder.raw_decode().
     config = GenerateContentConfig(
         system_instruction=system_prompt,
-        max_output_tokens=16384,
+        max_output_tokens=65536,
         temperature=0.0,
         seed=42,
     )


### PR DESCRIPTION
## Incident (continuation of alpha.13/14 tuning)

v0.1.0-alpha.13 tightened \`max_output_tokens\` from the model ceiling (65536) to 16384 as a "pathological-loop guard". v0.1.0-alpha.14 hotfix kept that tighter cap.

**In prod this silently truncates dense academic CVs mid-value.** Observed on 2026-04-22 16:09 UTC for Riccardo Massidda's CV (post-doc, long publication list):

\`\`\`
16:07:36 PDF extraction complete: 10891 characters
16:07:37 Calling Gemini via Vertex AI: model=gemini-2.5-pro
16:09:42 HTTP 200 OK
16:09:42 Gemini Vertex AI response received (19049 chars)
16:09:42 WARNING Failed to parse LLM response as JSON (len=19040, first 200: {"cv_owner_name":"Riccardo Massidda","headline":"Post-Doc Researcher @ University of Pisa","location":"Pisa, Italy","email":"riccardo.massidda@phd.unipi.it","website_url":"https://)  ← truncated
16:09:42 WARNING Gemini Pro returned empty result, trying next
16:09:42 ERROR All providers in fallback chain failed — returning as unmatched
16:09:42 ERROR Job 8d0dafe8 failed
16:09:42 INFO Email sent to massidda.riccardo@gmail.com — subject: CV processing needs attention
\`\`\`

The first-200-char snippet literally ends at \`"website_url":"https://\` — Gemini ran out of token budget mid-value. The downstream \`_parse_result\`'s \`raw_decode\` loop can't find a valid top-level object with \`"nodes"\` in the truncated output, returns an empty ClassificationResult.

The production fallback chain is \`LLM_FALLBACK_CHAIN=gemini-pro\` (Gemini only), so there is no Claude safety net when Gemini fails — the job dies immediately.

## Fix

Restore \`max_output_tokens=65536\` (model ceiling). The LLM timeout on the caller side (\`settings.llm_timeout_seconds\`) is the real runaway-loop guard; the tighter token cap was solving a problem we don't actually have while creating a real one.

Keep:
- \`temperature=0.0\` — safe, improves determinism
- \`seed=42\` — safe, improves cross-run reproducibility

## Post-deploy

Ask the affected user (Massidda) to retry their CV upload once alpha.15 is live.

## Documentation

No doc changes needed — this is a scalar config tweak.