### PR TITLE
fix(deploy): set FRONTEND_URL + CLOUD_RUN_URL on orbis-mcp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,7 +320,7 @@ jobs:
             --timeout=300s \
             --allow-unauthenticated \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest" \
-            --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID"
+            --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=https://open-orbis.com,CLOUD_RUN_URL=https://mcp.open-orbis.com"
 
       - name: Ensure MCP traffic routes to new revision
         run: |


### PR DESCRIPTION
## Summary

The MCP server's \`/.well-known/oauth-protected-resource\` discovery endpoint was responding with dev-default URLs in production:

```json
{"resource":"http://localhost:8081/mcp","authorization_servers":["http://localhost:5173"]}
```

Any AI client doing RFC 8414 discovery would walk away with those URLs and fail to find the real OAuth authorization server. Pasted URLs into ChatGPT / Cursor / Claude Code / Cline / Windsurf looked like the 401 they got was a generic auth problem, when the real cause was broken discovery metadata.

## Root cause

The \`orbis-mcp\` Cloud Run deploy step in \`.github/workflows/deploy.yml\` was missing two env vars that the MCP server reads to build its discovery payload:
- \`FRONTEND_URL\` — used as the \`authorization_servers\` entry.
- \`CLOUD_RUN_URL\` — used as the \`resource\` URL (with \`/mcp\` suffix).

Both fell back to their \`localhost\` defaults defined in \`backend/app/config.py\`.

## Fix

Add both env vars to the MCP deploy step. Values:
- \`FRONTEND_URL=https://open-orbis.com\` (matches the \`orbis-api\` backend's value).
- \`CLOUD_RUN_URL=https://mcp.open-orbis.com\` (the public MCP endpoint).

The live \`orbis-mcp\` service has already been patched manually with \`gcloud run services update --update-env-vars\`. Post-patch verification:

```
$ curl -s https://mcp.open-orbis.com/.well-known/oauth-protected-resource
{"resource":"https://mcp.open-orbis.com/mcp","authorization_servers":["https://open-orbis.com"]}
```

This PR makes the env vars persistent so the next release doesn't regress.

## Found while resolving

#418 — pasting the MCP URL into an AI client was still failing end-to-end even after the bundle fix shipped, because discovery was broken one level deeper.

## Test plan

- [x] Live service patched + discovery returns production URLs.
- [ ] Next release verifies the flag sticks.
- [ ] User pastes \`https://mcp.open-orbis.com/mcp\` into an MCP-capable AI client and the OAuth dance completes.