### PR TITLE
feat(chat): clicking a search result opens the node edit modal

### DIFF
--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -327,6 +327,28 @@
   next_state: ORB_VIEW (with highlights)
   fallback_on_failure: "No matches found" message
 
+- id: ORB_CLICK_RESULT
+  from_state: ORB_VIEW
+  action: Click a search result node in the ChatBox result list
+  selector_or_control: "node result in ChatBox results list"
+  preconditions: [search_results_exist]
+  expected_effect: >-
+    Focuses camera on the node in the 3D graph AND opens the NodeForm edit
+    modal pre-populated with the node's current properties. Result list
+    remains visible (dimmed) behind the modal backdrop; scroll position
+    preserved.
+  next_state: FLOATING_INPUT
+  fallback_on_failure: null
+
+- id: ORB_CLICK_RESULT_ENTER
+  from_state: ORB_VIEW
+  action: Press Enter on an active search result row (no text in input)
+  selector_or_control: "ChatBox input field with results visible"
+  preconditions: [search_results_exist, active_result_row]
+  expected_effect: Same as ORB_CLICK_RESULT (focus + open edit modal)
+  next_state: FLOATING_INPUT
+  fallback_on_failure: null
+
 - id: ORB_FILTER_NODE_TYPES
   from_state: ORB_VIEW
   action: Toggle node types in NodeTypeFilter
@@ -603,7 +625,9 @@
   action: Click a search result node
   selector_or_control: "node result in ChatBox results list"
   preconditions: [search_results_exist]
-  expected_effect: Camera centers on the node in 3D graph
+  expected_effect: >-
+    Camera centers on the node in 3D graph. No edit modal — shared orbs
+    are read-only for non-owners.
   next_state: SHARED_ORB (focused)
   fallback_on_failure: null
 

--- a/docs/navigation-flow.md
+++ b/docs/navigation-flow.md
@@ -2,7 +2,7 @@
 
 > Navigable user-flow map for agent-based UX evaluation. Covers all pages, modals, interactions, guards, and error states.
 >
-> **Last updated:** 2026-04-17 | **Issue:** #193, #274, #368
+> **Last updated:** 2026-04-23 | **Issue:** #193, #274, #368, #415
 
 ## How to Update This Map
 
@@ -125,7 +125,7 @@ stateDiagram-v2
     }
 
     %% ── Transitions ──
-    MAIN --> FLOATING_INPUT: Click node / Click "+" / Draft "Add to graph"
+    MAIN --> FLOATING_INPUT: Click node / Click "+" / Draft "Add to graph" / Click search result / Enter on active result row
     FLOATING_INPUT --> MAIN: Save / Cancel / Delete
     MAIN --> SHARE_PANEL: Click Share
     SHARE_PANEL --> MAIN: Close
@@ -154,6 +154,15 @@ stateDiagram-v2
     GUIDED_TOUR --> MAIN: Finish / Skip / Close
     ACCOUNT_SETTINGS --> GUIDED_TOUR: Sidebar "Guided tour" button
 ```
+
+### ChatBox Search → Node Edit
+
+- **From `MAIN` (ORB_VIEW) with search results visible:**
+  - `ORB_CLICK_RESULT` (click a result row) or `ORB_CLICK_RESULT_ENTER` (press Enter on an active result row with no text in the input):
+    → focuses camera on the node in the 3D graph AND opens the `FLOATING_INPUT` (NodeForm) modal pre-populated with the node's current properties.
+    → Transitions to `FLOATING_INPUT` state. Result list remains visible (dimmed) behind the modal backdrop; scroll position is preserved.
+    → Escape / backdrop-click / Cancel returns to `MAIN` with the result list still visible.
+  - Note: this flow is **owner-only**. On shared orbs (`SHARED_ORB`), clicking a result only centers the camera — no edit modal is opened (read-only).
 
 ---
 

--- a/frontend/src/components/chat/ChatBox.test.tsx
+++ b/frontend/src/components/chat/ChatBox.test.tsx
@@ -94,4 +94,73 @@ describe('ChatBox search result row', () => {
     expect(onFocusNode).toHaveBeenCalledWith('uid-a');
     expect(onEditNode).toHaveBeenCalledWith('uid-a');
   });
+
+  it('Enter on an active result row fires onEditNode', () => {
+    const onEditNode = vi.fn();
+    render(
+      <ChatBox
+        onHighlight={() => {}}
+        messages={seededMessages}
+        onMessagesChange={() => {}}
+        onFocusNode={() => {}}
+        onEditNode={onEditNode}
+      />,
+    );
+    const input = screen.getByPlaceholderText(/Query your orbis/i);
+    // selectedNodeUid in seededMessages already activates row 0.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onEditNode).toHaveBeenCalledWith('uid-a');
+  });
+
+  it('ArrowDown / ArrowUp cycle through rows and call onFocusNode for each', () => {
+    const nodeB = {
+      uid: 'uid-b',
+      name: 'Beta Skill',
+      _labels: ['Skill'],
+      score: 0.8,
+    } as unknown as import('../../api/orbs').OrbNode;
+    const messages = [
+      { role: 'user' as const, text: 'q' },
+      {
+        role: 'assistant' as const,
+        text: 'Found 2 matching nodes — click one to highlight it in your graph.',
+        matchedNodes: [nodeA, nodeB],
+        selectedNodeUid: nodeA.uid,
+      },
+    ];
+    const onFocusNode = vi.fn();
+    const onEditNode = vi.fn();
+    render(
+      <ChatBox
+        onHighlight={() => {}}
+        messages={messages}
+        onMessagesChange={() => {}}
+        onFocusNode={onFocusNode}
+        onEditNode={onEditNode}
+      />,
+    );
+    const input = screen.getByPlaceholderText(/Query your orbis/i);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    // Arrow keys navigate rows; onFocusNode fires for each step.
+    expect(onFocusNode).toHaveBeenCalled();
+    // Arrow navigation goes through handleResultClick which also fires onEditNode —
+    // verify it was called with row uids (not called zero times).
+    expect(onEditNode).toHaveBeenCalled();
+  });
+
+  it('omitting onEditNode still calls onFocusNode on click (no crash)', () => {
+    const onFocusNode = vi.fn();
+    render(
+      <ChatBox
+        onHighlight={() => {}}
+        messages={seededMessages}
+        onMessagesChange={() => {}}
+        onFocusNode={onFocusNode}
+      />,
+    );
+    const row = screen.getByRole('option', { name: /alpha skill/i });
+    fireEvent.click(row);
+    expect(onFocusNode).toHaveBeenCalledWith('uid-a');
+  });
 });

--- a/frontend/src/components/chat/ChatBox.test.tsx
+++ b/frontend/src/components/chat/ChatBox.test.tsx
@@ -112,7 +112,7 @@ describe('ChatBox search result row', () => {
     expect(onEditNode).toHaveBeenCalledWith('uid-a');
   });
 
-  it('ArrowDown / ArrowUp cycle through rows and call onFocusNode for each', () => {
+  it('ArrowDown / ArrowUp focus the next row but do not fire onEditNode', () => {
     const nodeB = {
       uid: 'uid-b',
       name: 'Beta Skill',
@@ -144,9 +144,7 @@ describe('ChatBox search result row', () => {
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     // Arrow keys navigate rows; onFocusNode fires for each step.
     expect(onFocusNode).toHaveBeenCalled();
-    // Arrow navigation goes through handleResultClick which also fires onEditNode —
-    // verify it was called with row uids (not called zero times).
-    expect(onEditNode).toHaveBeenCalled();
+    expect(onEditNode).not.toHaveBeenCalled();
   });
 
   it('omitting onEditNode still calls onFocusNode on click (no crash)', () => {

--- a/frontend/src/components/chat/ChatBox.test.tsx
+++ b/frontend/src/components/chat/ChatBox.test.tsx
@@ -77,39 +77,52 @@ describe('ChatBox search result row', () => {
     },
   ];
 
-  it('clicking a result row fires both onFocusNode and onEditNode with the node uid', () => {
-    const onFocusNode = vi.fn();
-    const onEditNode = vi.fn();
-    render(
-      <ChatBox
-        onHighlight={() => {}}
-        messages={seededMessages}
-        onMessagesChange={() => {}}
-        onFocusNode={onFocusNode}
-        onEditNode={onEditNode}
-      />,
-    );
-    const row = screen.getByRole('option', { name: /alpha skill/i });
-    fireEvent.click(row);
-    expect(onFocusNode).toHaveBeenCalledWith('uid-a');
-    expect(onEditNode).toHaveBeenCalledWith('uid-a');
+  it('clicking a result row focuses the camera synchronously and opens the edit modal after a short delay', () => {
+    vi.useFakeTimers();
+    try {
+      const onFocusNode = vi.fn();
+      const onEditNode = vi.fn();
+      render(
+        <ChatBox
+          onHighlight={() => {}}
+          messages={seededMessages}
+          onMessagesChange={() => {}}
+          onFocusNode={onFocusNode}
+          onEditNode={onEditNode}
+        />,
+      );
+      const row = screen.getByRole('option', { name: /alpha skill/i });
+      fireEvent.click(row);
+      expect(onFocusNode).toHaveBeenCalledWith('uid-a');
+      expect(onEditNode).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(onEditNode).toHaveBeenCalledWith('uid-a');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it('Enter on an active result row fires onEditNode', () => {
-    const onEditNode = vi.fn();
-    render(
-      <ChatBox
-        onHighlight={() => {}}
-        messages={seededMessages}
-        onMessagesChange={() => {}}
-        onFocusNode={() => {}}
-        onEditNode={onEditNode}
-      />,
-    );
-    const input = screen.getByPlaceholderText(/Query your orbis/i);
-    // selectedNodeUid in seededMessages already activates row 0.
-    fireEvent.keyDown(input, { key: 'Enter' });
-    expect(onEditNode).toHaveBeenCalledWith('uid-a');
+  it('Enter on an active result row opens the edit modal after the camera-focus delay', () => {
+    vi.useFakeTimers();
+    try {
+      const onEditNode = vi.fn();
+      render(
+        <ChatBox
+          onHighlight={() => {}}
+          messages={seededMessages}
+          onMessagesChange={() => {}}
+          onFocusNode={() => {}}
+          onEditNode={onEditNode}
+        />,
+      );
+      const input = screen.getByPlaceholderText(/Query your orbis/i);
+      // selectedNodeUid in seededMessages already activates row 0.
+      fireEvent.keyDown(input, { key: 'Enter' });
+      vi.runAllTimers();
+      expect(onEditNode).toHaveBeenCalledWith('uid-a');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('ArrowDown / ArrowUp focus the next row but do not fire onEditNode', () => {

--- a/frontend/src/components/chat/ChatBox.test.tsx
+++ b/frontend/src/components/chat/ChatBox.test.tsx
@@ -58,3 +58,40 @@ describe('ChatBox action buttons', () => {
     expect(order).toEqual([0, 1, 2]);
   });
 });
+
+describe('ChatBox search result row', () => {
+  const nodeA = {
+    uid: 'uid-a',
+    name: 'Alpha Skill',
+    _labels: ['Skill'],
+    score: 0.9,
+  } as unknown as import('../../api/orbs').OrbNode;
+
+  const seededMessages = [
+    { role: 'user' as const, text: 'alpha' },
+    {
+      role: 'assistant' as const,
+      text: 'Found 1 matching node — highlighted in your graph.',
+      matchedNodes: [nodeA],
+      selectedNodeUid: nodeA.uid,
+    },
+  ];
+
+  it('clicking a result row fires both onFocusNode and onEditNode with the node uid', () => {
+    const onFocusNode = vi.fn();
+    const onEditNode = vi.fn();
+    render(
+      <ChatBox
+        onHighlight={() => {}}
+        messages={seededMessages}
+        onMessagesChange={() => {}}
+        onFocusNode={onFocusNode}
+        onEditNode={onEditNode}
+      />,
+    );
+    const row = screen.getByRole('option', { name: /alpha skill/i });
+    fireEvent.click(row);
+    expect(onFocusNode).toHaveBeenCalledWith('uid-a');
+    expect(onEditNode).toHaveBeenCalledWith('uid-a');
+  });
+});

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -13,6 +13,7 @@ interface ChatMessage {
 interface ChatBoxProps {
   onHighlight: (nodeIds: Set<string>) => void;
   onFocusNode?: (nodeUid: string) => void;
+  onEditNode?: (nodeUid: string) => void;
   onClearResults?: () => void;
   highlightedNodeIds?: Set<string>;
   messages: ChatMessage[];
@@ -87,6 +88,7 @@ function getScoreStyle(score: number): { dot: string; text: string } {
 export default function ChatBox({
   onHighlight,
   onFocusNode,
+  onEditNode,
   onClearResults,
   highlightedNodeIds,
   messages,
@@ -218,6 +220,7 @@ export default function ChatBox({
   const handleResultClick = (messageIndex: number, nodeUid: string) => {
     onHighlight(new Set([nodeUid]));
     onFocusNode?.(nodeUid);
+    onEditNode?.(nodeUid);
     setMessages((prev) => prev.map((msg, idx) => {
       if (idx !== messageIndex || !msg.matchedNodes) return msg;
       return { ...msg, selectedNodeUid: nodeUid };

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -217,10 +217,10 @@ export default function ChatBox({
     }
   };
 
-  const handleResultClick = (messageIndex: number, nodeUid: string) => {
+  const handleResultClick = (messageIndex: number, nodeUid: string, openEdit: boolean = true) => {
     onHighlight(new Set([nodeUid]));
     onFocusNode?.(nodeUid);
-    onEditNode?.(nodeUid);
+    if (openEdit) onEditNode?.(nodeUid);
     setMessages((prev) => prev.map((msg, idx) => {
       if (idx !== messageIndex || !msg.matchedNodes) return msg;
       return { ...msg, selectedNodeUid: nodeUid };
@@ -244,7 +244,7 @@ export default function ChatBox({
       e.preventDefault();
       const next = activeResultIndex < 0 ? 0 : (activeResultIndex + 1) % resultNodes.length;
       setActiveResultIndex(next);
-      handleResultClick(resultMessageIndex, resultNodes[next].uid);
+      handleResultClick(resultMessageIndex, resultNodes[next].uid, false);
       return;
     }
 
@@ -254,7 +254,7 @@ export default function ChatBox({
         ? resultNodes.length - 1
         : (activeResultIndex - 1 + resultNodes.length) % resultNodes.length;
       setActiveResultIndex(next);
-      handleResultClick(resultMessageIndex, resultNodes[next].uid);
+      handleResultClick(resultMessageIndex, resultNodes[next].uid, false);
       return;
     }
 

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -220,11 +220,12 @@ export default function ChatBox({
   const handleResultClick = (messageIndex: number, nodeUid: string, openEdit: boolean = true) => {
     onHighlight(new Set([nodeUid]));
     onFocusNode?.(nodeUid);
-    if (openEdit) onEditNode?.(nodeUid);
     setMessages((prev) => prev.map((msg, idx) => {
       if (idx !== messageIndex || !msg.matchedNodes) return msg;
       return { ...msg, selectedNodeUid: nodeUid };
     }));
+    // Let the 900ms camera animation start before the modal covers the view.
+    if (openEdit) setTimeout(() => onEditNode?.(nodeUid), 400);
   };
 
   const handleClearResults = () => {
@@ -344,7 +345,7 @@ export default function ChatBox({
                                 onMouseEnter={() => setActiveResultIndex(j)}
                                 role="option"
                                 aria-selected={isSelected}
-                                className="w-full flex items-center gap-2 rounded-lg px-3 py-2 sm:py-2.5 backdrop-blur-sm text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/70"
+                                className="w-full flex items-center gap-2 rounded-lg px-3 py-2 sm:py-2.5 backdrop-blur-sm text-left transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/70"
                                 style={{
                                   backgroundColor: isSelected
                                     ? 'rgba(139,92,246,0.18)'

--- a/frontend/src/components/editor/FloatingInput.tsx
+++ b/frontend/src/components/editor/FloatingInput.tsx
@@ -27,10 +27,7 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        onCancel();
-      }
+      if (e.key === 'Escape') onCancel();
     };
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
@@ -45,7 +42,7 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black/70 backdrop-blur-[3px] z-[60]"
+            className="fixed inset-0 bg-black/70 backdrop-blur-[3px] z-[65]"
             onClick={onCancel}
           />
           <motion.div
@@ -53,7 +50,7 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.92, y: 30 }}
             transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-            className="fixed inset-0 z-[70] flex items-center justify-center p-2 sm:p-4"
+            className="fixed inset-0 z-[75] flex items-center justify-center p-2 sm:p-4"
           >
             <div className="relative w-full max-w-[96vw] sm:max-w-3xl rounded-3xl border border-white/12 bg-neutral-950 shadow-[0_30px_120px_-30px_rgba(0,0,0,0.9)] overflow-hidden">
               <div className="pointer-events-none absolute inset-x-0 top-0 h-44 bg-gradient-to-b from-white/[0.07] via-white/[0.02] to-transparent" />

--- a/frontend/src/components/editor/FloatingInput.tsx
+++ b/frontend/src/components/editor/FloatingInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { NODE_TYPE_COLORS, NODE_TYPE_LABELS } from '../graph/NodeColors';
 import NodeForm from './NodeForm';
@@ -24,6 +24,18 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
     setCurrentType(type);
   }, []);
 
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onCancel]);
+
   return (
     <AnimatePresence>
       {open && (
@@ -33,7 +45,7 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black/70 backdrop-blur-[3px] z-40"
+            className="fixed inset-0 bg-black/70 backdrop-blur-[3px] z-[60]"
             onClick={onCancel}
           />
           <motion.div
@@ -41,7 +53,7 @@ export default function FloatingInput({ open, editNode, referenceNote, onSubmit,
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.92, y: 30 }}
             transition={{ type: 'spring', damping: 28, stiffness: 320 }}
-            className="fixed inset-0 z-50 flex items-center justify-center p-2 sm:p-4"
+            className="fixed inset-0 z-[70] flex items-center justify-center p-2 sm:p-4"
           >
             <div className="relative w-full max-w-[96vw] sm:max-w-3xl rounded-3xl border border-white/12 bg-neutral-950 shadow-[0_30px_120px_-30px_rgba(0,0,0,0.9)] overflow-hidden">
               <div className="pointer-events-none absolute inset-x-0 top-0 h-44 bg-gradient-to-b from-white/[0.07] via-white/[0.02] to-transparent" />

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -1027,6 +1027,10 @@ export default function OrbViewPage() {
       {!isPendingDeletion && <ChatBox
         onHighlight={setHighlightedNodeIds}
         onFocusNode={handleFocusNode}
+        onEditNode={(uid) => {
+          const node = data?.nodes.find((n) => n.uid === uid);
+          if (node) handleNodeClick(node);
+        }}
         onClearResults={handleChatClear}
         highlightedNodeIds={highlightedNodeIds}
         messages={chatMessages}


### PR DESCRIPTION
Closes #415.

## Summary

- `ChatBox` now exposes an optional `onEditNode` callback. On `/myorbis`, clicking a search result row (or pressing `Enter` on an active row) focuses the 3D camera and — 400 ms later, after the camera has visibly started moving — opens the existing NodeForm edit modal pre-populated with that node's properties.
- ArrowUp/ArrowDown still navigate results with the camera only; no modal churn while browsing.
- `FloatingInput` now closes on `Escape` and stacks at `z-[65]`/`z-[75]` so the result list dims behind the modal backdrop instead of floating above it.
- Result rows get `cursor-pointer` for clearer affordance.
- Shared orb view (`SharedOrbPage`) is unchanged: it deliberately omits `onEditNode`, so clicking a result on someone else's orb still only moves the camera — matching the read-only nature of that page.

## Design & plan

- Spec and plan live under `docs/superpowers/` (gitignored). Core design summary: `ChatBox` remains stateless about what editing means — it just calls the callback. `OrbViewPage` passes a callback that looks up the node in `data.nodes` and delegates to the existing `handleNodeClick`, so the Person-node guard, label→type map, and `setEditNode` / `setShowInput` path remain the single source of truth.
- The new `Escape`-to-close handler in `FloatingInput` also benefits `CreateOrbPage`, which had no Escape support. It coexists idempotently with `OrbViewPage`'s existing document-level Escape handler — intentional redundancy, documented here so future maintainers don't remove the modal-local one thinking it's duplicate.

## Documentation

Per `CLAUDE.md`'s pre-PR doc check:
- `docs/navigation-actions.yaml`: added `ORB_CLICK_RESULT` and `ORB_CLICK_RESULT_ENTER` owner actions; clarified `SHARED_CLICK_RESULT.expected_effect` to note shared orbs are read-only (no modal).
- `docs/navigation-flow.md`: updated Mermaid `MAIN → FLOATING_INPUT` transition label; added a "ChatBox Search → Node Edit" subsection.
No API, schema, or deployment changes — pure frontend UI + docs.

## Test plan

- [x] `npx vitest run src/components/chat/ChatBox.test.tsx` → 7/7 passing (new coverage for click, Enter, Arrow-keys-no-modal, and the optional-prop absence case).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean (57 pre-existing warnings unchanged).
- [x] Manual smoke test on local dev (`/myorbis`): search → click result → camera pans → modal opens pre-populated → Escape closes → result list still visible underneath.