### PR TITLE
hotfix(mcp): include WWW-Authenticate on 401 so clients can discover OAuth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -320,7 +320,7 @@ jobs:
             --timeout=300s \
             --allow-unauthenticated \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ENCRYPTION_KEY=encryption-key:latest,NEO4J_PASSWORD=neo4j-password:latest,DATABASE_URL=database-url:latest" \
-            --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID"
+            --set-env-vars="ENV=production,NEO4J_URI=bolt://$NEO4J_INTERNAL_IP:7687,NEO4J_USER=neo4j,GCP_PROJECT_ID=$PROJECT_ID,FRONTEND_URL=https://open-orbis.com,CLOUD_RUN_URL=https://mcp.open-orbis.com"
 
       - name: Ensure MCP traffic routes to new revision
         run: |

--- a/backend/mcp_server/auth.py
+++ b/backend/mcp_server/auth.py
@@ -32,10 +32,40 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from app.auth.mcp_keys import resolve_api_key
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
 _HEADER = "x-mcp-key"
+
+
+def _resource_metadata_url() -> str:
+    """URL of the /.well-known/oauth-protected-resource endpoint.
+
+    Used in the WWW-Authenticate challenge so MCP clients (ChatGPT, Claude,
+    Cursor, etc.) can discover OAuth config per MCP spec 2025-03 + RFC 6750.
+    """
+    base = settings.cloud_run_url or "http://localhost:8081"
+    return f"{base.rstrip('/')}/.well-known/oauth-protected-resource"
+
+
+def _unauthorized(error: str, *, invalid_token: bool = False) -> JSONResponse:
+    """Build a 401 response with the MCP-required WWW-Authenticate header.
+
+    `invalid_token=True` signals a bad/expired/revoked credential was
+    presented (RFC 6750: `error="invalid_token"`). Default is the "no
+    credential presented" case — still returns WWW-Authenticate so
+    discovery-driven clients can find the OAuth resource metadata.
+    """
+    parts = ['Bearer realm="mcp"']
+    if invalid_token:
+        parts.append('error="invalid_token"')
+    parts.append(f'resource_metadata="{_resource_metadata_url()}"')
+    return JSONResponse(
+        status_code=401,
+        content={"error": error},
+        headers={"WWW-Authenticate": ", ".join(parts)},
+    )
 
 
 @dataclass(frozen=True)
@@ -113,9 +143,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         pool = await get_pool()
         grant = await resolve_oauth_token(pool, bearer)
         if grant is None:
-            return JSONResponse(
-                status_code=401,
-                content={"error": "invalid, expired, or revoked access token"},
+            return _unauthorized(
+                "invalid, expired, or revoked access token", invalid_token=True
             )
 
         if grant.get("share_token_id"):
@@ -127,9 +156,9 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             driver: AsyncDriver = await self._driver_factory()
             ctx = await validate_share_token_for_mcp(driver, grant["share_token_id"])
             if ctx is None:
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "share token for this grant is no longer valid"},
+                return _unauthorized(
+                    "share token for this grant is no longer valid",
+                    invalid_token=True,
                 )
             return None, _current_share_context.set(ctx)
         else:
@@ -159,19 +188,13 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             user_token, share_token_reset = result
 
         elif not raw_key:
-            return JSONResponse(
-                status_code=401,
-                content={"error": "missing X-MCP-Key header"},
-            )
+            return _unauthorized("authentication required")
 
         elif raw_key.startswith("orbk_"):
             driver: AsyncDriver = await self._driver_factory()
             user_id = await resolve_api_key(driver, raw_key=raw_key)
             if user_id is None:
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "invalid or revoked API key"},
-                )
+                return _unauthorized("invalid or revoked API key", invalid_token=True)
             user_token = _current_user_id.set(user_id)
 
         elif raw_key.startswith("orbs_"):
@@ -183,9 +206,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             bare = raw_key[len("orbs_") :]
             ctx = await validate_share_token_for_mcp(driver, bare)
             if ctx is None:
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "invalid, expired, or revoked share token"},
+                return _unauthorized(
+                    "invalid, expired, or revoked share token", invalid_token=True
                 )
             share_token_reset = _current_share_context.set(ctx)
 
@@ -199,10 +221,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             asyncio.create_task(increment_mcp_use(driver, ctx.token_id))
 
         else:
-            return JSONResponse(
-                status_code=401,
-                content={"error": "unrecognized credential prefix"},
-            )
+            return _unauthorized("unrecognized credential prefix", invalid_token=True)
 
         try:
             return await call_next(request)

--- a/backend/tests/unit/test_mcp_server_auth.py
+++ b/backend/tests/unit/test_mcp_server_auth.py
@@ -173,7 +173,14 @@ async def test_middleware_rejects_missing_header(monkeypatch, reset_context):
 
     r = client.get("/mcp")
     assert r.status_code == 401
-    assert "missing" in r.json()["error"]
+    assert r.json()["error"] == "authentication required"
+    # MCP clients (ChatGPT, Claude, Cursor) discover OAuth via WWW-Authenticate
+    # per RFC 6750 + MCP spec 2025-03; without it they report
+    # "does not implement OAuth" and refuse to start the flow.
+    www_auth = r.headers.get("www-authenticate", "")
+    assert www_auth.startswith("Bearer")
+    assert 'resource_metadata="' in www_auth
+    assert "/.well-known/oauth-protected-resource" in www_auth
 
 
 async def test_middleware_rejects_invalid_key(monkeypatch, reset_context):


### PR DESCRIPTION
## Summary

ChatGPT (and any MCP client doing proper OAuth discovery) was rejecting the server with:

> Error fetching OAuth configuration
> MCP server https://mcp.open-orbis.com/mcp does not implement OAuth

Root cause: the MCP server's 401 responses were missing the RFC 6750 \`WWW-Authenticate\` header with the \`resource_metadata=\` parameter the MCP spec (2025-03) requires. Clients see a bare 401 and conclude the server is header-auth-only.

## Change

All 401 paths in \`APIKeyMiddleware\` now route through a new \`_unauthorized()\` helper that emits:

\`\`\`
WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://mcp.open-orbis.com/.well-known/oauth-protected-resource"
\`\`\`

The \`invalid_token=True\` variant additionally tags \`error="invalid_token"\` per the RFC (distinguishes a bad/expired credential from "no credential presented").

## Test

Updated \`test_middleware_rejects_missing_header\` to assert the header presence; all 14 existing MCP auth tests pass.

## Impact

Live MCP service — ChatGPT custom connector OAuth discovery should now succeed.

## Deployment

Requires a redeploy of \`orbis-mcp\` to take effect in production. Will cut a hotfix release once this merges.