### PR TITLE
hotfix(firebase): proxy OAuth + well-known paths to orbis-api

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,34 @@
         }
       },
       {
+        "source": "/.well-known/oauth-authorization-server",
+        "run": {
+          "serviceId": "orbis-api",
+          "region": "europe-west1"
+        }
+      },
+      {
+        "source": "/oauth/register",
+        "run": {
+          "serviceId": "orbis-api",
+          "region": "europe-west1"
+        }
+      },
+      {
+        "source": "/oauth/token",
+        "run": {
+          "serviceId": "orbis-api",
+          "region": "europe-west1"
+        }
+      },
+      {
+        "source": "/oauth/revoke",
+        "run": {
+          "serviceId": "orbis-api",
+          "region": "europe-west1"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
## Problem

ChatGPT (and any MCP-compliant client) still fails OAuth discovery against \`https://mcp.open-orbis.com/mcp\` after #422/#423 — error: *MCP server does not implement OAuth*.

Traced through the full discovery chain:

1. POST \`https://mcp.open-orbis.com/mcp\` → 401 with \`WWW-Authenticate: Bearer ... resource_metadata=\"...\"\` ✅
2. GET \`https://mcp.open-orbis.com/.well-known/oauth-protected-resource\` → JSON \`{\"authorization_servers\": [\"https://open-orbis.com\"]}\` ✅
3. GET \`https://open-orbis.com/.well-known/oauth-authorization-server\` → **returns SPA \`index.html\`, not JSON** ❌

Step 3 is the failure. \`firebase.json\` only proxies \`/api/**\` to the backend; the OAuth-discovery paths fall through to the default \`**\` → \`/index.html\` rewrite.

\`backend/app/oauth/well_known_router.py\` serves the RFC 8414 metadata at both \`/api/.well-known/...\` and root \`/.well-known/...\` so Firebase can route either way, and the docstring explicitly states: *\"That origin MUST reverse-proxy /oauth/* paths to the backend API\".* That proxy was never added to \`firebase.json\`.

## Fix

Add Firebase Hosting rewrites for the specific OAuth-related paths that the RFC 8414 metadata advertises:

- \`/.well-known/oauth-authorization-server\` (RFC 8414 metadata)
- \`/oauth/register\` (RFC 7591 dynamic client registration)
- \`/oauth/token\` (token endpoint)
- \`/oauth/revoke\` (revocation endpoint)

\`/oauth/authorize\` is intentionally **not** proxied — the React SPA serves it as a consent page.

## Test plan

- [ ] After deploy: \`curl -s https://open-orbis.com/.well-known/oauth-authorization-server\` should return JSON, not HTML.
- [ ] Retry the ChatGPT custom MCP connector setup — expect OAuth discovery to succeed and the consent page to open.