### PR TITLE
hotfix(oauth): consent page login redirect shows 'Orbis not found'

### DIFF
--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -10,6 +10,15 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const goToPostLogin = async () => {
+      // Honor a pending return-to URL (e.g. OAuth consent flow where the
+      // user was bounced to /oauth/authorize?... before signing in).
+      // Mirrors LinkedInCallbackPage's behavior.
+      const returnTo = sessionStorage.getItem('orbis_return_to');
+      if (returnTo) {
+        sessionStorage.removeItem('orbis_return_to');
+        navigate(returnTo, { replace: true });
+        return;
+      }
       const hasContent = await hasOrbContent();
       navigate(hasContent ? '/myorbis' : '/create');
     };

--- a/frontend/src/pages/ConsentPage.test.tsx
+++ b/frontend/src/pages/ConsentPage.test.tsx
@@ -16,7 +16,7 @@ function renderPage() {
     <MemoryRouter initialEntries={[INITIAL_URL]}>
       <Routes>
         <Route path="/oauth/authorize" element={<ConsentPage />} />
-        <Route path="/login" element={<div>LOGIN</div>} />
+        <Route path="/" element={<div>LANDING</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -46,14 +46,19 @@ describe('ConsentPage', () => {
     expect(screen.getByText(/Restricted access/)).toBeInTheDocument();
   });
 
-  it('redirects to /login when login_required', async () => {
+  it('redirects to landing when login_required and stashes return URL', async () => {
+    sessionStorage.removeItem('orbis_return_to');
     (getAuthorizeContext as ReturnType<typeof vi.fn>).mockResolvedValue({
       login_required: true,
       next: '/oauth/authorize?client_id=c-1',
     });
 
     renderPage();
-    await waitFor(() => expect(screen.getByText('LOGIN')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('LANDING')).toBeInTheDocument());
+    expect(sessionStorage.getItem('orbis_return_to')).toBe(
+      '/oauth/authorize?client_id=c-1',
+    );
+    sessionStorage.removeItem('orbis_return_to');
   });
 
   it('displays the registered IP + client_id in the footer', async () => {

--- a/frontend/src/pages/ConsentPage.tsx
+++ b/frontend/src/pages/ConsentPage.tsx
@@ -19,7 +19,16 @@ export default function ConsentPage() {
     getAuthorizeContext(params)
       .then((c) => {
         if (c.login_required) {
-          navigate(`/login?next=${encodeURIComponent(c.next ?? '/myorbis')}`);
+          // No /login route exists — navigating there falls through to the
+          // /:orbId catch-all and shows "Orbis not found". Stash the OAuth
+          // URL so the landing + auth-callback pages can bounce back here
+          // after sign-in, then go to the public landing page which has
+          // the Google / LinkedIn buttons.
+          sessionStorage.setItem(
+            'orbis_return_to',
+            c.next ?? `${location.pathname}${location.search}`,
+          );
+          navigate('/', { replace: true });
           return;
         }
         setCtx(c);


### PR DESCRIPTION
## Problem

When an MCP client (e.g. ChatGPT custom connector) opens \`https://open-orbis.com/oauth/authorize?...\` and the user isn't signed in on that origin, the user sees **\"Orbis not found\"** instead of the login screen. Clicking the browser back button after signing in elsewhere shows the actual consent modal.

## Root cause

\`ConsentPage\` handled the \`login_required=true\` branch with:

\`\`\`ts
navigate(\`/login?next=...\`);
\`\`\`

No \`/login\` route exists in \`App.tsx\`. React Router fell through to the \`/:orbId\` catch-all, which renders \`SharedOrbPage\` for any single path segment. \`SharedOrbPage\` tried to load orb \`login\`, 404'd, and rendered its \"Orbis not found\" error state.

Independently, \`AuthCallbackPage\` (Google server-redirect flow) did not honor the \`orbis_return_to\` sessionStorage key that \`LandingPage\` and \`LinkedInCallbackPage\` use to bounce a returning user back to their original destination, so even after a successful Google login the user would land on \`/myorbis\` instead of back on \`/oauth/authorize?...\`.

## Fix

- \`ConsentPage\`: on \`login_required\`, stash the OAuth URL in \`sessionStorage\` under \`orbis_return_to\` and \`navigate('/')\`. The landing page has the Google/LinkedIn buttons the user needs.
- \`AuthCallbackPage\`: check \`orbis_return_to\` first (mirrors \`LinkedInCallbackPage\`). Fall back to \`hasOrbContent\` routing when unset.
- Updated the \`ConsentPage.test.tsx\` case: now asserts the landing route renders AND that the return URL was stashed.

## Flow after fix

1. ChatGPT opens \`/oauth/authorize?...\`.
2. Backend says \`login_required: true\`.
3. ConsentPage stashes \`orbis_return_to = /oauth/authorize?...\` and navigates to \`/\`.
4. User clicks Google / LinkedIn.
5. Callback handler reads \`orbis_return_to\`, clears it, navigates back to \`/oauth/authorize?...\`.
6. ConsentPage re-renders, \`getAuthorizeContext\` returns the real context (now that the session cookie exists), consent modal shows.

## Test plan

- [x] \`ConsentPage.test.tsx\` all 7 pass.
- [ ] Post-deploy: open ChatGPT connector from a logged-out session — expect to land on Orbis landing page (not \"Orbis not found\"), sign in, end up on the consent modal.