### PR TITLE
hotfix(oauth): omit client_secret from /oauth/register response for public clients

### DIFF
--- a/backend/app/oauth/register_router.py
+++ b/backend/app/oauth/register_router.py
@@ -37,7 +37,7 @@ def _validate_redirect_uri(uri: str) -> bool:
     return parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1"}
 
 
-@router.post("/register", status_code=201)
+@router.post("/register", status_code=201, response_model_exclude_none=True)
 @limiter.limit(
     settings.oauth_register_rate_limit,
     key_func=lambda request: f"oauth_register:{get_remote_address(request)}",

--- a/backend/tests/unit/test_oauth_register.py
+++ b/backend/tests/unit/test_oauth_register.py
@@ -63,7 +63,10 @@ class TestRegisterClient:
         body = resp.json()
         assert body["client_id"] == str(_mock_register_client)
         assert body["client_name"] == "ChatGPT"
-        assert body["client_secret"] is None
+        # RFC 7591: client_secret MUST NOT be present for public clients.
+        # ChatGPT's DCR response model rejects `"client_secret": null`
+        # (input_type=NoneType → string_type validation error).
+        assert "client_secret" not in body
         assert body["grant_types"] == ["authorization_code", "refresh_token"]
         assert body["response_types"] == ["code"]
 


### PR DESCRIPTION
## Problem

ChatGPT's custom MCP connector fails at the OAuth dynamic-client-registration step with:

\`\`\`
1 validation error for DynamicClientRegistrationResponse
client_secret
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
\`\`\`

Our \`POST /oauth/register\` response for public clients (\`token_endpoint_auth_method=none\`) was:

\`\`\`json
{ ..., "client_secret": null }
\`\`\`

## RFC

RFC 7591 §3.2.1 (*Client Information Response*) states:

> If the authorization server issues client credentials, it MUST include the \`client_secret\` parameter in the response. [...] If the client is public, this field MUST NOT be present.

We were including the field with a null value. ChatGPT's DCR client model requires \`client_secret: str\` and rejects nulls.

## Fix

Add \`response_model_exclude_none=True\` to the \`@router.post(\"/register\")\` decorator. Optional fields with a \`None\` value are dropped from the response JSON, satisfying RFC 7591 and ChatGPT's validator.

The confidential-client path (\`client_secret_post\`) is unaffected — the field is still present with a real secret.

## Test

Updated \`test_happy_path_public_client\` to assert \`\"client_secret\" not in body\` instead of \`body[\"client_secret\"] is None\`. All 12 \`test_oauth_register.py\` tests pass.