### PR TITLE
fix(snapshots): pass datetime (not ISO string) to asyncpg insert (#435)

### DIFF
--- a/backend/app/snapshots/db.py
+++ b/backend/app/snapshots/db.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from app.db.postgres import get_pool
 
 MAX_SNAPSHOTS_PER_USER = 3
@@ -15,7 +17,7 @@ async def insert_snapshot(
     node_count: int,
     edge_count: int,
     data: str,
-    now: str,
+    now: datetime,
 ) -> dict:
     pool = await get_pool()
     await pool.execute(

--- a/backend/app/snapshots/service.py
+++ b/backend/app/snapshots/service.py
@@ -146,7 +146,11 @@ async def create_snapshot(
         }
 
     snapshot_id = str(uuid.uuid4())
-    now = datetime.now(timezone.utc).isoformat()
+    # asyncpg's TIMESTAMP WITH TIME ZONE binding requires a datetime
+    # instance — passing an ISO string raises DataError at execute() time
+    # (#435). FastAPI/Pydantic still serializes it back to ISO on the way
+    # out, so wire format is unchanged.
+    now = datetime.now(timezone.utc)
 
     await snap_db.delete_oldest_if_at_limit(user_id)
 

--- a/backend/tests/unit/test_snapshots_service.py
+++ b/backend/tests/unit/test_snapshots_service.py
@@ -184,6 +184,34 @@ async def test_create_snapshot():
         mock_insert.assert_awaited_once()
 
 
+async def test_create_snapshot_passes_datetime_to_db_layer():
+    """Regression for #435: insert_snapshot's `now` argument must be a
+    datetime instance, not an ISO string. asyncpg's TIMESTAMP binding
+    rejects strings, which made every "Save current version" click 500.
+    """
+    from datetime import datetime
+
+    record = _make_orb_record()
+    mock_db, _ = _mock_db_with_record(record)
+
+    with (
+        patch.object(
+            snap_db, "delete_oldest_if_at_limit", new_callable=AsyncMock
+        ) as mock_evict,
+        patch.object(snap_db, "insert_snapshot", new_callable=AsyncMock) as mock_insert,
+    ):
+        mock_evict.return_value = None
+        mock_insert.return_value = {"snapshot_id": "snap-1"}
+        await snap_service.create_snapshot(
+            user_id="user-1", db=mock_db, trigger="manual"
+        )
+        kwargs = mock_insert.await_args.kwargs
+        assert isinstance(kwargs["now"], datetime), (
+            f"insert_snapshot got `now` as {type(kwargs['now']).__name__}; "
+            "asyncpg requires datetime for TIMESTAMP columns"
+        )
+
+
 async def test_create_snapshot_empty_orb():
     person = MockNode({"user_id": "user-1", "name": "Empty User"}, ["Person"])
     record = {


### PR DESCRIPTION
## Summary

\`create_snapshot\` built \`now = datetime.now(timezone.utc).isoformat()\` and handed the string to \`insert_snapshot\`, which bound it as \`$3\` against the \`TIMESTAMP WITH TIME ZONE\` column. asyncpg rejects strings for timestamp columns:

\`\`\`
asyncpg.exceptions.DataError: invalid input for query argument $3:
'2026-04-26T20:39:36+00:00' (expected a datetime.date or
datetime.datetime instance, got 'str')
\`\`\`

Every \"Save current version\" click 500'd. The frontend's bare \`catch {}\` in \`UserMenu.handleSaveVersion\` swallowed the cause so users only saw the generic toast.

## Fix

Pass the \`datetime\` through unchanged — FastAPI/Pydantic still serializes it to ISO on the response, so wire format is unchanged. \`db.py\`'s \`now\` parameter type annotation upgraded from \`str\` to \`datetime\` to match.

## Verification

Reproduced and verified live against the running backend:

\`\`\`bash
# Before:
$ curl -X POST http://localhost:8000/orbs/me/versions -b __session=...
Internal Server Error  # HTTP 500

# After:
$ curl -X POST http://localhost:8000/orbs/me/versions -b __session=...
{\"snapshot_id\":\"516db76a-...\",\"created_at\":\"2026-04-26T20:41:28+00:00\",
 \"trigger\":\"manual\",\"label\":\"Manual save\",\"node_count\":194,\"edge_count\":496}  # HTTP 200
\`\`\`

## Test plan

- [x] New unit test \`test_create_snapshot_passes_datetime_to_db_layer\` pins the contract: \`insert_snapshot\` must receive \`now\` as a \`datetime\` instance. The test fails on \`main\` with the existing string-from-isoformat code.
- [x] All 36 existing snapshot tests still pass.
- [x] Live POST /orbs/me/versions returns 200 with a real snapshot_id (was 500).
- [x] \`ruff check\` / \`ruff format --check\` clean.

## Out of scope (follow-ups)

- The frontend \`catch {}\` blocks in \`UserMenu.tsx\` for save / restore / delete still swallow errors silently. A small follow-up should add \`console.error(e)\` so the next backend regression doesn't take a debugging round-trip to find.
- \"Empty orb\" still returns \`skipped: True\` with \`snapshot_id: null\`; the UI could surface a clearer \"Add some entries before saving\" message instead of treating that as success.

## Documentation

No doc changes needed — pure backend bug fix, API contract unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #435