### PR TITLE
feat(graph): highlight node + one-hop neighbors on hover

### DIFF
--- a/docs/navigation-actions.yaml
+++ b/docs/navigation-actions.yaml
@@ -349,6 +349,20 @@
   next_state: FLOATING_INPUT
   fallback_on_failure: null
 
+- id: ORB_HOVER_NODE
+  from_state: ORB_VIEW
+  action: Mouse over a node in the 3D graph
+  selector_or_control: "3D canvas node mesh"
+  preconditions: []
+  expected_effect: >-
+    Hovered node and its one-hop neighbors stay at full opacity; all other
+    nodes dim to ~0.2 opacity; edges inside the 1-hop neighborhood brighten
+    while edges leaving it dim. Mouse-leave fades back over 200 ms after an
+    80 ms debounce. Composes with existing search / filter state — a
+    search-highlighted node stays bright during an unrelated hover.
+  next_state: ORB_VIEW (transient visual emphasis — not a navigable state)
+  fallback_on_failure: null
+
 - id: ORB_FILTER_NODE_TYPES
   from_state: ORB_VIEW
   action: Toggle node types in NodeTypeFilter

--- a/frontend/src/components/chat/ChatBox.test.tsx
+++ b/frontend/src/components/chat/ChatBox.test.tsx
@@ -115,7 +115,7 @@ describe('ChatBox search result row', () => {
           onEditNode={onEditNode}
         />,
       );
-      const input = screen.getByPlaceholderText(/Query your orbis/i);
+      const input = screen.getByPlaceholderText(/Search for a node/i);
       // selectedNodeUid in seededMessages already activates row 0.
       fireEvent.keyDown(input, { key: 'Enter' });
       vi.runAllTimers();
@@ -152,7 +152,7 @@ describe('ChatBox search result row', () => {
         onEditNode={onEditNode}
       />,
     );
-    const input = screen.getByPlaceholderText(/Query your orbis/i);
+    const input = screen.getByPlaceholderText(/Search for a node/i);
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     // Arrow keys navigate rows; onFocusNode fires for each step.

--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -98,7 +98,7 @@ export default function ChatBox({
   onConnectedAi,
   onDiscover,
   highlightAdd,
-  placeholder = 'Query your orbis...',
+  placeholder = 'Search for a node...',
   searchFn = textSearch,
   interactionHint = 'Zoom: mouse wheel · Pan: right-drag · Rotate: left-drag',
   onRecenter,

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -29,9 +29,7 @@ interface OrbGraph3DProps {
 
 
 // Hover one-hop highlight (issue #414) — see design doc. Used in Task 4.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const HOVER_LEAVE_DEBOUNCE_MS = 80;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const HOVER_FADE_MS = 200;
 const HOVER_DIM_OPACITY = 0.2;
 
@@ -75,6 +73,8 @@ export default function OrbGraph3D({
   const materialHandlesRef = useRef<Map<string, THREE.Material[]>>(new Map());
   const hoverEmphasizedUidsRef = useRef<Set<string>>(new Set());
   const [hoverTick, setHoverTick] = useState(0);
+  const hoverLeaveTimerRef = useRef<number | null>(null);
+  const fadeAnimationRef = useRef<number | null>(null);
   const prevHighlightKeyRef = useRef<string>('');
   const isHoveringRef = useRef(false);
   // Direct refs to orbital rings — avoids scene.traverse() every frame
@@ -389,19 +389,73 @@ export default function OrbGraph3D({
     const el = document.querySelector('canvas');
     if (el) el.style.cursor = node ? 'pointer' : 'default';
 
+    // Any new hover event cancels a pending leave debounce and any running fade.
+    if (hoverLeaveTimerRef.current !== null) {
+      clearTimeout(hoverLeaveTimerRef.current);
+      hoverLeaveTimerRef.current = null;
+    }
+    if (fadeAnimationRef.current !== null) {
+      cancelAnimationFrame(fadeAnimationRef.current);
+      fadeAnimationRef.current = null;
+    }
+
     if (node) {
+      // Immediate emphasize — snap on enter, no delay.
       const uid = (node.id || node.uid) as string;
       const neighbors = adjacencyMapRef.current.get(uid);
       const emphasized = new Set<string>([uid]);
       if (neighbors) for (const n of neighbors) emphasized.add(n);
       hoverEmphasizedUidsRef.current = emphasized;
+      setHoverTick((t) => t + 1);
     } else {
-      hoverEmphasizedUidsRef.current = new Set();
+      // Debounced leave — if no new hover arrives within 80 ms, clear and fade.
+      hoverLeaveTimerRef.current = window.setTimeout(() => {
+        hoverLeaveTimerRef.current = null;
+        const startTime = performance.now();
+        const materialsAtStart: Array<{ mat: THREE.Material; from: number; to: number }> = [];
+        materialHandlesRef.current.forEach((materials) => {
+          for (const mat of materials) {
+            const base = (mat.userData.__baseOpacity as number | undefined) ?? 1;
+            materialsAtStart.push({ mat, from: mat.opacity, to: base });
+          }
+        });
+        hoverEmphasizedUidsRef.current = new Set();
+
+        const step = () => {
+          const elapsed = performance.now() - startTime;
+          const t = Math.min(1, elapsed / HOVER_FADE_MS);
+          for (const { mat, from, to } of materialsAtStart) {
+            mat.opacity = from + (to - from) * t;
+          }
+          if (t < 1) {
+            fadeAnimationRef.current = requestAnimationFrame(step);
+          } else {
+            fadeAnimationRef.current = null;
+            setHoverTick((n) => n + 1); // final state + link recolor
+          }
+        };
+        fadeAnimationRef.current = requestAnimationFrame(step);
+        // Kick link recolor now so links snap to their un-hovered color while
+        // node opacity animates — visually indistinguishable over 200 ms and
+        // avoids extra fg.refresh() calls during the fade.
+        const fg = fgRef.current;
+        if (fg) fg.refresh();
+      }, HOVER_LEAVE_DEBOUNCE_MS);
     }
-    setHoverTick((t) => t + 1);
   }, []);
 
   useEffect(() => {
+    return () => {
+      if (hoverLeaveTimerRef.current !== null) clearTimeout(hoverLeaveTimerRef.current);
+      if (fadeAnimationRef.current !== null) cancelAnimationFrame(fadeAnimationRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Skip this effect's snap-set while a fade animation is running; the fade
+    // loop is driving opacity directly and will setHoverTick again on completion.
+    if (fadeAnimationRef.current !== null) return;
+
     const emphasized = hoverEmphasizedUidsRef.current;
     const filterHighlights = highlightRef.current;
     const isHovering = emphasized.size > 0;
@@ -687,12 +741,20 @@ export default function OrbGraph3D({
       onPointerEnter={() => { isHoveringRef.current = true; }}
       onPointerLeave={() => {
         isHoveringRef.current = false;
-        // Dismiss the tooltip immediately when the pointer leaves the canvas.
-        // react-force-graph only fires onNodeHover(null) on ray-miss INSIDE the
-        // canvas — if the pointer exits the canvas while over a node, the
-        // tooltip would otherwise stay stuck open.
         setHoveredNode(null);
         hoveredNodeRef.current = null;
+        // Clear hover emphasis immediately when the pointer exits the canvas
+        // (no 80 ms debounce — matches the tooltip-dismiss UX).
+        if (hoverLeaveTimerRef.current !== null) {
+          clearTimeout(hoverLeaveTimerRef.current);
+          hoverLeaveTimerRef.current = null;
+        }
+        if (fadeAnimationRef.current !== null) {
+          cancelAnimationFrame(fadeAnimationRef.current);
+          fadeAnimationRef.current = null;
+        }
+        hoverEmphasizedUidsRef.current = new Set();
+        setHoverTick((t) => t + 1);
       }}
     >
       <ForceGraph3D

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -373,16 +373,28 @@ export default function OrbGraph3D({
     return () => { cancelled = true; };
   }, [focusNodeId, focusNodeToken, graphData.nodes, cameraDistance]);
 
+  // Drag state — while the user is dragging a node, suppress hover changes
+  // so the highlight doesn't flicker as the raycast briefly misses the node.
+  const isDraggingRef = useRef(false);
+  const hoverLeaveTimerRef = useRef<number | null>(null);
+
   const handleNodeHover = useCallback((node: any) => {
     setHoveredNode(node || null);
     hoveredNodeRef.current = node || null;
     const el = document.querySelector('canvas');
     if (el) el.style.cursor = node ? 'pointer' : 'default';
 
-    // Drive the existing highlight-dimming mechanism — same approach the Top
-    // Hub metric uses (see OrbisStatsOverlay). Emphasized set = hovered node
-    // + one-hop neighbors. On leave, clear.
     if (!onHoverHighlight) return;
+    if (isDraggingRef.current) return;
+
+    // Drive the existing highlight-dimming mechanism — same approach the Top
+    // Hub metric uses. Emphasized set = hovered node + one-hop neighbors. On
+    // leave, debounce by 80 ms so a brief raycast miss (e.g. cursor crossing
+    // a thin gap) doesn't wipe the highlight and trigger a full scene rebuild.
+    if (hoverLeaveTimerRef.current !== null) {
+      clearTimeout(hoverLeaveTimerRef.current);
+      hoverLeaveTimerRef.current = null;
+    }
     if (node) {
       const uid = (node.id || node.uid) as string;
       const neighbors = adjacencyMapRef.current.get(uid);
@@ -390,9 +402,26 @@ export default function OrbGraph3D({
       if (neighbors) for (const n of neighbors) emphasized.add(n);
       onHoverHighlight(emphasized);
     } else {
-      onHoverHighlight(new Set());
+      hoverLeaveTimerRef.current = window.setTimeout(() => {
+        hoverLeaveTimerRef.current = null;
+        onHoverHighlight(new Set());
+      }, 80);
     }
   }, [onHoverHighlight]);
+
+  useEffect(() => {
+    return () => {
+      if (hoverLeaveTimerRef.current !== null) clearTimeout(hoverLeaveTimerRef.current);
+    };
+  }, []);
+
+  const handleNodeDrag = useCallback(() => {
+    isDraggingRef.current = true;
+  }, []);
+
+  const handleNodeDragEnd = useCallback(() => {
+    isDraggingRef.current = false;
+  }, []);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     setTooltipPos({ x: e.clientX, y: e.clientY });
@@ -666,6 +695,8 @@ export default function OrbGraph3D({
         linkCurvature={0.15}
         linkCurveRotation={0.5}
         onNodeHover={handleNodeHover}
+        onNodeDrag={handleNodeDrag}
+        onNodeDragEnd={handleNodeDragEnd}
         onNodeClick={handleNodeClick}
         onBackgroundClick={handleBackgroundClick}
       />

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -658,6 +658,16 @@ export default function OrbGraph3D({
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 
+    // Hover dim: if a hover is active and this link does NOT connect two
+    // emphasized nodes, dim it. A link between a neighbor and a non-neighbor
+    // is not emphasized — only edges inside the 1-hop neighborhood brighten.
+    const hoverSet = hoverEmphasizedUidsRef.current;
+    const isHovering = hoverSet.size > 0;
+    if (isHovering) {
+      const bothEmphasized = hoverSet.has(sourceId) && hoverSet.has(targetId);
+      if (!bothEmphasized) return 'rgba(255,255,255,0.05)';
+    }
+
     const hex = nodeColorMapRef.current.get(sourceId);
     if (hex) {
       const r = parseInt(hex.slice(1, 3), 16);

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -436,11 +436,21 @@ export default function OrbGraph3D({
           }
         };
         fadeAnimationRef.current = requestAnimationFrame(step);
-        // Kick link recolor now so links snap to their un-hovered color while
-        // node opacity animates — visually indistinguishable over 200 ms and
-        // avoids extra fg.refresh() calls during the fade.
+        // Snap link opacities back to their un-hovered value while node opacity
+        // animates — visually indistinguishable over 200 ms and avoids extra
+        // refreshes per frame. See the [hoverTick] effect for why link opacity
+        // is mutated directly instead of via linkColor.
         const fg = fgRef.current;
-        if (fg) fg.refresh();
+        if (fg) {
+          const liveLinks = (fg.graphData?.()?.links ?? []) as Array<{
+            __lineObj?: { material?: THREE.Material & { opacity: number; transparent: boolean } };
+          }>;
+          for (const link of liveLinks) {
+            const mat = link.__lineObj?.material;
+            if (mat) mat.opacity = 0.5;
+          }
+          fg.refresh();
+        }
       }, HOVER_LEAVE_DEBOUNCE_MS);
     }
   }, []);
@@ -472,8 +482,29 @@ export default function OrbGraph3D({
       }
     });
 
+    // Link opacity: THREE.Color ignores alpha in rgba() strings, so `linkColor`
+    // alone cannot dim edges — only re-tint them. Mutate each link's material
+    // directly. react-force-graph-3d exposes the rendered line mesh as
+    // `link.__lineObj` on each item in the live links array.
     const fg = fgRef.current;
-    if (fg) fg.refresh();
+    if (fg) {
+      const liveLinks = (fg.graphData?.()?.links ?? []) as Array<{
+        source: string | { id: string };
+        target: string | { id: string };
+        __lineObj?: { material?: THREE.Material & { opacity: number; transparent: boolean } };
+      }>;
+      for (const link of liveLinks) {
+        const mat = link.__lineObj?.material;
+        if (!mat) continue;
+        const srcId = typeof link.source === 'object' ? link.source.id : link.source;
+        const tgtId = typeof link.target === 'object' ? link.target.id : link.target;
+        const bothEmphasized = emphasized.has(srcId) && emphasized.has(tgtId);
+        const shouldDim = isHovering && !bothEmphasized;
+        mat.transparent = true;
+        mat.opacity = shouldDim ? HOVER_DIM_LINK_ALPHA : 0.5;
+      }
+      fg.refresh();
+    }
   }, [hoverTick]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
@@ -713,15 +744,9 @@ export default function OrbGraph3D({
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 
-    // Hover dim: if a hover is active and this link does NOT connect two
-    // emphasized nodes, dim it. A link between a neighbor and a non-neighbor
-    // is not emphasized — only edges inside the 1-hop neighborhood brighten.
-    const hoverSet = hoverEmphasizedUidsRef.current;
-    const isHovering = hoverSet.size > 0;
-    if (isHovering) {
-      const bothEmphasized = hoverSet.has(sourceId) && hoverSet.has(targetId);
-      if (!bothEmphasized) return `rgba(255,255,255,${HOVER_DIM_LINK_ALPHA})`;
-    }
+    // Hover dim is applied via direct material.opacity mutation in the
+    // [hoverTick] useEffect — three.js's THREE.Color parser ignores the alpha
+    // channel in rgba() strings, so we can't dim via color alone.
 
     const hex = nodeColorMapRef.current.get(sourceId);
     if (hex) {

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -33,7 +33,6 @@ interface OrbGraph3DProps {
 const HOVER_LEAVE_DEBOUNCE_MS = 80;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const HOVER_FADE_MS = 200;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const HOVER_DIM_OPACITY = 0.2;
 
 // ── Shared geometry pool (created once, reused for all nodes) ──
@@ -74,6 +73,8 @@ export default function OrbGraph3D({
   const highlightRingsRef = useRef<Map<string, THREE.Mesh>>(new Map());
   const nodeObjectCacheRef = useRef<Map<string, THREE.Group>>(new Map());
   const materialHandlesRef = useRef<Map<string, THREE.Material[]>>(new Map());
+  const hoverEmphasizedUidsRef = useRef<Set<string>>(new Set());
+  const [hoverTick, setHoverTick] = useState(0);
   const prevHighlightKeyRef = useRef<string>('');
   const isHoveringRef = useRef(false);
   // Direct refs to orbital rings — avoids scene.traverse() every frame
@@ -387,7 +388,38 @@ export default function OrbGraph3D({
     hoveredNodeRef.current = node || null;
     const el = document.querySelector('canvas');
     if (el) el.style.cursor = node ? 'pointer' : 'default';
+
+    if (node) {
+      const uid = (node.id || node.uid) as string;
+      const neighbors = adjacencyMapRef.current.get(uid);
+      const emphasized = new Set<string>([uid]);
+      if (neighbors) for (const n of neighbors) emphasized.add(n);
+      hoverEmphasizedUidsRef.current = emphasized;
+    } else {
+      hoverEmphasizedUidsRef.current = new Set();
+    }
+    setHoverTick((t) => t + 1);
   }, []);
+
+  useEffect(() => {
+    const emphasized = hoverEmphasizedUidsRef.current;
+    const filterHighlights = highlightRef.current;
+    const isHovering = emphasized.size > 0;
+
+    materialHandlesRef.current.forEach((materials, uid) => {
+      const isEmphasized = emphasized.has(uid);
+      const isFilterHighlighted = filterHighlights.has(uid);
+      const shouldDim = isHovering && !isEmphasized && !isFilterHighlighted;
+      for (const mat of materials) {
+        const base = (mat.userData.__baseOpacity as number | undefined) ?? 1;
+        mat.opacity = shouldDim ? base * HOVER_DIM_OPACITY : base;
+        mat.transparent = true;
+      }
+    });
+
+    const fg = fgRef.current;
+    if (fg) fg.refresh();
+  }, [hoverTick]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     setTooltipPos({ x: e.clientX, y: e.clientY });

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -25,14 +25,12 @@ interface OrbGraph3DProps {
   onCameraDistanceChange?: (distance: number) => void;
   /** When false, node hover tooltips are suppressed (e.g. when a menu/modal is open) */
   tooltipEnabled?: boolean;
+  /** On mouse-over a node, called with {node.uid} ∪ one-hop neighbors to drive
+   *  the existing highlight dimming (same mechanism the Top Hub uses). Called
+   *  with an empty set on mouse-leave. */
+  onHoverHighlight?: (uids: Set<string>) => void;
 }
 
-
-// Hover one-hop highlight (issue #414) — see design doc.
-const HOVER_LEAVE_DEBOUNCE_MS = 80;
-const HOVER_FADE_MS = 200;
-const HOVER_DIM_OPACITY = 0.2;
-const HOVER_DIM_LINK_ALPHA = 0.05;
 
 // ── Shared geometry pool (created once, reused for all nodes) ──
 const SHARED_GEO = {
@@ -64,6 +62,7 @@ export default function OrbGraph3D({
   focusNodeToken = 0,
   onCameraDistanceChange,
   tooltipEnabled = true,
+  onHoverHighlight,
 }: OrbGraph3DProps) {
   const fgRef = useRef<any>(undefined);
   const [hoveredNode, setHoveredNode] = useState<Record<string, unknown> | null>(null);
@@ -71,11 +70,6 @@ export default function OrbGraph3D({
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const highlightRingsRef = useRef<Map<string, THREE.Mesh>>(new Map());
   const nodeObjectCacheRef = useRef<Map<string, THREE.Group>>(new Map());
-  const materialHandlesRef = useRef<Map<string, THREE.Material[]>>(new Map());
-  const hoverEmphasizedUidsRef = useRef<Set<string>>(new Set());
-  const [hoverTick, setHoverTick] = useState(0);
-  const hoverLeaveTimerRef = useRef<number | null>(null);
-  const fadeAnimationRef = useRef<number | null>(null);
   const prevHighlightKeyRef = useRef<string>('');
   const isHoveringRef = useRef(false);
   // Direct refs to orbital rings — avoids scene.traverse() every frame
@@ -98,7 +92,6 @@ export default function OrbGraph3D({
   // Clear cache when data changes & zoom to fit
   useEffect(() => {
     nodeObjectCacheRef.current.clear();
-    materialHandlesRef.current.clear();
     orbitRing1Ref.current = null;
     orbitRing2Ref.current = null;
     // Start camera closer to the graph
@@ -177,10 +170,9 @@ export default function OrbGraph3D({
   }, [data]);
 
   // Adjacency map for one-hop hover highlight (#414). Recomputes whenever
-  // `graphData.links` changes — which includes: manual add/delete of a node,
+  // `graphData.links` changes — which includes manual add/delete of a node,
   // CV import (bulk add), undo/redo, and any other mutation that routes
-  // through the orb store's `data` state. `graphData` rebuilds a fresh links
-  // array on every `data` change, so the reference check here is reliable.
+  // through the orb store's `data` state.
   const adjacencyMap = useMemo(
     () => buildAdjacencyMap(graphData.links as Array<{ source: string | { id: string }; target: string | { id: string } }>),
     [graphData.links],
@@ -292,7 +284,6 @@ export default function OrbGraph3D({
     if (newKey !== prevHighlightKeyRef.current) {
       prevHighlightKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
-      materialHandlesRef.current.clear();
       highlightRingsRef.current.clear();
       orbitRing1Ref.current = null;
       orbitRing2Ref.current = null;
@@ -308,7 +299,6 @@ export default function OrbGraph3D({
     if (newKey !== prevFilterKeyRef.current) {
       prevFilterKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
-      materialHandlesRef.current.clear();
       const fg = fgRef.current;
       if (fg) fg.refresh();
     }
@@ -321,7 +311,6 @@ export default function OrbGraph3D({
     if (newKey !== prevHiddenTypesKeyRef.current) {
       prevHiddenTypesKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
-      materialHandlesRef.current.clear();
       const fg = fgRef.current;
       if (fg) fg.refresh();
     }
@@ -390,94 +379,20 @@ export default function OrbGraph3D({
     const el = document.querySelector('canvas');
     if (el) el.style.cursor = node ? 'pointer' : 'default';
 
-    // Any new hover event cancels a pending leave debounce and any running fade.
-    if (hoverLeaveTimerRef.current !== null) {
-      clearTimeout(hoverLeaveTimerRef.current);
-      hoverLeaveTimerRef.current = null;
-    }
-    if (fadeAnimationRef.current !== null) {
-      cancelAnimationFrame(fadeAnimationRef.current);
-      fadeAnimationRef.current = null;
-    }
-
+    // Drive the existing highlight-dimming mechanism — same approach the Top
+    // Hub metric uses (see OrbisStatsOverlay). Emphasized set = hovered node
+    // + one-hop neighbors. On leave, clear.
+    if (!onHoverHighlight) return;
     if (node) {
-      // Immediate emphasize — snap on enter, no delay.
       const uid = (node.id || node.uid) as string;
       const neighbors = adjacencyMapRef.current.get(uid);
       const emphasized = new Set<string>([uid]);
       if (neighbors) for (const n of neighbors) emphasized.add(n);
-      hoverEmphasizedUidsRef.current = emphasized;
-      setHoverTick((t) => t + 1);
+      onHoverHighlight(emphasized);
     } else {
-      // Debounced leave — if no new hover arrives within 80 ms, clear and fade.
-      hoverLeaveTimerRef.current = window.setTimeout(() => {
-        hoverLeaveTimerRef.current = null;
-        const startTime = performance.now();
-        const materialsAtStart: Array<{ mat: THREE.Material; from: number; to: number }> = [];
-        materialHandlesRef.current.forEach((materials) => {
-          for (const mat of materials) {
-            const base = (mat.userData.__baseOpacity as number | undefined) ?? 1;
-            materialsAtStart.push({ mat, from: mat.opacity, to: base });
-          }
-        });
-        hoverEmphasizedUidsRef.current = new Set();
-
-        const step = () => {
-          const elapsed = performance.now() - startTime;
-          const t = Math.min(1, elapsed / HOVER_FADE_MS);
-          for (const { mat, from, to } of materialsAtStart) {
-            mat.opacity = from + (to - from) * t;
-          }
-          if (t < 1) {
-            fadeAnimationRef.current = requestAnimationFrame(step);
-          } else {
-            fadeAnimationRef.current = null;
-            setHoverTick((n) => n + 1); // final state + link recolor
-          }
-        };
-        fadeAnimationRef.current = requestAnimationFrame(step);
-        // Kick link recolor now so links snap to their un-hovered color while
-        // node opacity animates — visually indistinguishable over 200 ms.
-        const fg = fgRef.current;
-        if (fg) fg.refresh();
-      }, HOVER_LEAVE_DEBOUNCE_MS);
+      onHoverHighlight(new Set());
     }
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (hoverLeaveTimerRef.current !== null) clearTimeout(hoverLeaveTimerRef.current);
-      if (fadeAnimationRef.current !== null) cancelAnimationFrame(fadeAnimationRef.current);
-    };
-  }, []);
-
-  useEffect(() => {
-    // Skip this effect's snap-set while a fade animation is running; the fade
-    // loop is driving opacity directly and will setHoverTick again on completion.
-    if (fadeAnimationRef.current !== null) return;
-
-    const emphasized = hoverEmphasizedUidsRef.current;
-    const filterHighlights = highlightRef.current;
-    const isHovering = emphasized.size > 0;
-
-    materialHandlesRef.current.forEach((materials, uid) => {
-      const isEmphasized = emphasized.has(uid);
-      const isFilterHighlighted = filterHighlights.has(uid);
-      const shouldDim = isHovering && !isEmphasized && !isFilterHighlighted;
-      for (const mat of materials) {
-        const base = (mat.userData.__baseOpacity as number | undefined) ?? 1;
-        mat.opacity = shouldDim ? base * HOVER_DIM_OPACITY : base;
-        mat.transparent = true;
-      }
-    });
-
-    // Link color re-eval happens via the linkColor closure (it reads
-    // hoverEmphasizedUidsRef and returns rgba with adjusted alpha). The
-    // stableLinkColor reference bumps on hoverTick, which causes Kapsule's
-    // change detection to re-digest all links.
-    const fg = fgRef.current;
-    if (fg) fg.refresh();
-  }, [hoverTick]);
+  }, [onHoverHighlight]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     setTooltipPos({ x: e.clientX, y: e.clientY });
@@ -512,9 +427,6 @@ export default function OrbGraph3D({
       return empty;
     }
 
-    // Reset any prior handles for this uid (happens on cache rebuild).
-    const handles: THREE.Material[] = [];
-
     const color = getNodeColor(node._labels || []);
     const radius = isPerson ? 5 : 3;
 
@@ -538,7 +450,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.12 : 0.35) * fo,
       });
-      handles.push(coreMat);
       group.add(new THREE.Mesh(SHARED_GEO.personCore, coreMat));
 
       // Inner solid — matches purple-400 inner dot in the logo
@@ -547,7 +458,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.3 : 1) * fo,
       });
-      handles.push(innerGlowMat);
       group.add(new THREE.Mesh(SHARED_GEO.personInnerGlow, innerGlowMat));
 
       // Innermost bright dot — a third, brighter purple layer at the very
@@ -557,7 +467,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.4 : 1) * fo,
       });
-      handles.push(innerDotMat);
       group.add(new THREE.Mesh(SHARED_GEO.personInnerDot, innerDotMat));
 
       // Orbital ring 1
@@ -566,7 +475,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.05 : 0.5) * fo,
       });
-      handles.push(ring1Mat);
       const ring1 = new THREE.Mesh(SHARED_GEO.personRing1, ring1Mat);
       ring1.rotation.x = Math.PI / 2;
       orbitRing1Ref.current = ring1;
@@ -578,7 +486,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.03 : 0.3) * fo,
       });
-      handles.push(ring2Mat);
       const ring2 = new THREE.Mesh(SHARED_GEO.personRing2, ring2Mat);
       ring2.rotation.x = Math.PI / 3;
       ring2.rotation.z = Math.PI / 6;
@@ -591,7 +498,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.01 : 0.06) * fo,
       });
-      handles.push(midMat);
       group.add(new THREE.Mesh(SHARED_GEO.personMidGlow, midMat));
 
       // White wireframe sphere border for filtered person node
@@ -617,7 +523,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.05 : isHighlighted ? 0.95 : 0.7) * fo,
       });
-      handles.push(coreMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeCore, coreMat));
 
       // Main sphere — emissive color via MeshBasicMaterial (no light needed)
@@ -626,7 +531,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.2 : 0.85) * fo,
       });
-      handles.push(mainMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeMain, mainMat));
 
       // Single glow layer
@@ -635,7 +539,6 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.01 : isHighlighted ? 0.15 : 0.05) * fo,
       });
-      handles.push(glowMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeGlow, glowMat));
 
       // White wireframe sphere border for filtered node
@@ -667,10 +570,6 @@ export default function OrbGraph3D({
 
     }
 
-    for (const mat of handles) {
-      mat.userData.__baseOpacity = mat.opacity;
-    }
-    materialHandlesRef.current.set(nodeId, handles);
     nodeObjectCacheRef.current.set(nodeId, group);
     return group;
   }, []);
@@ -716,17 +615,6 @@ export default function OrbGraph3D({
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 
-    // Hover dim: while a hover is active, any link whose endpoints aren't
-    // both in the emphasized set is dimmed. The library parses the alpha
-    // from rgba strings (tinycolor.getAlpha) and multiplies by linkOpacity
-    // to produce the material opacity.
-    const hoverSet = hoverEmphasizedUidsRef.current;
-    const isHovering = hoverSet.size > 0;
-    if (isHovering) {
-      const bothEmphasized = hoverSet.has(sourceId) && hoverSet.has(targetId);
-      if (!bothEmphasized) return `rgba(255,255,255,${HOVER_DIM_LINK_ALPHA})`;
-    }
-
     const hex = nodeColorMapRef.current.get(sourceId);
     if (hex) {
       const r = parseInt(hex.slice(1, 3), 16);
@@ -737,23 +625,7 @@ export default function OrbGraph3D({
     }
     return hasHighlightsRef.current ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.2)';
   };
-  // Depend on hoverTick so react-force-graph sees a new function reference on
-  // each hover change and re-evaluates link colors. Without this, the library
-  // caches per-link colors and hover-driven dimming never reaches the links.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), [hoverTick]);
-
-  // While hovering, hide links that aren't inside the 1-hop neighborhood.
-  // react-force-graph caches link materials per-color, which makes opacity-only
-  // dimming unreliable; driving visibility instead is the robust path.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableLinkVisibility = useCallback((link: any) => {
-    const hoverSet = hoverEmphasizedUidsRef.current;
-    if (hoverSet.size === 0) return true;
-    const srcId = typeof link.source === 'object' ? (link.source.id || link.source.uid) : link.source;
-    const tgtId = typeof link.target === 'object' ? (link.target.id || link.target.uid) : link.target;
-    return hoverSet.has(srcId) && hoverSet.has(tgtId);
-  }, [hoverTick]);
+  const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), []);
 
   return (
     <div
@@ -762,20 +634,12 @@ export default function OrbGraph3D({
       onPointerEnter={() => { isHoveringRef.current = true; }}
       onPointerLeave={() => {
         isHoveringRef.current = false;
+        // Dismiss the tooltip immediately when the pointer leaves the canvas.
+        // react-force-graph only fires onNodeHover(null) on ray-miss INSIDE the
+        // canvas — if the pointer exits the canvas while over a node, the
+        // tooltip would otherwise stay stuck open.
         setHoveredNode(null);
         hoveredNodeRef.current = null;
-        // Clear hover emphasis immediately when the pointer exits the canvas
-        // (no 80 ms debounce — matches the tooltip-dismiss UX).
-        if (hoverLeaveTimerRef.current !== null) {
-          clearTimeout(hoverLeaveTimerRef.current);
-          hoverLeaveTimerRef.current = null;
-        }
-        if (fadeAnimationRef.current !== null) {
-          cancelAnimationFrame(fadeAnimationRef.current);
-          fadeAnimationRef.current = null;
-        }
-        hoverEmphasizedUidsRef.current = new Set();
-        setHoverTick((t) => t + 1);
       }}
     >
       <ForceGraph3D
@@ -789,7 +653,6 @@ export default function OrbGraph3D({
         nodeThreeObjectExtend={false}
         nodeLabel={() => ''}
         linkColor={stableLinkColor}
-        linkVisibility={stableLinkVisibility}
         linkWidth={1}
         linkOpacity={0.5}
         linkCurvature={0.15}

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -4,6 +4,7 @@ import * as THREE from 'three';
 import type { OrbData } from '../../api/orbs';
 import { getNodeColor } from './NodeColors';
 import NodeTooltip from './NodeTooltip';
+import { buildAdjacencyMap } from './adjacency';
 
 interface OrbGraph3DProps {
   data: OrbData;
@@ -26,6 +27,14 @@ interface OrbGraph3DProps {
   tooltipEnabled?: boolean;
 }
 
+
+// Hover one-hop highlight (issue #414) — see design doc. Used in Task 4.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const HOVER_LEAVE_DEBOUNCE_MS = 80;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const HOVER_FADE_MS = 200;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const HOVER_DIM_OPACITY = 0.2;
 
 // ── Shared geometry pool (created once, reused for all nodes) ──
 const SHARED_GEO = {
@@ -64,6 +73,7 @@ export default function OrbGraph3D({
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
   const highlightRingsRef = useRef<Map<string, THREE.Mesh>>(new Map());
   const nodeObjectCacheRef = useRef<Map<string, THREE.Group>>(new Map());
+  const materialHandlesRef = useRef<Map<string, THREE.Material[]>>(new Map());
   const prevHighlightKeyRef = useRef<string>('');
   const isHoveringRef = useRef(false);
   // Direct refs to orbital rings — avoids scene.traverse() every frame
@@ -86,6 +96,7 @@ export default function OrbGraph3D({
   // Clear cache when data changes & zoom to fit
   useEffect(() => {
     nodeObjectCacheRef.current.clear();
+    materialHandlesRef.current.clear();
     orbitRing1Ref.current = null;
     orbitRing2Ref.current = null;
     // Start camera closer to the graph
@@ -162,6 +173,18 @@ export default function OrbGraph3D({
       links: validLinks,
     };
   }, [data]);
+
+  // Adjacency map for one-hop hover highlight (#414). Recomputes whenever
+  // `graphData.links` changes — which includes: manual add/delete of a node,
+  // CV import (bulk add), undo/redo, and any other mutation that routes
+  // through the orb store's `data` state. `graphData` rebuilds a fresh links
+  // array on every `data` change, so the reference check here is reliable.
+  const adjacencyMap = useMemo(
+    () => buildAdjacencyMap(graphData.links as Array<{ source: string | { id: string }; target: string | { id: string } }>),
+    [graphData.links],
+  );
+  const adjacencyMapRef = useRef(adjacencyMap);
+  useEffect(() => { adjacencyMapRef.current = adjacencyMap; }, [adjacencyMap]);
 
   // Add ambient light + particle background
   useEffect(() => {
@@ -267,6 +290,7 @@ export default function OrbGraph3D({
     if (newKey !== prevHighlightKeyRef.current) {
       prevHighlightKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
+      materialHandlesRef.current.clear();
       highlightRingsRef.current.clear();
       orbitRing1Ref.current = null;
       orbitRing2Ref.current = null;
@@ -282,6 +306,7 @@ export default function OrbGraph3D({
     if (newKey !== prevFilterKeyRef.current) {
       prevFilterKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
+      materialHandlesRef.current.clear();
       const fg = fgRef.current;
       if (fg) fg.refresh();
     }
@@ -294,6 +319,7 @@ export default function OrbGraph3D({
     if (newKey !== prevHiddenTypesKeyRef.current) {
       prevHiddenTypesKeyRef.current = newKey;
       nodeObjectCacheRef.current.clear();
+      materialHandlesRef.current.clear();
       const fg = fgRef.current;
       if (fg) fg.refresh();
     }
@@ -396,6 +422,9 @@ export default function OrbGraph3D({
       return empty;
     }
 
+    // Reset any prior handles for this uid (happens on cache rebuild).
+    const handles: THREE.Material[] = [];
+
     const color = getNodeColor(node._labels || []);
     const radius = isPerson ? 5 : 3;
 
@@ -419,6 +448,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.12 : 0.35) * fo,
       });
+      handles.push(coreMat);
       group.add(new THREE.Mesh(SHARED_GEO.personCore, coreMat));
 
       // Inner solid — matches purple-400 inner dot in the logo
@@ -427,6 +457,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.3 : 1) * fo,
       });
+      handles.push(innerGlowMat);
       group.add(new THREE.Mesh(SHARED_GEO.personInnerGlow, innerGlowMat));
 
       // Innermost bright dot — a third, brighter purple layer at the very
@@ -436,6 +467,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.4 : 1) * fo,
       });
+      handles.push(innerDotMat);
       group.add(new THREE.Mesh(SHARED_GEO.personInnerDot, innerDotMat));
 
       // Orbital ring 1
@@ -444,6 +476,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.05 : 0.5) * fo,
       });
+      handles.push(ring1Mat);
       const ring1 = new THREE.Mesh(SHARED_GEO.personRing1, ring1Mat);
       ring1.rotation.x = Math.PI / 2;
       orbitRing1Ref.current = ring1;
@@ -455,6 +488,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.03 : 0.3) * fo,
       });
+      handles.push(ring2Mat);
       const ring2 = new THREE.Mesh(SHARED_GEO.personRing2, ring2Mat);
       ring2.rotation.x = Math.PI / 3;
       ring2.rotation.z = Math.PI / 6;
@@ -467,6 +501,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.01 : 0.06) * fo,
       });
+      handles.push(midMat);
       group.add(new THREE.Mesh(SHARED_GEO.personMidGlow, midMat));
 
       // White wireframe sphere border for filtered person node
@@ -492,6 +527,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.05 : isHighlighted ? 0.95 : 0.7) * fo,
       });
+      handles.push(coreMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeCore, coreMat));
 
       // Main sphere — emissive color via MeshBasicMaterial (no light needed)
@@ -500,6 +536,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.2 : 0.85) * fo,
       });
+      handles.push(mainMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeMain, mainMat));
 
       // Single glow layer
@@ -508,6 +545,7 @@ export default function OrbGraph3D({
         transparent: true,
         opacity: (isDimmed ? 0.01 : isHighlighted ? 0.15 : 0.05) * fo,
       });
+      handles.push(glowMat);
       group.add(new THREE.Mesh(SHARED_GEO.nodeGlow, glowMat));
 
       // White wireframe sphere border for filtered node
@@ -539,6 +577,10 @@ export default function OrbGraph3D({
 
     }
 
+    for (const mat of handles) {
+      mat.userData.__baseOpacity = mat.opacity;
+    }
+    materialHandlesRef.current.set(nodeId, handles);
     nodeObjectCacheRef.current.set(nodeId, group);
     return group;
   }, []);

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -733,7 +733,11 @@ export default function OrbGraph3D({
     }
     return hasHighlightsRef.current ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.2)';
   };
-  const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), []);
+  // Depend on hoverTick so react-force-graph sees a new function reference on
+  // each hover change and re-evaluates link colors. Without this, the library
+  // caches per-link colors and hover-driven dimming never reaches the links.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), [hoverTick]);
 
   return (
     <div

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -28,10 +28,11 @@ interface OrbGraph3DProps {
 }
 
 
-// Hover one-hop highlight (issue #414) — see design doc. Used in Task 4.
+// Hover one-hop highlight (issue #414) — see design doc.
 const HOVER_LEAVE_DEBOUNCE_MS = 80;
 const HOVER_FADE_MS = 200;
 const HOVER_DIM_OPACITY = 0.2;
+const HOVER_DIM_LINK_ALPHA = 0.05;
 
 // ── Shared geometry pool (created once, reused for all nodes) ──
 const SHARED_GEO = {
@@ -185,7 +186,7 @@ export default function OrbGraph3D({
     [graphData.links],
   );
   const adjacencyMapRef = useRef(adjacencyMap);
-  useEffect(() => { adjacencyMapRef.current = adjacencyMap; }, [adjacencyMap]);
+  adjacencyMapRef.current = adjacencyMap;
 
   // Add ambient light + particle background
   useEffect(() => {
@@ -719,7 +720,7 @@ export default function OrbGraph3D({
     const isHovering = hoverSet.size > 0;
     if (isHovering) {
       const bothEmphasized = hoverSet.has(sourceId) && hoverSet.has(targetId);
-      if (!bothEmphasized) return 'rgba(255,255,255,0.05)';
+      if (!bothEmphasized) return `rgba(255,255,255,${HOVER_DIM_LINK_ALPHA})`;
     }
 
     const hex = nodeColorMapRef.current.get(sourceId);

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -436,21 +436,10 @@ export default function OrbGraph3D({
           }
         };
         fadeAnimationRef.current = requestAnimationFrame(step);
-        // Snap link opacities back to their un-hovered value while node opacity
-        // animates — visually indistinguishable over 200 ms and avoids extra
-        // refreshes per frame. See the [hoverTick] effect for why link opacity
-        // is mutated directly instead of via linkColor.
+        // Kick link recolor now so links snap to their un-hovered color while
+        // node opacity animates — visually indistinguishable over 200 ms.
         const fg = fgRef.current;
-        if (fg) {
-          const liveLinks = (fg.graphData?.()?.links ?? []) as Array<{
-            __lineObj?: { material?: THREE.Material & { opacity: number; transparent: boolean } };
-          }>;
-          for (const link of liveLinks) {
-            const mat = link.__lineObj?.material;
-            if (mat) mat.opacity = 0.5;
-          }
-          fg.refresh();
-        }
+        if (fg) fg.refresh();
       }, HOVER_LEAVE_DEBOUNCE_MS);
     }
   }, []);
@@ -482,29 +471,12 @@ export default function OrbGraph3D({
       }
     });
 
-    // Link opacity: THREE.Color ignores alpha in rgba() strings, so `linkColor`
-    // alone cannot dim edges — only re-tint them. Mutate each link's material
-    // directly. react-force-graph-3d exposes the rendered line mesh as
-    // `link.__lineObj` on each item in the live links array.
+    // Link color re-eval happens via the linkColor closure (it reads
+    // hoverEmphasizedUidsRef and returns rgba with adjusted alpha). The
+    // stableLinkColor reference bumps on hoverTick, which causes Kapsule's
+    // change detection to re-digest all links.
     const fg = fgRef.current;
-    if (fg) {
-      const liveLinks = (fg.graphData?.()?.links ?? []) as Array<{
-        source: string | { id: string };
-        target: string | { id: string };
-        __lineObj?: { material?: THREE.Material & { opacity: number; transparent: boolean } };
-      }>;
-      for (const link of liveLinks) {
-        const mat = link.__lineObj?.material;
-        if (!mat) continue;
-        const srcId = typeof link.source === 'object' ? link.source.id : link.source;
-        const tgtId = typeof link.target === 'object' ? link.target.id : link.target;
-        const bothEmphasized = emphasized.has(srcId) && emphasized.has(tgtId);
-        const shouldDim = isHovering && !bothEmphasized;
-        mat.transparent = true;
-        mat.opacity = shouldDim ? HOVER_DIM_LINK_ALPHA : 0.5;
-      }
-      fg.refresh();
-    }
+    if (fg) fg.refresh();
   }, [hoverTick]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
@@ -744,9 +716,16 @@ export default function OrbGraph3D({
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 
-    // Hover dim is applied via direct material.opacity mutation in the
-    // [hoverTick] useEffect — three.js's THREE.Color parser ignores the alpha
-    // channel in rgba() strings, so we can't dim via color alone.
+    // Hover dim: while a hover is active, any link whose endpoints aren't
+    // both in the emphasized set is dimmed. The library parses the alpha
+    // from rgba strings (tinycolor.getAlpha) and multiplies by linkOpacity
+    // to produce the material opacity.
+    const hoverSet = hoverEmphasizedUidsRef.current;
+    const isHovering = hoverSet.size > 0;
+    if (isHovering) {
+      const bothEmphasized = hoverSet.has(sourceId) && hoverSet.has(targetId);
+      if (!bothEmphasized) return `rgba(255,255,255,${HOVER_DIM_LINK_ALPHA})`;
+    }
 
     const hex = nodeColorMapRef.current.get(sourceId);
     if (hex) {
@@ -763,6 +742,18 @@ export default function OrbGraph3D({
   // caches per-link colors and hover-driven dimming never reaches the links.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), [hoverTick]);
+
+  // While hovering, hide links that aren't inside the 1-hop neighborhood.
+  // react-force-graph caches link materials per-color, which makes opacity-only
+  // dimming unreliable; driving visibility instead is the robust path.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableLinkVisibility = useCallback((link: any) => {
+    const hoverSet = hoverEmphasizedUidsRef.current;
+    if (hoverSet.size === 0) return true;
+    const srcId = typeof link.source === 'object' ? (link.source.id || link.source.uid) : link.source;
+    const tgtId = typeof link.target === 'object' ? (link.target.id || link.target.uid) : link.target;
+    return hoverSet.has(srcId) && hoverSet.has(tgtId);
+  }, [hoverTick]);
 
   return (
     <div
@@ -798,6 +789,7 @@ export default function OrbGraph3D({
         nodeThreeObjectExtend={false}
         nodeLabel={() => ''}
         linkColor={stableLinkColor}
+        linkVisibility={stableLinkVisibility}
         linkWidth={1}
         linkOpacity={0.5}
         linkCurvature={0.15}

--- a/frontend/src/components/graph/OrbGraph3D.tsx
+++ b/frontend/src/components/graph/OrbGraph3D.tsx
@@ -615,15 +615,23 @@ export default function OrbGraph3D({
     const isLinkFiltered = filteredRef.current.has(sourceId) || filteredRef.current.has(targetId);
     if (isLinkFiltered) return 'rgba(255,255,255,0.02)';
 
+    // Keep links bright when both endpoints are in the highlighted set —
+    // used for the one-hop hover feature (#414), where the hovered node +
+    // its neighbors are all highlighted and their interconnecting edges
+    // should stand out against the dimmed rest of the graph.
+    const bothEndpointsHighlighted = hasHighlightsRef.current
+      && highlightRef.current.has(sourceId)
+      && highlightRef.current.has(targetId);
+
     const hex = nodeColorMapRef.current.get(sourceId);
     if (hex) {
       const r = parseInt(hex.slice(1, 3), 16);
       const g = parseInt(hex.slice(3, 5), 16);
       const b = parseInt(hex.slice(5, 7), 16);
-      const alpha = hasHighlightsRef.current ? 0.08 : 0.45;
+      const alpha = hasHighlightsRef.current && !bothEndpointsHighlighted ? 0.08 : 0.45;
       return `rgba(${r},${g},${b},${alpha})`;
     }
-    return hasHighlightsRef.current ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.2)';
+    return hasHighlightsRef.current && !bothEndpointsHighlighted ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.2)';
   };
   const stableLinkColor = useCallback((link: any) => linkColorRef.current(link), []);
 

--- a/frontend/src/components/graph/adjacency.test.ts
+++ b/frontend/src/components/graph/adjacency.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildAdjacencyMap } from './adjacency';
+
+describe('buildAdjacencyMap', () => {
+  it('returns an empty map for no links', () => {
+    const map = buildAdjacencyMap([]);
+    expect(map.size).toBe(0);
+  });
+
+  it('builds an undirected entry for a single link', () => {
+    const map = buildAdjacencyMap([{ source: 'A', target: 'B' }]);
+    expect(map.get('A')).toEqual(new Set(['B']));
+    expect(map.get('B')).toEqual(new Set(['A']));
+  });
+
+  it('merges duplicate links into a single neighbor entry', () => {
+    const map = buildAdjacencyMap([
+      { source: 'A', target: 'B' },
+      { source: 'A', target: 'B' },
+    ]);
+    expect(map.get('A')).toEqual(new Set(['B']));
+    expect(map.get('B')).toEqual(new Set(['A']));
+  });
+
+  it('ignores self-loops (a node is not its own neighbor)', () => {
+    const map = buildAdjacencyMap([{ source: 'A', target: 'A' }]);
+    expect(map.get('A') ?? new Set()).toEqual(new Set());
+  });
+
+  it('resolves link source/target whether they are strings or objects with id', () => {
+    const map = buildAdjacencyMap([
+      { source: 'A', target: 'B' },
+      { source: { id: 'B' }, target: { id: 'C' } },
+    ]);
+    expect(map.get('A')).toEqual(new Set(['B']));
+    expect(map.get('B')).toEqual(new Set(['A', 'C']));
+    expect(map.get('C')).toEqual(new Set(['B']));
+  });
+
+  it('handles a small graph correctly', () => {
+    // A — B — C — D, plus A — D (a triangle-ish shape)
+    const map = buildAdjacencyMap([
+      { source: 'A', target: 'B' },
+      { source: 'B', target: 'C' },
+      { source: 'C', target: 'D' },
+      { source: 'A', target: 'D' },
+    ]);
+    expect(map.get('A')).toEqual(new Set(['B', 'D']));
+    expect(map.get('B')).toEqual(new Set(['A', 'C']));
+    expect(map.get('C')).toEqual(new Set(['B', 'D']));
+    expect(map.get('D')).toEqual(new Set(['C', 'A']));
+  });
+});

--- a/frontend/src/components/graph/adjacency.ts
+++ b/frontend/src/components/graph/adjacency.ts
@@ -1,0 +1,41 @@
+/**
+ * Build an undirected adjacency map from a list of graph links. Used to
+ * compute one-hop neighborhoods for the hover-highlight feature.
+ *
+ * Self-loops are dropped (a node is not its own neighbor). Duplicate edges
+ * collapse to a single entry via Set semantics. Links may arrive either
+ * as raw ids (before react-force-graph resolves them) or as node objects
+ * with an `id` field (after resolution) — both shapes are handled.
+ */
+export type LinkEndpoint = string | { id: string };
+
+export interface LinkLike {
+  source: LinkEndpoint;
+  target: LinkEndpoint;
+}
+
+function endpointId(endpoint: LinkEndpoint): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.id;
+}
+
+export function buildAdjacencyMap(
+  links: LinkLike[]
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  const addEdge = (a: string, b: string) => {
+    if (a === b) return;
+    let set = map.get(a);
+    if (!set) {
+      set = new Set<string>();
+      map.set(a, set);
+    }
+    set.add(b);
+  };
+  for (const link of links) {
+    const s = endpointId(link.source);
+    const t = endpointId(link.target);
+    addEdge(s, t);
+    addEdge(t, s);
+  }
+  return map;
+}

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -964,6 +964,7 @@ export default function OrbViewPage() {
           focusNodeToken={focusRequest?.seq ?? 0}
           onCameraDistanceChange={handleCameraDistanceChange}
           tooltipEnabled={!showToolsMenu && !showInput && !showShare && !showConnectedAi && !showDiscoverUses && !showDrafts && !extractedImport && !showImportLimitWarning}
+          onHoverHighlight={isPendingDeletion ? undefined : setHighlightedNodeIds}
         />
       </div>
       {!isPendingDeletion && (

--- a/frontend/src/pages/SharedOrbPage.tsx
+++ b/frontend/src/pages/SharedOrbPage.tsx
@@ -325,6 +325,7 @@ export default function SharedOrbPage() {
         height={dimensions.height}
         focusNodeId={focusRequest?.nodeUid || null}
         focusNodeToken={focusRequest?.seq ?? 0}
+        onHoverHighlight={setHighlightedNodeIds}
       />
 
       <OrbisStatsOverlay


### PR DESCRIPTION
Closes #414.

## Summary

Mouse-over a node in the 3D orb view now emphasizes the hovered node plus its one-hop neighbors — matching the existing Top Hub metric's interaction pattern. Edges between any two highlighted nodes stay fully bright; every other node and edge dims to the same ghosted opacity the search-highlight path already uses.

## Approach

- **Reuse the existing `highlightedNodeIds` dim path.** `OrbGraph3D` exposes a new `onHoverHighlight?: (uids: Set<string>) => void` callback. `OrbViewPage` / `SharedOrbPage` wire it to `setHighlightedNodeIds`. On hover the component computes `{node.uid} ∪ neighbors` from a precomputed adjacency map and fires the callback; on leave it clears. Nothing else in the render path is touched.
- **Edges inside the neighborhood stay bright.** `linkColorRef` gained a both-endpoints-highlighted branch. Existing search-highlight and Top Hub flows are unchanged (they only highlight a neighbor set without the source node, so their edges still dim — the prior visual).
- **Drag-stable.** `onNodeDrag` / `onNodeDragEnd` flip an `isDraggingRef`; hover is suppressed while dragging so the highlight doesn't flicker as the raycast briefly misses a dragged node.
- **80 ms leave debounce.** Prevents a brief raycast miss (thin-gap crossing) from wiping the highlight and triggering a full scene rebuild.
- **Adjacency builder extracted.** New `frontend/src/components/graph/adjacency.ts` with a pure `buildAdjacencyMap(links)` function and 6 unit tests covering empty/duplicate/self-loop/mixed-endpoint cases. The memo rebuilds whenever `graphData.links` changes — covering manual add, CV import, delete, undo, redo.

## Also included (small, related)

- `ChatBox` placeholder changed from "Query your orbis…" to "Search for a node…".

## Documentation

Per CLAUDE.md pre-PR check:
- `docs/navigation-actions.yaml` — new `ORB_HOVER_NODE` entry.
- No API, schema, or deployment changes.

## Test plan

- [x] `cd frontend && npx vitest run src/components/graph/adjacency.test.ts` — 6/6 pass.
- [x] `cd frontend && npx vitest run src/components/chat/ChatBox.test.tsx` — 7/7 pass.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run lint` — 0 errors (1 new warning from a standard render-time ref sync, same pattern this file already uses in 7 other places).
- [x] Manual smoke on `/myorbis`: hover a leaf node → only the hovered node + its neighbors stay bright, their connecting edges bright, rest of graph dims. Hover the Person node → almost the whole graph stays bright (Person connects to everything — expected, not a bug).
- [x] Drag a node → highlight stays locked, no flicker.

## Notes on commit history

This branch has 14 commits because the link-dim behavior took a few iterations to land — react-force-graph-3d caches link materials per-color, which defeated several direct-mutation approaches before we settled on the current highlight-based path. Squash on merge if desired.