### PR TITLE
chore(deploy): allow unauthenticated invocations on orbis-mcp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -313,7 +313,7 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --timeout=300s \
-            --no-allow-unauthenticated \
+            --allow-unauthenticated \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest" \
             --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID"
 


### PR DESCRIPTION
## Summary

The MCP Cloud Run service was deployed with \`--no-allow-unauthenticated\`, which means every request got blocked at the IAM layer before reaching the MCP server's own OAuth / X-MCP-Key validation. AI clients doing the RFC 8414 OAuth dance couldn't even get to the \`.well-known\` discovery endpoint. This PR makes the invocation public; authentication is still enforced, but at the application layer where it belongs.

## Background

Flagged alongside #418 (localhost URL in bundle). The bundle fix was out of scope for the IAM question, but the fix is useless without this one — pasting \`https://mcp.open-orbis.com/mcp\` into an AI client would still 401 at the gate.

The live service IAM has already been patched manually via:

\`\`\`bash
gcloud run services add-iam-policy-binding orbis-mcp \
  --region=europe-west1 --project=open-orbis \
  --member=allUsers --role=roles/run.invoker
\`\`\`

This PR makes it persistent — without it, the next deploy would flip the policy back via \`--no-allow-unauthenticated\`.

## Security

- MCP bearer tokens (OAuth flow) are validated by \`app.auth.mcp_oauth\` on every request.
- Share-token MCP keys (\`X-MCP-Key\` header) are validated by \`app.auth.mcp_keys\`.
- Endpoints without tokens return 401 from the app layer.
- No PII is exposed pre-auth — only the public OAuth metadata endpoints (\`/.well-known/oauth-authorization-server\` etc.) are intentionally anonymous.

## Documentation

Per CLAUDE.md pre-PR check: no API/schema/nav changes; the workflow change is self-documenting and \`docs/deployment.md\` already discusses the IAM posture implicitly.

## Test plan

- [x] Live service IAM already flipped (above gcloud command).
- [ ] Next deploy run confirms the flag sticks.
- [ ] After #420 + \`MCP_URL\` secret are in place, paste \`https://mcp.open-orbis.com/mcp\` into an AI connector and verify the OAuth dance completes.