### PR TITLE
fix(profile): photo modal reflects uploads, removes, and rejections (#432)

### DIFF
--- a/backend/app/orbs/router.py
+++ b/backend/app/orbs/router.py
@@ -312,12 +312,19 @@ async def delete_profile_image(
     current_user: dict = Depends(get_current_user),
     db: AsyncDriver = Depends(get_db),
 ):
-    """Remove the profile picture."""
+    """Remove the profile picture.
+
+    Clears both ``profile_image`` (the user's custom upload, if any) AND
+    ``picture`` (the OAuth provider's avatar URL). Without clearing the
+    latter, "Remove photo" would leave the Google/LinkedIn avatar as a
+    fallback on the next render — confusing because the user explicitly
+    asked for no photo. The avatar slot then renders the name initial.
+    """
     async with db.session() as session:
         result = await session.run(
             UPDATE_PERSON,
             user_id=current_user["user_id"],
-            properties={"profile_image": ""},
+            properties={"profile_image": "", "picture": ""},
         )
         record = await result.single()
         if record is None:

--- a/backend/tests/unit/test_orbs_router.py
+++ b/backend/tests/unit/test_orbs_router.py
@@ -198,6 +198,61 @@ def test_delete_node_success(client, mock_db):
     assert response.json()["status"] == "deleted"
 
 
+def _tiny_png_bytes() -> bytes:
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (10, 10), (255, 0, 0)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def test_upload_profile_image_persists_data_uri(client, mock_db):
+    """POST /orbs/me/profile-image must write a non-empty JPEG data URI
+    to Person.profile_image via UPDATE_PERSON."""
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value={"p": MockNode({"user_id": "test-user"}, ["Person"])})
+    )
+
+    response = client.post(
+        "/orbs/me/profile-image",
+        files={"file": ("avatar.png", _tiny_png_bytes(), "image/png")},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "uploaded"}
+
+    run_mock = mock_db.session.return_value.__aenter__.return_value.run
+    sent_props = run_mock.call_args.kwargs["properties"]
+    assert "profile_image" in sent_props
+    assert sent_props["profile_image"].startswith("data:image/jpeg;base64,")
+    assert len(sent_props["profile_image"]) > len("data:image/jpeg;base64,")
+
+
+def test_get_my_orb_returns_profile_image(client, mock_db):
+    """GET /orbs/me must round-trip a previously-uploaded profile_image
+    data URI back to the client. This is the half of the loop that
+    keeps the modal showing a stale empty avatar (#432)."""
+    data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD"
+    person_node = MockNode(
+        {"user_id": "test-user", "name": "Test User", "profile_image": data_uri},
+        ["Person"],
+    )
+    record = {
+        "p": person_node,
+        "connections": [],
+        "cross_skill_nodes": [],
+        "cross_links": [],
+    }
+    mock_db.session.return_value.__aenter__.return_value.run.return_value.single = (
+        AsyncMock(return_value=record)
+    )
+
+    response = client.get("/orbs/me")
+    assert response.status_code == 200
+    assert response.json()["person"]["profile_image"] == data_uri
+
+
 @patch("app.orbs.router.get_orb_visibility", new_callable=AsyncMock)
 def test_get_public_orb_success(mock_visibility, client, mock_db):
     mock_visibility.return_value = "public"

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,8 +79,8 @@ All endpoints require `is_admin = true` on the authenticated Person.
 | GET | `/orbs/me` | JWT | — | Full orb: person + nodes + links |
 | PUT | `/orbs/me` | JWT | — | Update Person profile fields. `email` is **not** in the accepted schema — it is the OAuth sign-up address and can only be changed by re-authenticating with a different provider account (#394). |
 | PUT | `/orbs/me/orb-id` | JWT | — | Claim/update public orb_id (409 if taken) |
-| POST | `/orbs/me/profile-image` | JWT | — | Upload profile image as base64 (max 2MB) |
-| DELETE | `/orbs/me/profile-image` | JWT | — | Clear profile image |
+| POST | `/orbs/me/profile-image` | JWT | — | Upload profile image (max 2MB upload, max 1000×1000 px enforced client-side; backend resizes to 256×256 JPEG) |
+| DELETE | `/orbs/me/profile-image` | JWT | — | Clear profile image AND OAuth `picture` URL so the avatar falls back to the name initial (#432) |
 | POST | `/orbs/me/nodes` | JWT | — | Create node (any type) linked to Person |
 | PUT | `/orbs/me/nodes/{uid}` | JWT | — | Update node properties |
 | DELETE | `/orbs/me/nodes/{uid}` | JWT | — | Delete node |

--- a/frontend/e2e/fixtures/mock-orb.ts
+++ b/frontend/e2e/fixtures/mock-orb.ts
@@ -56,7 +56,7 @@ export async function mockOrbRoutes(page: Page) {
     route.fulfill(json([])),
   );
   await page.route((url) => url.pathname === '/api/orbs/me/connection-requests', (route) =>
-    route.fulfill(json([])),
+    route.fulfill(json({ requests: [] })),
   );
   await page.route((url) => url.pathname === '/api/orbs/me/public-filters', (route) =>
     route.fulfill(json({})),

--- a/frontend/e2e/profile-image-upload.spec.ts
+++ b/frontend/e2e/profile-image-upload.spec.ts
@@ -1,0 +1,283 @@
+import { test, expect } from '@playwright/test';
+import { mockAuthRoutes } from './fixtures/auth';
+import { MOCK_ORB } from './fixtures/mock-orb';
+import type { Page, Route } from '@playwright/test';
+
+const TINY_PNG_DATA_URI =
+  'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpgB//Z';
+
+const PRE_EXISTING_DATA_URI =
+  'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABwSFBcUEhwXFhcfHRwhKEMrKCQkKFE6PTBDYFVlZF9VXVtqeJmDanGQc1tdhrWHkJ6jq62rZ4G8ybmnx5moq6X/2wBDAR0fHygjKE4rK06lbl1upaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaX/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAA/AH4z/9k=';
+
+async function setupAuthed(page: Page) {
+  await page.addInitScript(() => {
+    window.addEventListener(
+      'orbis:session-expired',
+      (e) => { e.stopImmediatePropagation(); },
+      true,
+    );
+  });
+  await mockAuthRoutes(page);
+}
+
+test.describe('Profile image upload (#432)', () => {
+  test('after upload, modal stays open AND trigger avatar shows new image', async ({ page }) => {
+    await setupAuthed(page);
+
+    // /api/orbs/me — return PRE_EXISTING until the test flips a flag (the
+    // moment of upload), then return TINY_PNG with a 600ms delay so the
+    // optimistic-preview path is observable.
+    let uploadFired = false;
+    let orbCallsAfterUpload = 0;
+    await page.route((url) => url.pathname === '/api/orbs/me' && url.search === '', async (route: Route) => {
+      if (!uploadFired) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...MOCK_ORB,
+            person: { ...MOCK_ORB.person, profile_image: PRE_EXISTING_DATA_URI },
+          }),
+        });
+      }
+      orbCallsAfterUpload += 1;
+      await new Promise((r) => setTimeout(r, 600));
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...MOCK_ORB,
+          person: { ...MOCK_ORB.person, profile_image: TINY_PNG_DATA_URI },
+        }),
+      });
+    });
+
+    const json = (body: string) => ({ status: 200, contentType: 'application/json', body });
+    await page.route((u) => u.pathname === '/api/orbs/has-content', (r) => r.fulfill(json('true')));
+    await page.route((u) => u.pathname === '/api/cv/documents', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/cv/processing-count', (r) => r.fulfill(json('0')));
+    await page.route((u) => u.pathname === '/api/drafts', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/share-tokens', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/access-grants', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/connection-requests', (r) => r.fulfill(json('{"requests":[]}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/public-filters', (r) => r.fulfill(json('{}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/visibility', (r) => r.fulfill(json('"restricted"')));
+
+    await page.route((u) => u.pathname === '/api/orbs/me/profile-image', (route) => {
+      uploadFired = true;
+      return route.fulfill(json('{"status":"uploaded"}'));
+    });
+
+    await page.goto('/myorbis');
+
+    await expect(page.getByText(MOCK_ORB.person.name)).toBeVisible({ timeout: 15_000 });
+
+    // Open user menu → click "Edit Profile" to open the modal.
+    await page.getByTitle('Account menu').click();
+    await page.getByText('Edit Profile').click();
+
+    // Modal is open (confirmed by its headline copy).
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeVisible();
+
+    // Capture the modal preview's src BEFORE upload to verify it switches.
+    const modalAvatar = page.getByTitle('Upload profile picture').locator('img');
+    await expect(modalAvatar).toHaveAttribute('src', PRE_EXISTING_DATA_URI);
+
+    // Upload via the hidden file input inside the modal.
+    const fileInput = page.locator('input[type="file"][accept*="image"]');
+    await fileInput.setInputFiles({
+      name: 'avatar.png',
+      mimeType: 'image/png',
+      buffer: Buffer.from(
+        '89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D4944415478DA63F8CFC0F01F00050001FFA1FE9C720000000049454E44AE426082',
+        'hex',
+      ),
+    });
+
+    // Optimistic-preview check: WITHIN ~300ms of file pick (well before the
+    // 600ms-delayed fetchOrb resolves), the modal preview must already show
+    // a NEW src — either the blob URL or the persistent data URI. The point
+    // is "not the pre-existing one" — the user's perceived "immediately".
+    await expect.poll(
+      async () => modalAvatar.getAttribute('src'),
+      { timeout: 300, intervals: [50] },
+    ).not.toBe(PRE_EXISTING_DATA_URI);
+
+    // Wait until fetchOrb's post-upload refresh has resolved.
+    await expect.poll(() => orbCallsAfterUpload, { timeout: 5_000 }).toBeGreaterThanOrEqual(1);
+
+    // Bug B regression: the modal MUST stay open after fetchOrb refreshes.
+    // The OrbViewPage spinner gate (`if (loading || !data)`) used to unmount
+    // the entire subtree on every refresh, killing modals mid-flow.
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeVisible();
+
+    // Bug A regression: the trigger avatar in UserMenu must reflect the new
+    // image. UserMenu used to read only from authStore.user.profile_image,
+    // which fetchOrb does not refresh — so the trigger stayed empty.
+    const triggerImg = page.getByTitle('Account menu').locator('img').first();
+    await expect(triggerImg).toHaveAttribute('src', TINY_PNG_DATA_URI, { timeout: 5_000 });
+
+    // Final state: once fetchOrb has refreshed, the persistent data URI takes
+    // over from the optimistic blob URL.
+    await expect(modalAvatar).toHaveAttribute('src', TINY_PNG_DATA_URI, { timeout: 5_000 });
+  });
+
+  test('clicking "Save profile" closes the modal after the PUT succeeds', async ({ page }) => {
+    await setupAuthed(page);
+
+    let putFired = false;
+    await page.route((url) => url.pathname === '/api/orbs/me' && url.search === '', async (route: Route) => {
+      if (route.request().method() === 'PUT') {
+        putFired = true;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"updated"}' });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...MOCK_ORB,
+          person: { ...MOCK_ORB.person, headline: putFired ? 'Updated headline' : 'Software Engineer' },
+        }),
+      });
+    });
+
+    const json = (body: string) => ({ status: 200, contentType: 'application/json', body });
+    await page.route((u) => u.pathname === '/api/orbs/has-content', (r) => r.fulfill(json('true')));
+    await page.route((u) => u.pathname === '/api/cv/documents', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/cv/processing-count', (r) => r.fulfill(json('0')));
+    await page.route((u) => u.pathname === '/api/drafts', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/share-tokens', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/access-grants', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/connection-requests', (r) => r.fulfill(json('{"requests":[]}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/public-filters', (r) => r.fulfill(json('{}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/visibility', (r) => r.fulfill(json('"restricted"')));
+
+    await page.goto('/myorbis');
+    await expect(page.getByText(MOCK_ORB.person.name)).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTitle('Account menu').click();
+    await page.getByText('Edit Profile').click();
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Save profile' }).click();
+    await expect.poll(() => putFired, { timeout: 5_000 }).toBe(true);
+
+    // Save profile must auto-close the modal once the PUT succeeds.
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeHidden({ timeout: 3_000 });
+  });
+
+  test('rejects image larger than 1000×1000 px before uploading', async ({ page }) => {
+    await setupAuthed(page);
+
+    let uploadAttempted = false;
+    await page.route((url) => url.pathname === '/api/orbs/me/profile-image', (route) => {
+      uploadAttempted = true;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"uploaded"}' });
+    });
+
+    const json = (body: string) => ({ status: 200, contentType: 'application/json', body });
+    await page.route((u) => u.pathname === '/api/orbs/me' && u.search === '', (r) => r.fulfill(json(JSON.stringify({
+      ...MOCK_ORB,
+      person: { ...MOCK_ORB.person, profile_image: '' },
+    }))));
+    await page.route((u) => u.pathname === '/api/orbs/has-content', (r) => r.fulfill(json('true')));
+    await page.route((u) => u.pathname === '/api/cv/documents', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/cv/processing-count', (r) => r.fulfill(json('0')));
+    await page.route((u) => u.pathname === '/api/drafts', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/share-tokens', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/access-grants', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/connection-requests', (r) => r.fulfill(json('{"requests":[]}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/public-filters', (r) => r.fulfill(json('{}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/visibility', (r) => r.fulfill(json('"restricted"')));
+
+    await page.goto('/myorbis');
+    await expect(page.getByText(MOCK_ORB.person.name)).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTitle('Account menu').click();
+    await page.getByText('Edit Profile').click();
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeVisible();
+
+    // Generate a 1200×800 PNG inside the browser and attach it to the file
+    // input — bigger than the 1000-px ceiling on the wider edge.
+    await page.evaluate(async () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 1200;
+      canvas.height = 800;
+      const ctx = canvas.getContext('2d')!;
+      ctx.fillStyle = '#3366cc';
+      ctx.fillRect(0, 0, 1200, 800);
+      const blob = await new Promise<Blob>((resolve) => canvas.toBlob((b) => resolve(b!), 'image/png'));
+      const file = new File([blob], 'oversize.png', { type: 'image/png' });
+      const input = document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement;
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      input.files = dt.files;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    // Inline error (NOT a toast) cites the actual dimensions and the limit.
+    await expect(page.getByRole('alert')).toContainText(/Image is 1200.800 px.+maximum is 1000.1000/);
+
+    // Upload endpoint must NOT have been called.
+    await page.waitForTimeout(300);
+    expect(uploadAttempted).toBe(false);
+  });
+
+  test('Remove photo clears the image and falls back to the name initial', async ({ page }) => {
+    await setupAuthed(page);
+
+    let deleteFired = false;
+    await page.route((u) => u.pathname === '/api/orbs/me/profile-image', (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteFired = true;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"deleted"}' });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"uploaded"}' });
+    });
+
+    // First fetchOrb returns a person WITH a profile_image; once delete fires
+    // the backend would clear both profile_image and picture, so the next
+    // fetchOrb returns both empty.
+    await page.route((url) => url.pathname === '/api/orbs/me' && url.search === '', (route: Route) => {
+      const person = deleteFired
+        ? { ...MOCK_ORB.person, profile_image: '', picture: '' }
+        : { ...MOCK_ORB.person, profile_image: PRE_EXISTING_DATA_URI, picture: '' };
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...MOCK_ORB, person }),
+      });
+    });
+
+    const json = (body: string) => ({ status: 200, contentType: 'application/json', body });
+    await page.route((u) => u.pathname === '/api/orbs/has-content', (r) => r.fulfill(json('true')));
+    await page.route((u) => u.pathname === '/api/cv/documents', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/cv/processing-count', (r) => r.fulfill(json('0')));
+    await page.route((u) => u.pathname === '/api/drafts', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/share-tokens', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/access-grants', (r) => r.fulfill(json('[]')));
+    await page.route((u) => u.pathname === '/api/orbs/me/connection-requests', (r) => r.fulfill(json('{"requests":[]}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/public-filters', (r) => r.fulfill(json('{}')));
+    await page.route((u) => u.pathname === '/api/orbs/me/visibility', (r) => r.fulfill(json('"restricted"')));
+
+    await page.goto('/myorbis');
+    await expect(page.getByText(MOCK_ORB.person.name)).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTitle('Account menu').click();
+    await page.getByText('Edit Profile').click();
+    await expect(page.getByText('Update your public identity, links, and profile image.')).toBeVisible();
+
+    // Confirm the modal starts with the existing photo.
+    const modalAvatar = page.getByTitle('Upload profile picture').locator('img');
+    await expect(modalAvatar).toHaveAttribute('src', PRE_EXISTING_DATA_URI);
+
+    // Two-step destructive confirm: Remove → Confirm remove.
+    await page.getByRole('button', { name: 'Remove photo' }).click();
+    await page.getByRole('button', { name: /Confirm remove/ }).click();
+    await expect.poll(() => deleteFired, { timeout: 5_000 }).toBe(true);
+
+    // Modal preview now shows the initial (no <img> in the upload tile).
+    await expect(page.getByTitle('Upload profile picture').locator('img')).toHaveCount(0);
+    await expect(page.getByTitle('Upload profile picture').locator('span')).toContainText('T'); // 'Test User'
+  });
+});

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -76,7 +76,14 @@ export default function UserMenu({ orbId, onOrbIdChanged, person, onProfileSaved
 
   if (!user) return null;
 
-  const avatarSrc = user.profile_image || user.picture || '';
+  // The Person prop (refreshed by fetchOrb) is the source of truth.
+  // Falling back to authStore.user.* would show a stale image after upload
+  // or, worse, the OAuth picture even after the user explicitly removed
+  // their photo (which clears `picture` on the backend).
+  const avatarSrc =
+    (person?.profile_image as string) ||
+    (person?.picture as string) ||
+    '';
   const initial = (user.name || 'O').charAt(0).toUpperCase();
 
   const handleLogout = () => {

--- a/frontend/src/components/profile/ProfileEditorModal.tsx
+++ b/frontend/src/components/profile/ProfileEditorModal.tsx
@@ -36,36 +36,99 @@ export default function ProfileEditorModal({ person, onClose, onSaved }: Profile
   const photoRemovedRef = useRef(false);
   const [, forceRender] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Optimistic preview while the upload + fetchOrb refresh are in flight,
+  // so the new image appears immediately on file pick instead of after the
+  // ~300ms network round-trip.
+  const [optimisticPreview, setOptimisticPreview] = useState<string | null>(null);
+  // Inline rejection message shown directly under the photo. Toasts were
+  // missed because the toast container is on the opposite side of the
+  // viewport from the modal's avatar tile.
+  const [imageError, setImageError] = useState<string | null>(null);
 
   useEffect(() => {
+    // A fresh `person` from fetchOrb means the persistent profile_image is
+    // now in the prop — drop the optimistic blob URL.
+    setOptimisticPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
     setValues(extractInitialValues(person));
   }, [person]);
 
-  const profileImage = photoRemovedRef.current ? '' : ((person.profile_image as string) || (person.picture as string) || '');
+  useEffect(() => () => {
+    // Free the blob URL on unmount to avoid leaks if the modal closes
+    // before the next person refresh.
+    if (optimisticPreview) URL.revokeObjectURL(optimisticPreview);
+  }, [optimisticPreview]);
+
+  const profileImage = photoRemovedRef.current
+    ? ''
+    : (optimisticPreview || (person.profile_image as string) || (person.picture as string) || '');
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    const resetInput = () => { if (fileInputRef.current) fileInputRef.current.value = ''; };
+    setImageError(null);
     if (!file.type.startsWith('image/')) {
-      addToast('Please select an image file', 'error');
+      setImageError('Please select an image file (JPEG, PNG, or WebP).');
+      resetInput();
       return;
     }
     if (file.size > 2 * 1024 * 1024) {
-      addToast('Image too large (max 2MB)', 'error');
+      setImageError('Image is too large — maximum file size is 2 MB.');
+      resetInput();
       return;
     }
+
+    // Reject images larger than 1000×1000 px before any network I/O so the
+    // user gets immediate feedback that matches the in-modal hint.
+    const probeUrl = URL.createObjectURL(file);
+    let width = 0;
+    let height = 0;
+    try {
+      ({ width, height } = await new Promise<{ width: number; height: number }>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+        img.onerror = () => reject(new Error('decode failed'));
+        img.src = probeUrl;
+      }));
+    } catch {
+      URL.revokeObjectURL(probeUrl);
+      setImageError('Could not read image — please try a different file.');
+      resetInput();
+      return;
+    }
+    if (width > 1000 || height > 1000) {
+      URL.revokeObjectURL(probeUrl);
+      setImageError(`Image is ${width}×${height} px — maximum is 1000×1000 px.`);
+      resetInput();
+      return;
+    }
+
+    // Reuse the probe blob URL as the optimistic preview so we don't
+    // allocate a second one. The persistent server-side URI takes over
+    // once fetchOrb refreshes the person prop.
+    setOptimisticPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return probeUrl;
+    });
+    photoRemovedRef.current = false;
 
     setUploadingImage(true);
     try {
       await uploadProfileImage(file);
-      photoRemovedRef.current = false;
       addToast('Profile picture updated', 'success');
       onSaved();
     } catch {
       addToast('Failed to upload profile picture', 'error');
+      setOptimisticPreview((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
     } finally {
       setUploadingImage(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      resetInput();
     }
   };
 
@@ -93,6 +156,7 @@ export default function ProfileEditorModal({ person, onClose, onSaved }: Profile
       await updateProfile(props);
       addToast('Profile updated', 'success');
       onSaved();
+      onClose();
     } catch {
       addToast('Failed to update profile', 'error');
     } finally {
@@ -196,6 +260,11 @@ export default function ProfileEditorModal({ person, onClose, onSaved }: Profile
                   )
                 )}
               </div>
+              {imageError ? (
+                <p className="mt-2 text-[10px] text-red-300" role="alert">{imageError}</p>
+              ) : (
+                <p className="mt-2 text-[10px] text-white/35">Maximum 1000 × 1000 px.</p>
+              )}
             </div>
           </div>
 

--- a/frontend/src/pages/OrbViewPage.tsx
+++ b/frontend/src/pages/OrbViewPage.tsx
@@ -592,7 +592,7 @@ export default function OrbViewPage() {
     e.target.value = '';
   }, [handleImportFile]);
 
-  if (loading || !data) {
+  if (!data) {
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center">
         <div className="w-12 h-12 border-4 border-purple-500 border-t-transparent rounded-full animate-spin" />


### PR DESCRIPTION
## Summary

The profile-image modal had a cluster of bugs that left users guessing whether their upload took. This rewires the upload, refresh, and remove paths around a single source of truth (`Person.profile_image`) and surfaces rejections inline next to the photo. Closes #432.

**Bugs fixed**
- `OrbViewPage`'s \`loading || !data\` gate unmounted the whole subtree on every \`fetchOrb\` refresh, killing the modal mid-upload. Now only \`!data\` triggers the spinner.
- \`UserMenu\`'s avatar trigger read from \`authStore.user.profile_image\`, which is only seeded at login and never refreshed. Now reads from the \`person\` prop.
- Modal preview waited the full ~300 ms fetchOrb round-trip before swapping in the new image. Now shows an optimistic blob URL on file pick; the persistent server URI replaces it via \`useEffect\` on \`[person]\`.
- \`Save profile\` left the modal open. Now closes after the PUT succeeds.
- \`Remove photo\` previously cleared only \`profile_image\` and left the OAuth \`picture\` URL as a fallback, so the avatar would re-appear. The DELETE handler now clears both fields and the avatar drops to the name initial.

**UX additions**
- Inline \"Maximum 1000 × 1000 px.\" hint under the photo.
- Client-side rejection of >1000×1000 images before any network I/O. The error message replaces the hint inline (toasts on the opposite side of the viewport went unnoticed).

## Test plan

- [x] \`frontend/e2e/profile-image-upload.spec.ts\` — 4 new Playwright tests:
  - upload → modal stays open + trigger avatar updates (Bug A + B + optimistic preview)
  - Save profile → modal closes after PUT resolves
  - oversize image → inline error, no upload fired
  - Remove photo → both \`profile_image\` and \`picture\` cleared → name initial shown
- [x] \`backend/tests/unit/test_orbs_router.py\` — 2 new tests pinning the upload-write and read-back of \`profile_image\`.
- [x] Pre-existing \`authenticated-pages.spec.ts:22\` (\"loads without console errors\") was failing on \`main\` because \`mockOrbRoutes\` returned a bare array for connection-requests instead of \`{requests: []}\`. Fixture fixed; that test now passes too.
- [x] Backend lint + format clean (\`ruff check\` / \`ruff format --check\`).
- [x] Frontend lint clean (only pre-existing warnings).

## Documentation

- \`docs/api.md\` — updated POST and DELETE \`/orbs/me/profile-image\` rows for the new client-side limit and the dual-field clear on delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)