### PR TITLE
hotfix(mcp): allowlist production host (ChatGPT MCP calls 421-bounced)

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from neo4j import AsyncGraphDatabase
 
 from app.config import settings
@@ -26,8 +27,51 @@ from mcp_server.tools import (
 
 logger = logging.getLogger(__name__)
 
+
+def _build_transport_security() -> TransportSecuritySettings:
+    """DNS rebinding protection allowlist.
+
+    FastMCP auto-enables host validation for localhost and blocks every
+    other Host header, so in production the public domain must be added
+    here explicitly — otherwise every authenticated MCP call from
+    ChatGPT / Claude / Cursor gets 421 "Invalid Host header".
+
+    Parsed from settings.cloud_run_url (set on the orbis-mcp Cloud Run
+    service, e.g. https://mcp.open-orbis.com). Localhost entries stay in
+    the list so dev still works after flipping the env var.
+    """
+    allowed_hosts: list[str] = [
+        "127.0.0.1:*",
+        "localhost:*",
+        "[::1]:*",
+    ]
+    allowed_origins: list[str] = [
+        "http://127.0.0.1:*",
+        "http://localhost:*",
+        "http://[::1]:*",
+    ]
+    if settings.cloud_run_url:
+        # cloud_run_url is e.g. "https://mcp.open-orbis.com". Extract the
+        # bare host (no scheme, no trailing slash) for allowed_hosts, and
+        # keep the full origin in allowed_origins.
+        from urllib.parse import urlparse
+
+        parsed = urlparse(settings.cloud_run_url.rstrip("/"))
+        if parsed.hostname:
+            allowed_hosts.append(parsed.hostname)
+            allowed_hosts.append(f"{parsed.hostname}:*")
+        allowed_origins.append(f"{parsed.scheme}://{parsed.netloc}")
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
+
+
 mcp = FastMCP(
-    "Orbis", instructions="Query professional knowledge graphs (orbs) from Orbis."
+    "Orbis",
+    instructions="Query professional knowledge graphs (orbs) from Orbis.",
+    transport_security=_build_transport_security(),
 )
 
 _driver = None


### PR DESCRIPTION
## Problem

ChatGPT (and any MCP client) completed OAuth successfully and obtained a bearer token, but every subsequent authenticated call to \`https://mcp.open-orbis.com/mcp\` returned **421 Misdirected Request**. From the MCP logs:

\`\`\`
WARNING  Invalid Host header: mcp.open-orbis.com   transport_security.py:64
POST /mcp HTTP/1.1 421 Misdirected Request
\`\`\`

Result: ChatGPT reports "something went wrong with the connection" even though the grant was created on our side and the token worked.

## Root cause

FastMCP auto-enables DNS-rebinding protection when the configured \`host\` is \`127.0.0.1\`/\`localhost\`/\`::1\` — which is the default. The auto-generated allowlist only contains localhost variants, so the production FQDN is rejected.

Because our server runs behind Cloud Run (which handles the actual bind), FastMCP's \`host\` default stays at \`127.0.0.1\`, the heuristic fires, and every request from \`mcp.open-orbis.com\` trips the allowlist check.

## Fix

Pass an explicit \`TransportSecuritySettings\` derived from \`settings.cloud_run_url\`:

- Production (\`CLOUD_RUN_URL=https://mcp.open-orbis.com\`): adds \`mcp.open-orbis.com\` + \`mcp.open-orbis.com:*\` to \`allowed_hosts\` and \`https://mcp.open-orbis.com\` to \`allowed_origins\`.
- Dev: localhost entries remain so nothing changes locally.

No test changes — the existing auth tests keep passing; transport security is enforced by the MCP SDK layer above our middleware.

## Test plan

- [x] 14/14 \`test_mcp_server_auth.py\` pass.
- [ ] Post-deploy: \`curl -I https://mcp.open-orbis.com/.well-known/oauth-protected-resource\` still returns 200.
- [ ] In ChatGPT: re-add the custom MCP connector; after consent, send a prompt that forces a tool call and confirm it succeeds (no 421 in MCP logs).