### PR TITLE
hotfix(mcp): resolve caller user_id to their actual orb_id

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -87,7 +87,7 @@ async def _get_driver():
     return _driver
 
 
-def _resolve_scope(orb_id_arg: str, token_arg: str) -> tuple[str, str]:
+async def _resolve_scope(orb_id_arg: str, token_arg: str) -> tuple[str, str]:
     """Return the effective (orb_id, token) for this tool invocation.
 
     - Share-token mode: the share context set by APIKeyMiddleware is
@@ -95,9 +95,10 @@ def _resolve_scope(orb_id_arg: str, token_arg: str) -> tuple[str, str]:
       we pass the share token's id back through as `token` so the
       existing filter code in `tools.py` treats the request uniformly.
     - Full-access mode (user API key or full-mode OAuth grant): if the
-      LLM didn't provide an orb_id (or passed "me"/"self"), resolve to
-      the authenticated caller's own orb. Otherwise pass through — the
-      tool layer enforces visibility against public orbs.
+      LLM didn't provide an orb_id (or passed "me"/"self"), look up the
+      authenticated caller's own orb_id from Neo4j (user_id and orb_id
+      are distinct fields on the Person node — the tool layer queries
+      by orb_id, not user_id, so the conversion happens here).
     - Anonymous (shouldn't happen — middleware blocks): pass through.
     """
     from mcp_server.auth import get_current_user_id, get_share_context
@@ -118,14 +119,18 @@ def _resolve_scope(orb_id_arg: str, token_arg: str) -> tuple[str, str]:
             )
         return ctx.orb_id, ctx.token_id
 
-    # Full-access mode: an empty or "me"/"self" orb_id resolves to the
-    # authenticated caller's own orb. A Person's user_id is the orb id
-    # for that person's own Orbis graph (1-1), so get_current_user_id()
-    # is exactly what tools expect as orb_id.
     if not orb_id_arg or orb_id_arg.lower() in ("me", "self", "own"):
         caller_id = get_current_user_id()
         if caller_id is not None:
-            return caller_id, token_arg
+            driver = await _get_driver()
+            async with driver.session() as session:
+                result = await session.run(
+                    "MATCH (p:Person {user_id: $user_id}) RETURN p.orb_id AS orb_id",
+                    user_id=caller_id,
+                )
+                record = await result.single()
+            if record and record["orb_id"]:
+                return record["orb_id"], token_arg
 
     return orb_id_arg, token_arg
 
@@ -171,7 +176,7 @@ def _build_starlette_app():
 @mcp.tool()
 async def orbis_get_summary(orb_id: str = "", token: str = "") -> dict:
     """Get a summary of a person's professional profile (name, headline, location, and counts of each node type). Leave ``orb_id`` empty (or pass ``"me"``) to query the authenticated caller's own Orbis. Leave ``token`` empty when you already have full access."""
-    orb_id, token = _resolve_scope(orb_id, token)
+    orb_id, token = await _resolve_scope(orb_id, token)
     driver = await _get_driver()
     return await get_orb_summary(driver, orb_id, token)
 
@@ -179,7 +184,7 @@ async def orbis_get_summary(orb_id: str = "", token: str = "") -> dict:
 @mcp.tool()
 async def orbis_get_full_orb(orb_id: str = "", token: str = "") -> dict:
     """Get the complete graph data for a person's Orbis. Leave ``orb_id`` empty (or pass ``"me"``) to query the authenticated caller's own Orbis. Results are filtered by the share token's privacy settings when a token is supplied."""
-    orb_id, token = _resolve_scope(orb_id, token)
+    orb_id, token = await _resolve_scope(orb_id, token)
     driver = await _get_driver()
     return await get_orb_full(driver, orb_id, token)
 
@@ -189,7 +194,7 @@ async def orbis_get_nodes_by_type(
     node_type: str, orb_id: str = "", token: str = ""
 ) -> list[dict]:
     """Get all nodes of a specific type from an Orbis. Leave ``orb_id`` empty (or pass ``"me"``) to query the authenticated caller's own Orbis. Valid ``node_type`` values: education, work_experience, certification, language, publication, project, skill, patent, award, outreach, training."""
-    orb_id, token = _resolve_scope(orb_id, token)
+    orb_id, token = await _resolve_scope(orb_id, token)
     driver = await _get_driver()
     return await get_nodes_by_type(driver, orb_id, node_type, token)
 
@@ -199,7 +204,7 @@ async def orbis_get_connections(
     node_uid: str, orb_id: str = "", token: str = ""
 ) -> dict:
     """Get all relationships and connected nodes for a specific node identified by its uid. Leave ``orb_id`` empty (or pass ``"me"``) to query the authenticated caller's own Orbis."""
-    orb_id, token = _resolve_scope(orb_id, token)
+    orb_id, token = await _resolve_scope(orb_id, token)
     driver = await _get_driver()
     return await get_connections(driver, orb_id, node_uid, token)
 
@@ -209,7 +214,7 @@ async def orbis_get_skills_for_experience(
     experience_uid: str, orb_id: str = "", token: str = ""
 ) -> list[dict]:
     """Get all skills that were used in a specific work experience or project, identified by the experience's uid. Leave ``orb_id`` empty (or pass ``"me"``) to query the authenticated caller's own Orbis."""
-    orb_id, token = _resolve_scope(orb_id, token)
+    orb_id, token = await _resolve_scope(orb_id, token)
     driver = await _get_driver()
     return await get_skills_for_experience(driver, orb_id, experience_uid, token)
 

--- a/backend/tests/unit/test_mcp_share_context.py
+++ b/backend/tests/unit/test_mcp_share_context.py
@@ -8,15 +8,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 class TestResolveScope:
-    """Translates tool args based on whether share context is set."""
+    """Translates tool args based on whether share context is set.
 
-    def test_passes_through_when_no_share_context(self):
+    `_resolve_scope` is async because the full-access "me" path resolves
+    a caller's user_id to their orb_id via Neo4j. Tests that don't
+    exercise that path still need to await the coroutine.
+    """
+
+    async def test_passes_through_when_no_share_context_and_no_caller(self):
         from mcp_server.server import _resolve_scope
 
-        # Baseline: no context set
-        assert _resolve_scope("orb-123", "tok-xyz") == ("orb-123", "tok-xyz")
+        # No share context, no authenticated user → pass through verbatim.
+        assert await _resolve_scope("orb-123", "tok-xyz") == ("orb-123", "tok-xyz")
 
-    def test_uses_share_context_when_set(self):
+    async def test_uses_share_context_when_set(self):
         from mcp_server.auth import ShareContext, _current_share_context
         from mcp_server.server import _resolve_scope
 
@@ -28,17 +33,15 @@ class TestResolveScope:
         )
         reset = _current_share_context.set(ctx)
         try:
-            # LLM passes empty values — we fill from context
-            assert _resolve_scope("", "") == ("orb-from-share", "tok-scoped")
-            # LLM passes matching orb_id — same outcome
-            assert _resolve_scope("orb-from-share", "anything") == (
+            assert await _resolve_scope("", "") == ("orb-from-share", "tok-scoped")
+            assert await _resolve_scope("orb-from-share", "anything") == (
                 "orb-from-share",
                 "tok-scoped",
             )
         finally:
             _current_share_context.reset(reset)
 
-    def test_logs_warning_on_orb_id_mismatch(self, caplog):
+    async def test_logs_warning_on_orb_id_mismatch(self, caplog):
         import hashlib
 
         from mcp_server.auth import ShareContext, _current_share_context
@@ -53,10 +56,9 @@ class TestResolveScope:
         reset = _current_share_context.set(ctx)
         try:
             with caplog.at_level("WARNING", logger="mcp_server.server"):
-                orb, tok = _resolve_scope("orb-B", "")
+                orb, tok = await _resolve_scope("orb-B", "")
             assert orb == "orb-A"  # share context wins
             assert tok == "tok-A"
-            # The WARNING must reveal the mismatch but NEVER the raw token_id
             expected_hint = hashlib.sha256(b"tok-A").hexdigest()[:12]
             assert any(
                 "mismatched orb_id" in r.message
@@ -66,6 +68,32 @@ class TestResolveScope:
             )
         finally:
             _current_share_context.reset(reset)
+
+    async def test_resolves_caller_user_id_to_orb_id_for_me(self, monkeypatch):
+        """Full-access mode: empty/"me" orb_id → caller's orb_id via Neo4j."""
+        from mcp_server.auth import _current_user_id
+        from mcp_server.server import _resolve_scope
+
+        # Fake driver + session + record chain
+        record = {"orb_id": "orb-resolved-123"}
+        result = MagicMock()
+        result.single = AsyncMock(return_value=record)
+        session = MagicMock()
+        session.run = AsyncMock(return_value=result)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=session)
+
+        with patch("mcp_server.server._get_driver", AsyncMock(return_value=driver)):
+            reset = _current_user_id.set("google-sub-abc")
+            try:
+                for alias in ("", "me", "Self", "own"):
+                    orb, tok = await _resolve_scope(alias, "ignored")
+                    assert orb == "orb-resolved-123"
+                    assert tok == "ignored"
+            finally:
+                _current_user_id.reset(reset)
 
 
 # ── _check_access in tools.py under share context ───────────────────────

--- a/backend/tests/unit/test_mcp_share_context.py
+++ b/backend/tests/unit/test_mcp_share_context.py
@@ -69,7 +69,7 @@ class TestResolveScope:
         finally:
             _current_share_context.reset(reset)
 
-    async def test_resolves_caller_user_id_to_orb_id_for_me(self, monkeypatch):
+    async def test_resolves_caller_user_id_to_orb_id_for_me(self):
         """Full-access mode: empty/"me" orb_id → caller's orb_id via Neo4j."""
         from mcp_server.auth import _current_user_id
         from mcp_server.server import _resolve_scope


### PR DESCRIPTION
## Problem

After #428 (empty orb_id → caller), ChatGPT's tool call now reaches the server and passes \`orb_id=google-102684892671297868834\` (my Google user_id). The tool layer returns:

> Orb 'google-102684892671297868834' not accessible

## Root cause

The Person node has \`user_id\` and \`orb_id\` as distinct fields:
- \`user_id\` — auth identifier (e.g. \`google-<sub>\`, \`linkedin-<sub>\`)
- \`orb_id\` — the vanity / public Orbis id

Tool queries match by \`orb_id\` (see \`tools.py\` lines 77/225/252/292), but #428 resolved "me" to \`get_current_user_id()\` — the user_id. They don't match, so the access check failed.

## Fix

\`_resolve_scope\` now does one async Neo4j lookup to translate the caller's user_id → orb_id when "me"/\`""\` is passed:

\`\`\`cypher
MATCH (p:Person {user_id: $user_id}) RETURN p.orb_id AS orb_id
\`\`\`

Made \`_resolve_scope\` async; all 5 tool call sites now \`await\` it. Share-token mode path unchanged.

## Test plan

- [x] 14/14 \`test_mcp_server_auth.py\` pass (middleware layer unchanged).
- [ ] Post-deploy: "Using the Orbis connector, summarize my Orbis." expect an actual summary, not a rejection.