### PR TITLE
fix(deploy): set VITE_MCP_URL in build-frontend job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,11 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           VITE_LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
           VITE_API_URL: /api
+          # Public MCP endpoint baked into the bundle. If unset the build
+          # falls back to the dev default http://localhost:8081/mcp, which
+          # breaks every AI connector users paste into ChatGPT / Cursor /
+          # Claude Code / Cline / Windsurf. See #418.
+          VITE_MCP_URL: ${{ secrets.MCP_URL }}
         run: |
           npm ci
           npm run build

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -286,6 +286,8 @@ The frontend build bakes the MCP endpoint URL into the bundle. If it's unset, th
 | `VITE_API_URL` | (usually unset — defaults to `/api`) | Backend API origin if not same-origin with the frontend. |
 | `VITE_GOOGLE_CLIENT_ID` | `...apps.googleusercontent.com` | Google OAuth client ID for user sign-in. |
 
+For the open-orbis deploy workflow, `VITE_MCP_URL` is wired from the `MCP_URL` GitHub repository secret (see `.github/workflows/deploy.yml` → `build-frontend` job). To change the URL, update the secret — no code change needed. If the secret is unset the build falls back to the dev default and every AI connector copied from the UI will be broken (#418).
+
 ## MCP Server
 
 The MCP server runs as a separate process:


### PR DESCRIPTION
Closes #418.

## Summary

The production Firebase bundle was shipping `http://localhost:8081/mcp` in both the Connected AI clients modal and the share-token Copy MCP config button, because `VITE_*` vars bake in at build time and `.github/workflows/deploy.yml` never set `VITE_MCP_URL`. Every AI connector users pasted into ChatGPT / Cursor / Claude Code / Cline / Windsurf was silently broken.

## Change

- **`.github/workflows/deploy.yml`** — `build-frontend` job now reads `VITE_MCP_URL` from a new `MCP_URL` repository secret and passes it to `npm run build`.
- **`docs/deployment.md`** — noted that the workflow reads from the `MCP_URL` secret and pointed at this issue so the gotcha is documented alongside the existing warning at the table.

No frontend code change was required — the fallback `??` already works correctly when `VITE_MCP_URL` is set at build time.

## Manual step required before merge effect is visible

The `MCP_URL` repository secret must be set in GitHub (Settings → Secrets and variables → Actions). Value: the public MCP endpoint (e.g. `https://mcp.open-orbis.com/mcp` or the Cloud Run `*.run.app` URL until the custom domain + path routing lands).

## Out of scope (called out in the issue)

The MCP Cloud Run service is deployed `--no-allow-unauthenticated`. Once the public URL ships in the bundle, AI clients still need the auth/OAuth front-door lifted or proxied. That's a separate deployment concern — this PR just unblocks the frontend side.

## Documentation

Per `CLAUDE.md` pre-PR check:
- `docs/deployment.md` updated.
- No API, schema, nav, or test changes.

## Test plan

- [x] Existing `CopyMcpConfigButton.test.tsx` stubs `VITE_MCP_URL` — unchanged, still passes.
- [ ] Add `MCP_URL` repo secret, trigger a deploy, grep the deployed bundle for `localhost:8081` (expect no matches) and for the public URL (expect matches).
- [ ] Paste the copied URL into a test AI client and confirm it connects (post-auth, once the backend is reachable).